### PR TITLE
chore(ci): harden git hooks, CI pipeline, and security dependency chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,9 +252,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary

Resolves a series of cascading CI failures introduced by dependency updates and tightens the overall developer-workflow safety net via version-controlled git hooks.

---

## Changes

### 🔒 Security

- **`fix(security)`** — Upgraded `aws-lc-rs` to `1.16.2` / `aws-lc-sys` to `0.39.0`, resolving two high-severity CVEs:
  - `RUSTSEC-2026-0044` — X.509 Name Constraints Bypass
  - `RUSTSEC-2026-0048` — CRL Distribution Point Scope Check (CVSS 7.4)
  - `cargo audit` now exits `0` (four remaining unmaintained-crate warnings are informational only)

### 🦀 Rust / JNI

- **`fix(jni)`** — Replaced `fn_item as usize` casts with `fn_item as *const ()` in `JNI_OnLoad`; fixes undefined behaviour on 64-bit Android targets
- **`fix(tests)`** — Added `TEST_DB_GENERATION` counter to `dsm_sdk` client DB, preventing `SQLITE_LOCKED_SHAREDCACHE` (error 262) races between concurrent test resets
- **`refactor(test)`** — Converted `bilateral_full_offline_flow` integration tests to `Result`-returning form for proper error propagation

### ⚙️ CI / Scripts

- **`fix(ci)`** — `dsm_storage_node` test step now passes `--no-default-features --features local-dev,strict`, enabling SQLite in-memory mode and eliminating the PostgreSQL requirement in CI
- **`fix(ci)`** — Repaired `codegen_enforce.sh` grep fallback to exclude `target/`, `node_modules/`, and `pgdata/` directories (was producing false positives)
- **`style`** — Normalised YAML string quotes in `ci.yml` (no behaviour change)

### 🖥️ Frontend

- **`fix(frontend)`** — Resolved React 19 compatibility failures (type errors, missing scripts)
- **`fix(test)`** — Mocked `BridgeRegistry` in `dsmClient.test.ts` so `isReady()` correctly reaches `hasIdentity()`; unblocked 325 previously failing frontend tests

### 🔧 Tooling

- **`fix(dsm-gen)`** — Added `clippy::disallowed_methods` allow in `schema.rs` for `JsonSchema` derive macros
- **`fix`** — Resolved dependency conflicts and test races from Dependabot bumps
- **`chore`** — Added version-controlled git hooks (`.githooks/`) for pre-commit and pre-push guardrails

---

## CI Checklist

- [x] `cargo audit` — exits `0` (0 vulnerabilities)
- [x] `cargo clippy` — 0 errors
- [x] `cargo test` (core + SDK + storage node) — all pass
- [x] Frontend type-check + unit tests — all pass
- [x] `codegen_enforce.sh` — passes