### PR TITLE
fix: remove debug print macros from Merkle + SPHINCS production paths

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/crypto/sphincs.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/crypto/sphincs.rs
@@ -63,7 +63,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 #[cfg(feature = "sphincs-trace")]
 macro_rules! sphincs_trace {
     ($($arg:tt)*) => {
-        eprintln!($($arg)*);
+        tracing::debug!($($arg)*);
     };
 }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/merkle/tree.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/merkle/tree.rs
@@ -325,15 +325,15 @@ mod tests {
         tree.add_leaf(hash_data(b"data4"));
 
         let root_hash = tree.root_hash().expect("Expected root hash");
-        println!("Root hash (bytes): {:?}", root_hash);
-        println!("Leaf2 hash (bytes): {:?}", leaf2);
+        tracing::debug!("Root hash (bytes): {:?}", root_hash);
+        tracing::debug!("Leaf2 hash (bytes): {:?}", leaf2);
 
         let leaf3 = hash_data(b"data3");
 
         let proof = tree.generate_proof(1);
-        println!("Proof path length: {}", proof.path.len());
+        tracing::debug!("Proof path length: {}", proof.path.len());
         for (i, hash) in proof.path.iter().enumerate() {
-            println!("Proof element {} (bytes): {:?}", i, hash);
+            tracing::debug!("Proof element {} (bytes): {:?}", i, hash);
         }
 
         assert!(MerkleTree::verify_proof(
@@ -369,21 +369,21 @@ mod tests {
         assert_eq!(tree.leaves.len(), 3);
 
         let root_hash = tree.root_hash().expect("Expected root hash");
-        println!("Root hash (bytes): {:?}", root_hash);
-        println!("Leaf3 hash (bytes): {:?}", leaf3);
+        tracing::debug!("Root hash (bytes): {:?}", root_hash);
+        tracing::debug!("Leaf3 hash (bytes): {:?}", leaf3);
 
         let proof = tree.generate_proof(2);
-        println!("Proof path length: {}", proof.path.len());
+        tracing::debug!("Proof path length: {}", proof.path.len());
         for (i, hash) in proof.path.iter().enumerate() {
-            println!("Proof element {} (bytes): {:?}", i, hash);
+            tracing::debug!("Proof element {} (bytes): {:?}", i, hash);
         }
 
         // With odd-leaf duplication, proof must verify
         let combined_0_1 = MerkleNode::combine_hashes(&tree.leaves[0], &tree.leaves[1]);
         let combined_2_2 = MerkleNode::combine_hashes(&tree.leaves[2], &tree.leaves[2]);
         let expected_root = MerkleNode::combine_hashes(&combined_0_1, &combined_2_2);
-        println!("Expected root (bytes): {:?}", expected_root);
-        println!("Actual root   (bytes): {:?}", root_hash);
+        tracing::debug!("Expected root (bytes): {:?}", expected_root);
+        tracing::debug!("Actual root   (bytes): {:?}", root_hash);
 
         assert!(MerkleTree::verify_proof(
             &root_hash,


### PR DESCRIPTION
## Summary
Removes ad-hoc stdout/stderr debug output from the two production source files called out in issue #8 and replaces it with structured tracing.

Closes #8.

## What Changed
- Updated `dsm_client/deterministic_state_machine/dsm/src/merkle/tree.rs`
  - Replaced debug `println!` calls in Merkle proof tests/diagnostics with `tracing::debug!`
- Updated `dsm_client/deterministic_state_machine/dsm/src/crypto/sphincs.rs`
  - Updated `sphincs_trace!` macro (`sphincs-trace` feature path) to use `tracing::debug!` instead of `eprintln!`

## Why
Issue #8 requires removing debug print macros from production files to keep logging consistent with the project’s tracing-based observability and avoid direct stdout/stderr usage in protocol code paths.

## Validation
Executed focused tests for touched areas:
- `cargo test --locked -p dsm --lib merkle::tree::tests::test_proof_generation_and_verification -- --nocapture`
- `cargo test --locked -p dsm --lib crypto::sphincs::tests::sizes_match_known -- --nocapture`

Both passed.

## Notes
- This PR is intentionally scoped to the two files listed in issue #8.
- Other `println!` / `eprintln!` usages exist elsewhere in the repo (tests, tools, examples, and additional modules) and are out of scope for this issue.