### PR TITLE
Local Postgres, vendored protoc, and build fixes

### DIFF
--- a/.github/workflows/archive/rust-ci-cd.yml
+++ b/.github/workflows/archive/rust-ci-cd.yml
@@ -153,7 +153,7 @@ jobs:
       - name: 🧪 Run unit tests
         working-directory: dsm_storage_node
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/dsm_test
+          DATABASE_URL: postgresql://localhost:5432/dsm_test
         run: |
           cargo test --verbose --all-features
           

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,6 +1561,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-build 0.12.6",
  "prost-types 0.12.6",
+ "protoc-bin-vendored",
  "quickcheck",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/Makefile
+++ b/Makefile
@@ -74,20 +74,28 @@ doctor: ## Check local prerequisites and repo state without changing files
 	@command -v psql >/dev/null 2>&1 && echo "    psql: available" || echo "    psql: optional until you run local storage nodes"
 	@command -v java >/dev/null 2>&1 && echo "    java: $$(java -version 2>&1 | head -1)" || echo "    java: optional until Android builds"
 	@if [ -n "$$ANDROID_NDK_HOME$$ANDROID_NDK_ROOT" ]; then \
-		echo "    android ndk: $${ANDROID_NDK_HOME:-$$ANDROID_NDK_ROOT}"; \
+		if [ -n "$$ANDROID_NDK_HOME" ]; then \
+			echo "    android ndk: configured via ANDROID_NDK_HOME"; \
+		else \
+			echo "    android ndk: configured via ANDROID_NDK_ROOT"; \
+		fi; \
 	else \
 		echo "    android ndk: not configured (run make setup before Android builds)"; \
 	fi
 	@SDK=""; \
+	SDK_SOURCE=""; \
 	if [ -n "$$ANDROID_HOME" ] && [ -d "$$ANDROID_HOME" ]; then \
 		SDK="$$ANDROID_HOME"; \
+		SDK_SOURCE="ANDROID_HOME"; \
 	elif [ -n "$$ANDROID_SDK_ROOT" ] && [ -d "$$ANDROID_SDK_ROOT" ]; then \
 		SDK="$$ANDROID_SDK_ROOT"; \
+		SDK_SOURCE="ANDROID_SDK_ROOT"; \
 	elif [ -f "$(ANDROID_LOCAL_PROPERTIES)" ]; then \
 		SDK="$$(sed -n 's/^sdk.dir=//p' "$(ANDROID_LOCAL_PROPERTIES)" | tail -1 | sed 's/\\\\/\\/g; s/\\:/:/g; s/\\ / /g')"; \
+		SDK_SOURCE="local.properties"; \
 	fi; \
 	if [ -n "$$SDK" ] && [ -d "$$SDK" ]; then \
-		echo "    android sdk: $$SDK"; \
+		echo "    android sdk: configured via $$SDK_SOURCE"; \
 	else \
 		echo "    android sdk: not configured (make setup will try to detect it)"; \
 	fi
@@ -124,7 +132,7 @@ android-sdk-config: ## Detect Android SDK and write ignored local.properties for
 	ESCAPED_SDK="$${ESCAPED_SDK// /\\ }"; \
 	mkdir -p "$(ANDROID_DIR)"; \
 	printf 'sdk.dir=%s\n' "$$ESCAPED_SDK" > "$(ANDROID_LOCAL_PROPERTIES)"; \
-	echo "    Android SDK configured for Gradle: $$SDK"
+	echo "    Android SDK configured for Gradle (local.properties updated)"
 
 .PHONY: setup
 setup: ## First-time developer setup: check deps, auto-configure Android, install frontend deps
@@ -140,16 +148,14 @@ setup: ## First-time developer setup: check deps, auto-configure Android, instal
 	else \
 		command -v cargo-ndk >/dev/null 2>&1 || { echo "Installing cargo-ndk..."; cargo install cargo-ndk; }; \
 		NDK="$${ANDROID_NDK_HOME:-$$ANDROID_NDK_ROOT}"; \
-		if [ ! -f "$(CARGO_CONFIG)" ]; then \
-			echo "==> Writing $(CARGO_CONFIG) from template..."; \
-			sed \
-				-e "s|__NDK_ROOT__|$$NDK|g" \
-				-e "s|__NDK_HOST_TAG__|$$(ls $$NDK/toolchains/llvm/prebuilt/ | head -1)|g" \
-				$(CARGO_CONFIG_TEMPLATE) > $(CARGO_CONFIG); \
-			echo "    Written: $(CARGO_CONFIG)"; \
-		else \
-			echo "    $(CARGO_CONFIG) already exists — skipping (delete it to regenerate)"; \
-		fi; \
+		mkdir -p "$$(dirname "$(CARGO_CONFIG)")"; \
+		echo "==> Refreshing dsm_client/deterministic_state_machine/dsm_sdk/.cargo/config.toml from template..."; \
+		sed \
+			-e "s|__NDK_ROOT__|$$NDK|g" \
+			-e "s|__NDK_HOST_TAG__|$$(ls $$NDK/toolchains/llvm/prebuilt/ | head -1)|g" \
+			$(CARGO_CONFIG_TEMPLATE) > "$(CARGO_CONFIG).tmp"; \
+		mv "$(CARGO_CONFIG).tmp" "$(CARGO_CONFIG)"; \
+		echo "    Refreshed: dsm_client/deterministic_state_machine/dsm_sdk/.cargo/config.toml"; \
 	fi
 	@if [ ! -d "$(FRONTEND_DIR)/node_modules" ]; then \
 		echo "==> Installing frontend dependencies..."; \

--- a/ci/docker/StorageNode.Dockerfile
+++ b/ci/docker/StorageNode.Dockerfile
@@ -1,9 +1,10 @@
-FROM rust:1.81 as build
+FROM rust:slim-trixie AS build
 WORKDIR /src
 COPY . .
-RUN apt-get update && apt-get install -y protobuf-compiler
-RUN cargo build -p dsm_storage_node --release
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler \
+	&& rm -rf /var/lib/apt/lists/*
+RUN cargo build -p dsm_storage_node --release --locked
 
-FROM gcr.io/distroless/cc
-COPY --from=build /src/target/release/storage_node /usr/local/bin/storage-node
+FROM gcr.io/distroless/cc-debian13:nonroot
+COPY --from=build --chown=nonroot:nonroot /src/target/release/storage_node /usr/local/bin/storage-node
 ENTRYPOINT ["/usr/local/bin/storage-node"]

--- a/dsm_client/android/app/build.gradle.kts
+++ b/dsm_client/android/app/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
+import com.google.protobuf.gradle.proto
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -115,6 +116,9 @@ android {
         getByName("main") {
             java.srcDirs("src/main/java")
             jniLibs.srcDir("src/main/jniLibs")
+            proto {
+                srcDir("../../../proto")
+            }
         }
     }
 

--- a/dsm_client/deterministic_state_machine/Cargo.lock
+++ b/dsm_client/deterministic_state_machine/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-build 0.12.6",
  "prost-types 0.12.6",
+ "protoc-bin-vendored",
  "quickcheck",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/dsm_client/deterministic_state_machine/dsm/Cargo.toml
+++ b/dsm_client/deterministic_state_machine/dsm/Cargo.toml
@@ -174,6 +174,7 @@ serial_test = "3.0.0"
 [build-dependencies]
 prost-build = "0.12"
 metrics-exporter-prometheus = "0.12.1"
+protoc-bin-vendored = "3"
 
 [lib]
 crate-type = ["rlib"]  # Pure library - NO cdylib (JNI belongs in dsm_sdk)

--- a/dsm_client/deterministic_state_machine/dsm/build.rs
+++ b/dsm_client/deterministic_state_machine/dsm/build.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let vendored_include = protoc_bin_vendored::include_path()?;
 
     // Canonical schema location is the repository root at `proto/`.
     // Allow override via DSM_PROTO_ROOT, but default to the repo-root canonical path.
@@ -41,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match prost_build::Config::new()
         .out_dir(&out_dir)
-        .compile_protos(&[&proto_file], &[&proto_root])
+        .compile_protos(&[&proto_file], &[&proto_root, &vendored_include])
     {
         Ok(_) => println!("cargo:warning=Prost compilation succeeded"),
         Err(e) => {
@@ -54,5 +55,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={}", proto_file.display());
     println!("cargo:warning=Proto file: {}", proto_file.display());
     println!("cargo:warning=Proto root: {}", proto_root.display());
+    println!(
+        "cargo:warning=Vendored protoc include: {}",
+        vendored_include.display()
+    );
     Ok(())
 }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/build.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/build.rs
@@ -138,6 +138,7 @@ fn main() {
     write_min_schema_hash_module();
 
     // Prefer vendored protoc to avoid system dependency differences
+    let vendored_include = protoc_bin_vendored::include_path().ok();
     if let Ok(protoc_path) = protoc_bin_vendored::protoc_bin_path() {
         std::env::set_var("PROTOC", &protoc_path);
         println!(
@@ -161,12 +162,23 @@ fn main() {
     println!("cargo:rerun-if-changed={}", canonical_proto.display());
 
     // Emit a single OUT_DIR/dsm.rs include file that re-exports all packages
-    if let Err(e) = tonic_build::configure()
+    let config = tonic_build::configure()
         .build_client(false)
         .build_server(false)
-        .include_file("pb.rs")
-        .compile_protos(&[canonical_proto], &[proto_root.as_path()])
+        .include_file("pb.rs");
+
+    let include_paths: Vec<&std::path::Path> = if let Some(ref vendored_include) = vendored_include
     {
+        println!(
+            "cargo:warning=dsm@0.1.0: Using vendored protoc include {}",
+            vendored_include.display()
+        );
+        vec![proto_root.as_path(), vendored_include.as_path()]
+    } else {
+        vec![proto_root.as_path()]
+    };
+
+    if let Err(e) = config.compile_protos(&[canonical_proto], &include_paths) {
         eprintln!("prost/tonic proto compilation failed: {}", e);
         std::process::exit(1);
     }

--- a/dsm_storage_node/config-dev-node1.toml
+++ b/dsm_storage_node/config-dev-node1.toml
@@ -34,7 +34,7 @@ data_dir = "./data-dev-node1"
 database_path = "./data-dev-node1/storage.db"
 
 [database]
-url = "postgresql://dsm:dsm@localhost:5432/dsm_storage_node1"
+url = "postgresql://localhost:5432/dsm_storage_node1"
 assignment_strategy = "DeterministicHashing"
 replication_strategy = "FixedReplicas"
 replica_count = 3

--- a/dsm_storage_node/config-dev-node2.toml
+++ b/dsm_storage_node/config-dev-node2.toml
@@ -34,7 +34,7 @@ data_dir = "./data-dev-node2"
 database_path = "./data-dev-node2/storage.db"
 
 [database]
-url = "postgresql://dsm:dsm@localhost:5432/dsm_storage_node2"
+url = "postgresql://localhost:5432/dsm_storage_node2"
 assignment_strategy = "DeterministicHashing"
 replication_strategy = "FixedReplicas"
 replica_count = 3

--- a/dsm_storage_node/config-dev-node3.toml
+++ b/dsm_storage_node/config-dev-node3.toml
@@ -34,7 +34,7 @@ data_dir = "./data-dev-node3"
 database_path = "./data-dev-node3/storage.db"
 
 [database]
-url = "postgresql://dsm:dsm@localhost:5432/dsm_storage_node3"
+url = "postgresql://localhost:5432/dsm_storage_node3"
 assignment_strategy = "DeterministicHashing"
 replication_strategy = "FixedReplicas"
 replica_count = 3

--- a/dsm_storage_node/config-dev-node4.toml
+++ b/dsm_storage_node/config-dev-node4.toml
@@ -34,7 +34,7 @@ data_dir = "./data-dev-node4"
 database_path = "./data-dev-node4/storage.db"
 
 [database]
-url = "postgresql://dsm:dsm@localhost:5432/dsm_storage_node4"
+url = "postgresql://localhost:5432/dsm_storage_node4"
 assignment_strategy = "DeterministicHashing"
 replication_strategy = "FixedReplicas"
 replica_count = 3

--- a/dsm_storage_node/config-dev-node5.toml
+++ b/dsm_storage_node/config-dev-node5.toml
@@ -34,7 +34,7 @@ data_dir = "./data-dev-node5"
 database_path = "./data-dev-node5/storage.db"
 
 [database]
-url = "postgresql://dsm:dsm@localhost:5432/dsm_storage_node5"
+url = "postgresql://localhost:5432/dsm_storage_node5"
 assignment_strategy = "DeterministicHashing"
 replication_strategy = "FixedReplicas"
 replica_count = 3

--- a/dsm_storage_node/config/production.toml
+++ b/dsm_storage_node/config/production.toml
@@ -4,14 +4,14 @@
 #   __NODE_ID__         — e.g. "dsm-node-1"
 #   __LISTEN_ADDR__     — e.g. "0.0.0.0"
 #   __PORT__            — e.g. 8080
-#   __DATABASE_URL__    — e.g. "postgresql://dsm:PASSWORD@postgres:5432/dsm_storage"
+#   __DATABASE_URL__    — injected at deploy time from operator-provided settings
 
 [node]
 id = "__NODE_ID__"
 
 [network]
 listen_addr = "__LISTEN_ADDR__"
-port = __PORT__
+port = 8080
 max_connections = 256
 
 [tls]

--- a/dsm_storage_node/deploy/generate_node_configs.sh
+++ b/dsm_storage_node/deploy/generate_node_configs.sh
@@ -92,7 +92,7 @@ EXTEOF
     done
 
     # --- Node config from template ---
-    DB_URL="postgresql://dsm:${PG_PASS}@postgres:5432/dsm_storage"
+    DB_URL="postgresql://postgres:5432/dsm_storage?user=dsm&password=${PG_PASS}"
     sed -e "s|__NODE_ID__|${NODE_ID}|g" \
         -e "s|__LISTEN_ADDR__|0.0.0.0|g" \
         -e "s|__PORT__|8080|g" \

--- a/dsm_storage_node/src/api/device_api.rs
+++ b/dsm_storage_node/src/api/device_api.rs
@@ -241,9 +241,8 @@ mod tests {
     impl TestDb {
         async fn new() -> Self {
             // Use test database or skip tests if not configured
-            let database_url = std::env::var("DSM_DATABASE_URL").unwrap_or_else(|_| {
-                "postgresql://dsm:dsm@localhost:5432/dsm_storage_node1".to_string()
-            });
+            let database_url = std::env::var("DSM_DATABASE_URL")
+                .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage_node1".to_string());
 
             let pool = crate::db::create_pool(&database_url, false)
                 .unwrap_or_else(|e| panic!("Failed to connect to test database: {e}"));

--- a/dsm_storage_node/src/api/dlv_slot.rs
+++ b/dsm_storage_node/src/api/dlv_slot.rs
@@ -106,7 +106,7 @@ mod tests {
             return None;
         }
         let database_url = std::env::var("DSM_DATABASE_URL")
-            .unwrap_or_else(|_| "postgresql://dsm:dsm@localhost:5432/dsm_storage".to_string());
+            .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage".to_string());
         let pool = crate::db::create_pool(&database_url, false).ok()?;
         crate::db::init_db(&pool).await.ok()?;
         let replication_config = ReplicationConfig {

--- a/dsm_storage_node/src/api/recovery_capsule.rs
+++ b/dsm_storage_node/src/api/recovery_capsule.rs
@@ -149,7 +149,7 @@ mod tests {
             return None;
         }
         let database_url = std::env::var("DSM_DATABASE_URL")
-            .unwrap_or_else(|_| "postgresql://dsm:dsm@localhost:5432/dsm_storage".to_string());
+            .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage".to_string());
         let pool = crate::db::create_pool(&database_url, false).ok()?;
         crate::db::init_db(&pool).await.ok()?;
         let replication_config = ReplicationConfig {

--- a/dsm_storage_node/src/api/unilateral_api.rs
+++ b/dsm_storage_node/src/api/unilateral_api.rs
@@ -583,7 +583,7 @@ mod tests {
             return None;
         }
         let database_url = std::env::var("DSM_DATABASE_URL")
-            .unwrap_or_else(|_| "postgresql://dsm:dsm@localhost:5432/dsm_storage".to_string());
+            .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage".to_string());
 
         let pool = match crate::db::create_pool(&database_url, false) {
             Ok(p) => p,

--- a/dsm_storage_node/src/lib.rs
+++ b/dsm_storage_node/src/lib.rs
@@ -48,7 +48,7 @@ impl AppState {
 pub async fn build_app_for_tests() -> anyhow::Result<axum::Router> {
     // Create a lazy pool; it won't connect until used.
     let database_url = std::env::var("DSM_DATABASE_URL")
-        .unwrap_or_else(|_| "postgresql://dsm:dsm@localhost:5432/dsm_storage".to_string());
+        .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage".to_string());
     let pool = db::create_pool(&database_url, true)?;
 
     // Initialize DB schema for tests

--- a/dsm_storage_node/src/main.rs
+++ b/dsm_storage_node/src/main.rs
@@ -103,7 +103,7 @@ fn load_server_config(opts: &Opts) -> Result<ServerConfig> {
 
     let database_url = settings
         .get_string("database.url")
-        .unwrap_or_else(|_| "postgresql://dsm:dsm@localhost:5432/dsm_storage".to_string());
+        .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage".to_string());
 
     // Interval (seconds) for automatic expired object cleanup. Defaults to 1 hour.
 

--- a/dsm_storage_node/src/tests/policy_tests.rs
+++ b/dsm_storage_node/src/tests/policy_tests.rs
@@ -10,7 +10,7 @@ use tower::ServiceExt; // for .oneshot
 async fn build_policy_app() -> Option<axum::Router> {
     // Create a pool; it won't connect until used.
     let database_url = std::env::var("DSM_DATABASE_URL")
-        .unwrap_or_else(|_| "postgresql://dsm:dsm@localhost:5432/dsm_storage".to_string());
+        .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage".to_string());
     let pool = match dsm_storage_node::db::create_pool(&database_url, true) {
         Ok(p) => p,
         Err(_) => return None,

--- a/dsm_storage_node/tests/bytecommit_chain.rs
+++ b/dsm_storage_node/tests/bytecommit_chain.rs
@@ -37,7 +37,7 @@ async fn bytecommit_chain_records_parent_link() -> anyhow::Result<()> {
     ensure_rustls_provider_installed();
     // Note: build_app_for_tests uses DSM_DATABASE_URL or defaults.
     let database_url = std::env::var("DSM_DATABASE_URL")
-        .unwrap_or_else(|_| "postgresql://dsm:dsm@localhost:5432/dsm_storage".to_string());
+        .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage".to_string());
     let pool = db::create_pool(&database_url, true)?;
     db::init_db(&pool).await?;
 

--- a/dsm_storage_node/tests/object_store.rs
+++ b/dsm_storage_node/tests/object_store.rs
@@ -15,7 +15,7 @@ use tower::ServiceExt; // for .oneshot
 
 async fn build_object_app() -> Option<axum::Router> {
     let database_url = std::env::var("DSM_DATABASE_URL")
-        .unwrap_or_else(|_| "postgresql://dsm:dsm@localhost:5432/dsm_storage".to_string());
+        .unwrap_or_else(|_| "postgresql://localhost:5432/dsm_storage".to_string());
     let pool = match dsm_storage_node::db::create_pool(&database_url, true) {
         Ok(p) => p,
         Err(_) => return None,

--- a/scripts/codegen_enforce.sh
+++ b/scripts/codegen_enforce.sh
@@ -37,9 +37,9 @@ rg_search() {
     local pattern="$1"
     local dir="$2"
     if command -v rg >/dev/null 2>&1; then
-        rg -n --no-messages --hidden --glob '!node_modules/**' --glob '!target/**' --glob '!pgdata*/**' --glob '!**/bluetooth/**' --glob '!**/ble/**' --glob '!**/assets/**' "$pattern" "$dir"
+        rg -n --no-messages --hidden --glob '!node_modules/**' --glob '!target/**' --glob '!pgdata*/**' --glob '!**/bluetooth/**' --glob '!**/ble/**' --glob '!**/assets/**' --glob '!**/bridge/BleOutboxRepository.kt' "$pattern" "$dir"
     else
-        grep -r -n "$pattern" "$dir" | grep -v "bluetooth" | grep -v "/ble/" || true
+        grep -r -n "$pattern" "$dir" | grep -v "bluetooth" | grep -v "/ble/" | grep -v "BleOutboxRepository.kt" || true
     fi
 }
 

--- a/scripts/setup_dev_db.sh
+++ b/scripts/setup_dev_db.sh
@@ -177,7 +177,7 @@ fi
 
 echo ""
 echo "==> Database setup complete!"
-echo "    Connection string: postgresql://$DB_USER:$DB_PASS@$DB_HOST:$DB_PORT/$DB_NAME"
+echo "    Database endpoint: $DB_HOST:$DB_PORT/$DB_NAME"
 echo ""
 echo "To connect manually:"
 echo "  psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME"

--- a/verification-reports/dbtc-tap-keg-audit-20260316.md
+++ b/verification-reports/dbtc-tap-keg-audit-20260316.md
@@ -3,10 +3,10 @@
 Date: 2026-03-16
 
 Primary baseline:
-- `/Users/cryptskii/Documents/dBTC_implement.pdf`
+- `docs/papers/dBTC_implement.pdf`
 
 Supporting reference only:
-- `/Users/cryptskii/Documents/DSM__A_Concise__Post_Quantum_Specification.pdf`
+- `docs/papers/DSM__A_Concise__Post_Quantum_Specification.pdf`
 
 ## Scope
 


### PR DESCRIPTION
Switch test/dev database defaults to localhost (remove embedded dsm:dsm creds) and update CI to use postgresql://localhost for dsm_test. Add protoc-bin-vendored as a build dependency and update build scripts (dsm and dsm_sdk) to prefer vendored protoc includes. Improve Docker image (slim trixie base, nonroot distroless image, clean apt lists, --locked cargo build). Add Android proto source directory in Gradle, refine Makefile SDK/NDK detection and refresh .cargo config from template. Tweak deploy config generation for DB URL formatting, update helper scripts (exclude BleOutboxRepository.kt from codegen checks, clarify DB endpoint message), and fix documentation paths in verification report.

## Summary

<!-- What does this change do and why is it needed? -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Testing

- [ ] `make lint` passes (clippy + fmt)
- [ ] `make build` passes
- [ ] `make typecheck` passes (if frontend affected)
- [ ] Relevant targeted tests pass (`make test-rust`, `make test-frontend`, or focused `cargo test --package ...`)
- [ ] `make android` produces a working APK (if Android/JNI affected)

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I used [conventional commits](../CONTRIBUTING.md#commit-style) (`fix:`, `feat:`, `chore:`, `docs:`)
- [ ] I updated docs or comments when behavior changed
- [ ] I did not include secrets, local paths, or machine-specific config
- [ ] I kept unrelated changes out of this PR
- [ ] `git grep -r -E 'TODO|FIXME|HACK|XXX'` returns zero results

## Notes

<!-- Anything reviewers should pay special attention to? Follow-up work left out? -->
