### PR TITLE
chore: add rust-toolchain.toml to enforce stable channel across workpace

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/ble_frame_coordinator.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/ble_frame_coordinator.rs
@@ -792,8 +792,6 @@ mod tests {
     fn prepare_reject_marks_sender_rejected() {
         use dsm::types::contact_types::DsmVerifiedContact;
         use dsm::types::operations::Operation;
-        let mut dev_id = [0u8; 32];
-        dev_id[0] = 1;
         let mut counterparty = [0u8; 32];
         counterparty[0] = 9;
 

--- a/dsm_client/deterministic_state_machine/rust-toolchain.toml
+++ b/dsm_client/deterministic_state_machine/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "nightly-2025-02-26"  # Specific nightly version that matches dependencies
-components = ["rustfmt", "clippy", "llvm-tools-preview"]
-profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable" # latest stable release
+components = ["rustfmt", "clippy", "llvm-tools-preview"]
+profile = "minimal"


### PR DESCRIPTION
Resolves #60 