### PR TITLE
Bump local dsm deps; add ignores and licenses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+**/target/
+**/build/
+**/.gradle/
+**/node_modules/
+.git/
+.agents/
+dsm_client/android/.cxx/
+dsm_client/android/app/build/
+dsm_client/new_frontend/dist/
+dsm_client/new_frontend/build/
+dsm_client/deterministic_state_machine/target/

--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,8 @@ exceptions = [
     { allow = ["MPL-2.0", "CDLA-Permissive-2.0"], name = "webpki-roots" },
     # Used transitively by tokio-postgres-rustls.
     { allow = ["MPL-2.0"], name = "x509-certificate" },
+    # Pulled transitively by bitcoin; acceptable for current release train.
+    { allow = ["MITNFA"], name = "hex_lit" },
 ]
 
 [advisories]
@@ -61,4 +63,11 @@ ignore = [
 
     # Transitive via config; evaluate yaml-rust2 migration later.
     "RUSTSEC-2024-0320", # yaml-rust: unmaintained
+
+    # Bincode is frozen/unmaintained upstream, but current usage is intentional
+    # and tracked for future migration.
+    "RUSTSEC-2025-0141", # bincode: unmaintained
+
+    # Used only in vertical validation tooling for operational timing.
+    "RUSTSEC-2024-0384", # instant: unmaintained
 ]

--- a/dsm_client/deterministic_state_machine/dsm_sdk/Cargo.toml
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/Cargo.toml
@@ -57,7 +57,7 @@ glob = "0.3"
 [dependencies]
 ctor = "0.2"
 # Core dependencies
-dsm = { path = "../dsm", default-features = false }
+dsm = { version = "0.1.0-beta.1", path = "../dsm", default-features = false }
 
 # JNI for Android integration
 jni = { version = "0.21", optional = true }
@@ -177,7 +177,7 @@ proptest = "1.4.0"
 quickcheck = "1.0.3"
 rstest = "0.18.2"
 serial_test = "3.0.0"
-dsm = { path = "../dsm", default-features = false, features = ["testing"] }
+dsm = { version = "0.1.0-beta.1", path = "../dsm", default-features = false, features = ["testing"] }
 
 
  

--- a/dsm_storage_node/Cargo.toml
+++ b/dsm_storage_node/Cargo.toml
@@ -61,10 +61,10 @@ async-trait = "0.1"
 # Deterministic tick sources live in dsm core
 
 # DSM Core (for SPHINCS+ and shared types)
-dsm = { path = "../dsm_client/deterministic_state_machine/dsm" }
+dsm = { version = "0.1.0-beta.1", path = "../dsm_client/deterministic_state_machine/dsm" }
 
 # DSM SDK (for centralized utilities like base32 Crockford)
-dsm_sdk = { path = "../dsm_client/deterministic_state_machine/dsm_sdk" }
+dsm_sdk = { version = "0.1.0-beta.1", path = "../dsm_client/deterministic_state_machine/dsm_sdk" }
 
 # Protobuf support
 prost = "0.12"

--- a/scripts/codegen_enforce.sh
+++ b/scripts/codegen_enforce.sh
@@ -37,7 +37,7 @@ rg_search() {
     local pattern="$1"
     local dir="$2"
     if command -v rg >/dev/null 2>&1; then
-        rg -n --no-messages --hidden --glob '!node_modules/**' --glob '!target/**' --glob '!pgdata*/**' --glob '!**/bluetooth/**' --glob '!**/ble/**' "$pattern" "$dir"
+        rg -n --no-messages --hidden --glob '!node_modules/**' --glob '!target/**' --glob '!pgdata*/**' --glob '!**/bluetooth/**' --glob '!**/ble/**' --glob '!**/assets/**' "$pattern" "$dir"
     else
         grep -r -n "$pattern" "$dir" | grep -v "bluetooth" | grep -v "/ble/" || true
     fi

--- a/tools/vector_builder/Cargo.toml
+++ b/tools/vector_builder/Cargo.toml
@@ -3,8 +3,9 @@ name = "dsm_vector_builder"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
 prost = "0.12"
-dsm = { path = "../../dsm_client/deterministic_state_machine/dsm" }
+dsm = { version = "0.1.0-beta.1", path = "../../dsm_client/deterministic_state_machine/dsm" }

--- a/tools/vector_runner/Cargo.toml
+++ b/tools/vector_runner/Cargo.toml
@@ -3,6 +3,7 @@ name = "dsm_vector_runner"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [features]
 noop_api = []
@@ -10,5 +11,5 @@ noop_api = []
 [dependencies]
 anyhow = "1"
 walkdir = "2"
-dsm = { path = "../../dsm_client/deterministic_state_machine/dsm" }
+dsm = { version = "0.1.0-beta.1", path = "../../dsm_client/deterministic_state_machine/dsm" }
 prost = "0.12"

--- a/tools/vertical_validation/Cargo.toml
+++ b/tools/vertical_validation/Cargo.toml
@@ -3,6 +3,7 @@ name = "dsm_vertical_validation"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 description = "Vertical Validation: TLA+ model checking + scaling benchmarks + investor report"
 
 [[bin]]
@@ -39,7 +40,7 @@ regex = "1.10"
 instant = "0.1"
 
 # Direct access to core DSM types, state machine, and crypto primitives
-dsm = { path = "../../dsm_client/deterministic_state_machine/dsm" }
+dsm = { version = "0.1.0-beta.1", path = "../../dsm_client/deterministic_state_machine/dsm" }
 
 # Deterministic seeded RNG for reproducible property tests
 rand = "0.8"


### PR DESCRIPTION
Pin local DSM packages to v0.1.0-beta.1 across multiple Cargo.toml files and add license fields to tooling crates. Add a .dockerignore with common build/artifact patterns and expand rg exclusions in scripts/codegen_enforce.sh to skip assets. Update deny.toml to allow a transitive MITNFA crate and to ignore several RustSec advisories (yaml-rust, bincode, instant) with notes explaining intent.

## Summary

<!-- What does this change do and why is it needed? -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Testing

- [ ] `make lint` passes (clippy + fmt)
- [ ] `make build` passes
- [ ] `make typecheck` passes (if frontend affected)
- [ ] Relevant targeted tests pass (`make test-rust`, `make test-frontend`, or focused `cargo test --package ...`)
- [ ] `make android` produces a working APK (if Android/JNI affected)

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I used [conventional commits](../CONTRIBUTING.md#commit-style) (`fix:`, `feat:`, `chore:`, `docs:`)
- [ ] I updated docs or comments when behavior changed
- [ ] I did not include secrets, local paths, or machine-specific config
- [ ] I kept unrelated changes out of this PR
- [ ] `git grep -r -E 'TODO|FIXME|HACK|XXX'` returns zero results

## Notes

<!-- Anything reviewers should pay special attention to? Follow-up work left out? -->
