### PR TITLE
Use device canonical state for bilateral settlement

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -2387,6 +2387,8 @@ impl BilateralBleHandler {
                 tx_type: "bilateral_offline",
                 new_chain_tip: [0u8; 32],
                 canonical_state: Some(finalized_local_state.clone()),
+                device_canonical_state: crate::bridge::app_router()
+                    .and_then(|r| r.get_device_current_state()),
             };
             let outcome = delegate.settle(ctx).map_err(|e| {
                 DsmError::invalid_operation(format!(
@@ -2934,6 +2936,8 @@ impl BilateralBleHandler {
                     tx_type: "bilateral_offline",
                     new_chain_tip,
                     canonical_state: Some(tx_result.local_state.clone()),
+                    device_canonical_state: crate::bridge::app_router()
+                        .and_then(|r| r.get_device_current_state()),
                 };
                 match delegate.settle(ctx) {
                     Ok(outcome) => (outcome, None),
@@ -3337,6 +3341,8 @@ impl BilateralBleHandler {
                         tx_type: "bilateral_offline",
                         new_chain_tip: [0u8; 32],
                         canonical_state: Some(result.local_state.clone()),
+                        device_canonical_state: crate::bridge::app_router()
+                            .and_then(|r| r.get_device_current_state()),
                     };
                     delegate
                         .settle(ctx)
@@ -3459,6 +3465,8 @@ impl BilateralBleHandler {
                         tx_type: "bilateral_offline_recovered",
                         new_chain_tip: [0u8; 32],
                         canonical_state: None,
+                        device_canonical_state: crate::bridge::app_router()
+                            .and_then(|r| r.get_device_current_state()),
                     };
                     if let Err(e) = delegate.settle(ctx) {
                         warn!("[BILATERAL RECOVERY] Sender settlement failed (recovery path): {e}");

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_session.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_session.rs
@@ -64,6 +64,16 @@ pub struct BilateralSettlementContext {
     /// The application layer may merge token-balance settlement into this state
     /// so the archived BCR snapshot reflects the completed wallet settlement.
     pub canonical_state: Option<State>,
+    /// Device's canonical tip state from `CoreSDK::get_current_state()`.
+    ///
+    /// Carries the authoritative `token_balances` (B_n), correct raw device_id,
+    /// correct public_key, and the device's state_number.  Settlement reads B_n
+    /// from this state and applies the bilateral transfer delta Δ_{n+1}.
+    ///
+    /// This replaces the old `latest_archived_state()` approach which mined a
+    /// BCR archive mixing faucet/mint/bilateral states under one state_number
+    /// space — violating the spec's per-relationship chain model (§2.1, §4.3).
+    pub device_canonical_state: Option<State>,
 }
 
 /// Result returned by [`BilateralSettlementDelegate::settle`].

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
@@ -82,6 +82,11 @@ pub trait AppRouter: Send + Sync {
     async fn invoke(&self, i: AppInvoke) -> AppResult;
     /// Reload in-memory balance cache from SQLite after external balance changes (e.g. BLE debit).
     fn sync_balance_cache(&self) {}
+    /// Return the device's canonical tip state (authoritative token balances).
+    ///
+    /// Used by bilateral settlement to source B_n before applying the transfer
+    /// delta.  Returns `None` if no canonical state is available yet.
+    fn get_device_current_state(&self) -> Option<dsm::types::state_types::State> { None }
 }
 
 /// App router storage. Uses RwLock to allow replacement (MinimalBootstrapRouter → AppRouterImpl).

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
@@ -2431,6 +2431,10 @@ impl AppRouter for AppRouterImpl {
         }
     }
 
+    fn get_device_current_state(&self) -> Option<dsm::types::state_types::State> {
+        self.core_sdk.get_current_state().ok()
+    }
+
     // ====================== QUERY ======================
     async fn query(&self, q: AppQuery) -> AppResult {
         self.ensure_bitcoin_tap_restored().await;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_settlement.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_settlement.rs
@@ -76,15 +76,22 @@ fn resolve_policy_commit(token_id: &str) -> Result<[u8; 32], String> {
     .map_err(|e| format!("resolve policy commit failed for {token_id}: {e}"))
 }
 
-fn latest_archived_state(local_device_id: &[u8; 32]) -> Result<Option<State>, String> {
-    crate::storage::client_db::get_bcr_states(local_device_id, false)
-        .map(|states| states.into_iter().last())
-        .map_err(|e| format!("load latest archived state failed: {e}"))
+/// Check whether a transaction with the given commitment hash has already been
+/// settled (status = "completed").  Used as a replay guard for bilateral
+/// balance application — the DB-level `ON CONFLICT(tx_id)` upsert handles
+/// storage-layer idempotency, but we need to avoid double-applying balance
+/// deltas in `build_canonical_settled_state`.
+fn is_already_settled(commitment_hash: &[u8; 32]) -> bool {
+    let tx_id = encode_base32_crockford(commitment_hash);
+    crate::storage::client_db::get_transaction_history(None, Some(500))
+        .ok()
+        .map(|txs| txs.iter().any(|tx| tx.tx_id == tx_id && tx.status == "completed"))
+        .unwrap_or(false)
 }
 
 fn reconcile_sender_state(
     prior_state: &State,
-    base_state: &State,
+    _base_state: &State,
     transfer: &TransferFields,
     policy_commit: &[u8; 32],
 ) -> Result<State, String> {
@@ -99,8 +106,9 @@ fn reconcile_sender_state(
         transfer.recipient.as_slice()
     };
 
-    let mut settled_state = base_state.clone();
-    settled_state.token_balances = prior_state.token_balances.clone();
+    // Clone the device canonical state and apply the bilateral delta.
+    // prior_state IS the device canonical state (correct device_id, public_key, balances).
+    let mut settled_state = prior_state.clone();
 
     token_state::apply_transfer_debit_credit(
         &mut settled_state.token_balances,
@@ -113,15 +121,13 @@ fn reconcile_sender_state(
         prior_state.state_number,
     )?;
 
-    settled_state.hash = settled_state
-        .compute_hash()
-        .map_err(|e| format!("sender settled-state hash failed: {e}"))?;
+    // Caller (build_canonical_settled_state) handles state_number bump and hash recompute.
     Ok(settled_state)
 }
 
 fn reconcile_receiver_state(
     prior_state: &State,
-    base_state: &State,
+    _base_state: &State,
     transfer: &TransferFields,
     policy_commit: &[u8; 32],
 ) -> Result<State, String> {
@@ -131,8 +137,8 @@ fn reconcile_receiver_state(
         transfer.token_id.as_str()
     };
 
-    let mut settled_state = base_state.clone();
-    settled_state.token_balances = prior_state.token_balances.clone();
+    // Clone the device canonical state and apply the bilateral credit.
+    let mut settled_state = prior_state.clone();
 
     token_state::apply_transfer_credit(
         &mut settled_state.token_balances,
@@ -144,46 +150,74 @@ fn reconcile_receiver_state(
         prior_state.state_number,
     )?;
 
-    settled_state.hash = settled_state
-        .compute_hash()
-        .map_err(|e| format!("receiver settled-state hash failed: {e}"))?;
+    // Caller handles state_number bump and hash recompute.
     Ok(settled_state)
 }
 
+/// Build the canonical settled state by applying the bilateral transfer delta
+/// to the device's canonical state.
+///
+/// The device's canonical state (`ctx.device_canonical_state`) is the single
+/// source of truth for token balances (B_n).  This function applies Δ_{n+1}
+/// from the bilateral operation, increments the device state_number, and
+/// recomputes the hash.  The result is the next canonical device state.
+///
+/// This replaces the old `latest_archived_state()` approach which mined a BCR
+/// archive mixing faucet/mint/bilateral states under one state_number space —
+/// violating the spec's per-relationship chain model (§2.1, §4.3).
 fn build_canonical_settled_state(
     ctx: &BilateralSettlementContext,
 ) -> Result<Option<State>, String> {
-    let Some(base_state) = ctx.canonical_state.as_ref() else {
-        return Ok(None);
+    // The device's canonical state is the authoritative balance source.
+    let device_state = match ctx.device_canonical_state.as_ref() {
+        Some(s) => s,
+        None => {
+            // No device state available (e.g. tests, early bootstrap).
+            // Fall through to canonical_state if present.
+            return Ok(ctx.canonical_state.clone());
+        }
     };
 
-    let transfer_opt = parse_transfer(&ctx.operation_bytes);
-    if transfer_opt.as_ref().map(|t| t.amount == 0).unwrap_or(true) {
-        return Ok(ctx.canonical_state.clone());
+    let transfer = match parse_transfer(&ctx.operation_bytes) {
+        Some(t) if t.amount > 0 => t,
+        _ => return Ok(Some(device_state.clone())),
+    };
+
+    // Replay guard: if this commitment_hash was already settled, return the
+    // current device state without re-applying the delta.  This replaces the
+    // old (broken) state_number comparison guard.
+    if is_already_settled(&ctx.commitment_hash) {
+        log::info!(
+            "[BILATERAL][settle] duplicate settlement skipped for commitment={}",
+            encode_base32_crockford(&ctx.commitment_hash),
+        );
+        return Ok(Some(device_state.clone()));
     }
 
-    let transfer = transfer_opt.unwrap();
-
-    let prior_state_opt = latest_archived_state(&ctx.local_device_id)?;
-    if let Some(ref prior_state) = prior_state_opt {
-        if prior_state.state_number >= base_state.state_number {
-            return Ok(Some(prior_state.clone()));
-        }
-    }
-
-    let prior_state = prior_state_opt.unwrap_or_else(|| base_state.clone());
     let token_for_policy = if transfer.token_id.is_empty() {
         "ERA"
     } else {
         transfer.token_id.as_str()
     };
     let policy_commit = resolve_policy_commit(token_for_policy)?;
-    let settled_state = if ctx.is_sender {
-        reconcile_sender_state(&prior_state, base_state, &transfer, &policy_commit)?
+
+    // Apply Δ_{n+1} to B_n from the device's canonical state.
+    // Both prior_state and base_state are the device state:
+    //   prior_state → token_balances source (B_n), public_key for key derivation
+    //   base_state  → skeleton (correct device_id, state_number)
+    let mut settled_state = if ctx.is_sender {
+        reconcile_sender_state(device_state, device_state, &transfer, &policy_commit)?
     } else {
-        reconcile_receiver_state(&prior_state, base_state, &transfer, &policy_commit)?
+        reconcile_receiver_state(device_state, device_state, &transfer, &policy_commit)?
     };
 
+    // Advance the device's state_number and recompute hash.
+    settled_state.state_number = device_state.state_number + 1;
+    settled_state.hash = settled_state
+        .compute_hash()
+        .map_err(|e| format!("settled-state hash recompute failed: {e}"))?;
+
+    // Sync balance projection so balance.list reflects the updated balance.
     let local_txt = encode_base32_crockford(&ctx.local_device_id);
     let locked = crate::storage::client_db::get_locked_balance(&local_txt, token_for_policy)
         .map_err(|e| format!("read locked balance failed: {e}"))?;
@@ -423,20 +457,22 @@ mod tests {
         let policy_commit = *crate::policy::builtins::NATIVE_POLICY_COMMIT;
         let sender_pk = vec![0x21; 32];
         let recipient = vec![0x42; 32];
-        let mut prior = make_state([0x11; 32], sender_pk.clone(), 7);
+        // In the new model, prior_state IS the device canonical state.
+        // base_state is unused (reconcile clones from prior_state).
+        let mut device_state = make_state([0x11; 32], sender_pk.clone(), 7);
         let base = make_state([0x11; 32], sender_pk.clone(), 8);
 
         let sender_key =
             dsm::core::token::derive_canonical_balance_key(&policy_commit, &sender_pk, "ERA");
         let recipient_key =
             dsm::core::token::derive_canonical_balance_key(&policy_commit, &recipient, "ERA");
-        prior.token_balances.insert(
+        device_state.token_balances.insert(
             sender_key.clone(),
-            Balance::from_state(10, prior.hash, prior.state_number),
+            Balance::from_state(10, device_state.hash, device_state.state_number),
         );
 
         let settled = reconcile_sender_state(
-            &prior,
+            &device_state,
             &base,
             &TransferFields {
                 amount: 4,
@@ -448,7 +484,9 @@ mod tests {
         )
         .expect("sender settlement should succeed");
 
-        assert_eq!(settled.state_number, 8);
+        // Reconcile clones from prior_state (device_state at sn=7).
+        // Caller (build_canonical_settled_state) bumps to sn=8.
+        assert_eq!(settled.state_number, 7);
         assert_eq!(
             settled.token_balances.get(&sender_key).map(Balance::value),
             Some(6)
@@ -466,13 +504,13 @@ mod tests {
     fn reconcile_receiver_state_credits_local_owner() {
         let policy_commit = *crate::policy::builtins::NATIVE_POLICY_COMMIT;
         let receiver_pk = vec![0x33; 32];
-        let prior = make_state([0x22; 32], receiver_pk.clone(), 3);
+        let device_state = make_state([0x22; 32], receiver_pk.clone(), 3);
         let base = make_state([0x22; 32], receiver_pk.clone(), 4);
         let local_key =
             dsm::core::token::derive_canonical_balance_key(&policy_commit, &receiver_pk, "ERA");
 
         let settled = reconcile_receiver_state(
-            &prior,
+            &device_state,
             &base,
             &TransferFields {
                 amount: 7,
@@ -484,7 +522,9 @@ mod tests {
         )
         .expect("receiver settlement should succeed");
 
-        assert_eq!(settled.state_number, 4);
+        // Reconcile clones from prior_state (device_state at sn=3).
+        // Caller bumps to sn=4.
+        assert_eq!(settled.state_number, 3);
         assert_eq!(
             settled.token_balances.get(&local_key).map(Balance::value),
             Some(7)

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/mod.rs
@@ -153,6 +153,26 @@ pub fn is_database_initialized() -> bool {
 /// Acquires a write lock and clears the connection. Use `#[serial_test]` to
 /// ensure tests run sequentially and no other thread holds the connection.
 pub fn reset_database_for_tests() {
+    // Drop all user tables before releasing the connection so the shared
+    // in-memory DB (`mode=memory&cache=shared`) starts clean for the next
+    // test.  Simply clearing the connection handle is not enough because
+    // the shared cache keeps the database alive.
+    if let Ok(guard) = DB_CONNECTION.read() {
+        if let Some(ref arc_conn) = *guard {
+            if let Ok(conn) = arc_conn.lock() {
+                let tables: Vec<String> = conn
+                    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+                    .and_then(|mut stmt| {
+                        stmt.query_map([], |row| row.get::<_, String>(0))
+                            .map(|rows| rows.filter_map(|r| r.ok()).collect())
+                    })
+                    .unwrap_or_default();
+                for table in &tables {
+                    let _ = conn.execute(&format!("DELETE FROM \"{table}\""), []);
+                }
+            }
+        }
+    }
     if let Ok(mut guard) = DB_CONNECTION.write() {
         *guard = None;
     }


### PR DESCRIPTION
Use the device's canonical tip (CoreSDK::get_current_state) as the authoritative B_n when applying bilateral transfer deltas. Added a device_canonical_state field to BilateralSettlementContext and plumbed it from the AppRouter (trait default + AppRouterImpl impl) via BLE handlers. Replaced the old latest_archived_state logic with a DB-backed replay guard (is_already_settled) to avoid double-applying deltas. Reworked reconcile_sender/receiver to clone and apply deltas from the device canonical state, and moved state_number increment + hash recompute into build_canonical_settled_state. Updated tests to match the new behavior. Also enhanced reset_database_for_tests to delete user tables in the shared in-memory SQLite DB so tests start with a clean schema.

## Summary

<!-- What does this change do and why is it needed? -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Testing

- [x] `make lint` passes (clippy + fmt)
- [x] `make build` passes
- [x] `make typecheck` passes (if frontend affected)
- [x] Relevant targeted tests pass (`make test-rust`, `make test-frontend`, or focused `cargo test --package ...`)
- [x] `make android` produces a working APK (if Android/JNI affected)

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I used [conventional commits](../CONTRIBUTING.md#commit-style) (`fix:`, `feat:`, `chore:`, `docs:`)
- [ ] I updated docs or comments when behavior changed
- [ ] I did not include secrets, local paths, or machine-specific config
- [ ] I kept unrelated changes out of this PR
- [ ] `git grep -r -E 'TODO|FIXME|HACK|XXX'` returns zero results

## Notes

<!-- Anything reviewers should pay special attention to? Follow-up work left out? -->
