### PR TITLE
Improve BLE connect flow; update withdrawal API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,54 @@ flow-mapping-assertions: ## Run flow mapping assertion checks
 	bash scripts/flow_mapping_assertions.sh
 
 # ---------------------------------------------------------------------------
+# RELEASE PREFLIGHT
+# ---------------------------------------------------------------------------
+
+.PHONY: release-preflight
+release-preflight: ## Run the full pre-tag release gate (lint, test, audit, CI scan, formal verification, frontend, SBOM)
+	@echo ""
+	@echo "╔══════════════════════════════════════════════════════════╗"
+	@echo "║              DSM Release Preflight                      ║"
+	@echo "╚══════════════════════════════════════════════════════════╝"
+	@echo ""
+	@echo "── [1/7] Lint ──────────────────────────────────────────────"
+	cargo fmt --all -- --check
+	cargo clippy --all-targets -- -D warnings
+	@echo ""
+	@echo "── [2/7] Rust tests ────────────────────────────────────────"
+	cargo test --workspace --exclude dsm_storage_node -- --nocapture
+	cargo test -p dsm_storage_node --no-default-features --features local-dev,strict -- --nocapture
+	@echo ""
+	@echo "── [3/7] Security audit ────────────────────────────────────"
+	cargo deny check
+	cargo audit
+	@echo ""
+	@echo "── [4/7] Protocol purity (CI scan) ─────────────────────────"
+	bash scripts/ci_scan.sh
+	bash scripts/flow_assertions.sh
+	bash scripts/flow_mapping_assertions.sh
+	bash scripts/check_forbidden_symbols.sh
+	@echo ""
+	@echo "── [5/7] Frontend (typecheck + test + build) ───────────────"
+	cd $(FRONTEND_DIR) && \
+		[ -s $$HOME/.nvm/nvm.sh ] && . $$HOME/.nvm/nvm.sh; \
+		nvm use --silent 2>/dev/null || true; \
+		npm run type-check && npm test -- --passWithNoTests && npm run build
+	@echo ""
+	@echo "── [6/7] Formal verification (TLA+ vertical validation) ────"
+	cargo run -p dsm_vertical_validation -- tla-check
+	@echo ""
+	@echo "── [7/7] SBOM generation ───────────────────────────────────"
+	bash scripts/generate-sbom.sh --run-id preflight-$$(date +%Y%m%d)
+	@echo ""
+	@echo "╔══════════════════════════════════════════════════════════╗"
+	@echo "║  ✓ All gates passed — ready to tag                      ║"
+	@echo "║                                                          ║"
+	@echo "║    git tag v0.1.0-beta.1                                 ║"
+	@echo "║    git push origin v0.1.0-beta.1                         ║"
+	@echo "╚══════════════════════════════════════════════════════════╝"
+
+# ---------------------------------------------------------------------------
 # CLEAN
 # ---------------------------------------------------------------------------
 

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/UnifiedBleBridge.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/UnifiedBleBridge.kt
@@ -228,8 +228,10 @@ internal object UnifiedBleBridge {
                     // Track effective BLE address — may change if Android rotated the peer's RPA
                     var effectiveAddress = deviceAddress
                     try {
-                        // Attempt 1: direct on-demand GATT client connect (works if peer is connectable)
-                        var connected = withTimeoutOrNull(8000L) {
+                        // Attempt 1: direct on-demand GATT client connect (works if peer is connectable).
+                        // connectToDevice now includes a 1.5s scan for RPA resolution + 12s poll,
+                        // so allow 15s total.
+                        var connected = withTimeoutOrNull(15000L) {
                             svc.connectToDevice(deviceAddress).await()
                         } ?: false
                         if (!connected) {
@@ -273,7 +275,7 @@ internal object UnifiedBleBridge {
                                 }
                                 return@runBlocking ok
                             } else {
-                                connected = withTimeoutOrNull(8000L) {
+                                connected = withTimeoutOrNull(15000L) {
                                     svc.connectToDevice(effectiveAddress).await()
                                 } ?: false
                             }

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/ble/BleCoordinator.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/ble/BleCoordinator.kt
@@ -123,6 +123,9 @@ class BleCoordinator private constructor(private val context: Context) : BleScan
     }
 
     companion object {
+        /** Max time to wait for GATT connection readiness (connect + discover + MTU). */
+        private const val CONNECT_READY_TIMEOUT_MS = 12_000L
+
         private var instance: BleCoordinator? = null
 
         fun getInstance(context: Context): BleCoordinator {
@@ -460,13 +463,15 @@ class BleCoordinator private constructor(private val context: Context) : BleScan
      */
     fun notifyAdvertiserPairingComplete(bleAddress: String) {
         runOperation {
-            // Clear session state after pairing so the bilateral send uses a fresh
-            // on-demand connection instead of the pairing session. The active session
-            // (activeSessions) is kept alive; connectToDevice() will clean it up if
-            // needed when the send is initiated.
-            sessionStates.remove(bleAddress)
+            // Mark the session as disconnected but keep the entry so on-demand
+            // reconnect does not lose track of the device entirely. connectToDevice()
+            // will clean up and re-establish the GATT connection as needed.
+            sessionStates[bleAddress]?.let { state ->
+                state.isConnected = false
+                state.serviceDiscoveryCompleted = false
+            }
             pendingConnectionAddresses.remove(bleAddress)
-            Log.i("BleCoordinator", "Advertiser pairing complete for $bleAddress — keeping advertising active for reconnects")
+            Log.i("BleCoordinator", "Advertiser pairing complete for $bleAddress — marked disconnected, keeping advertising active for reconnects")
         }
     }
 
@@ -1051,21 +1056,44 @@ class BleCoordinator private constructor(private val context: Context) : BleScan
                 deferred.complete(true)
                 return@runOperation
             }
-            // Clean up stale session
+            // Clean up stale session (gatt.close() is called by dropClientSession → disconnect → cleanup)
             if (activeSessions.containsKey(address)) {
                 dropClientSession(address, "pre_connect_stale_session")
+            }
+            // Brief scan to resolve current RPA before connecting — the pairing-time
+            // address may have rotated. Scanner calls are safe here because they operate
+            // directly on the scanner object, not through the operation channel.
+            Log.i("BleCoordinator", "connectToDevice($address): scanning briefly to resolve current RPA")
+            scanner.startScanning()
+            kotlinx.coroutines.delay(1500)
+            scanner.stopScanning()
+            // If a scan result yielded a ready session under a different address, use it
+            val resolvedAddress = if (hasActiveClientSession(address)) {
+                address
+            } else {
+                val freshAddr = findAnyReadySessionAddress()
+                if (freshAddr != null && freshAddr != address) {
+                    Log.i("BleCoordinator", "connectToDevice: RPA rotated $address → $freshAddr")
+                }
+                freshAddr ?: address
+            }
+            // If the scan resolved a ready session, we can skip the connect entirely
+            if (hasActiveClientSession(resolvedAddress)) {
+                pendingConnectionAddresses.remove(resolvedAddress)
+                deferred.complete(true)
+                return@runOperation
             }
             // Ensure GATT server is running
             if (!gattStartInFlight) {
                 gattStartInFlight = true
                 try { gattServer.ensureStarted() } finally { gattStartInFlight = false }
             }
-            val session = getOrCreateSession(address)
-            pendingConnectionAddresses.add(address)
+            val session = getOrCreateSession(resolvedAddress)
+            pendingConnectionAddresses.add(resolvedAddress)
             // Bilateral reconnect — identity read skip is determined by Rust pairing status
             val connected = session.connect()
             if (!connected) {
-                dropClientSession(address, "connect_init_failed")
+                dropClientSession(resolvedAddress, "connect_init_failed")
                 deferred.complete(false)
                 return@runOperation
             }
@@ -1074,16 +1102,24 @@ class BleCoordinator private constructor(private val context: Context) : BleScan
             // semantics.
             bleScope.launch {
                 val startTime = android.os.SystemClock.elapsedRealtime()
-                while (android.os.SystemClock.elapsedRealtime() - startTime < 6000L) {
-                    val state = sessionStates[address]
+                while (android.os.SystemClock.elapsedRealtime() - startTime < CONNECT_READY_TIMEOUT_MS) {
+                    val state = sessionStates[resolvedAddress]
                     if (state != null && state.isConnected && state.negotiatedMtu > 23 && state.serviceDiscoveryCompleted) {
-                        pendingConnectionAddresses.remove(address)
+                        pendingConnectionAddresses.remove(resolvedAddress)
                         deferred.complete(true)
                         return@launch
                     }
-                    if (state == null || (!state.isConnected && !activeSessions.containsKey(address))) {
+                    // If peer connected to our GATT server while we polled, succeed —
+                    // the caller will detect the server notification path.
+                    if (isGattServerClient(resolvedAddress) && isServerClientSubscribedToTxResponse(resolvedAddress)) {
+                        pendingConnectionAddresses.remove(resolvedAddress)
+                        Log.i("BleCoordinator", "connectToDevice: peer $resolvedAddress connected to our GATT server during poll — succeeding")
+                        deferred.complete(true)
+                        return@launch
+                    }
+                    if (state == null || (!state.isConnected && !activeSessions.containsKey(resolvedAddress))) {
                         runOperation {
-                            dropClientSession(address, "connect_aborted_before_ready")
+                            dropClientSession(resolvedAddress, "connect_aborted_before_ready")
                         }
                         deferred.complete(false)
                         return@launch
@@ -1091,7 +1127,7 @@ class BleCoordinator private constructor(private val context: Context) : BleScan
                     kotlinx.coroutines.delay(100)
                 }
                 runOperation {
-                    dropClientSession(address, "connect_ready_timeout")
+                    dropClientSession(resolvedAddress, "connect_ready_timeout")
                 }
                 deferred.complete(false)
             }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/ble_frame_coordinator.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/ble_frame_coordinator.rs
@@ -649,22 +649,21 @@ impl BleFrameCoordinator {
 
             // P1.4: LRU eviction — evict the oldest buffer by created_at, not arbitrary insertion order.
             if buffers.len() >= MAX_PENDING_REASSEMBLY {
-                if let Some(oldest_key) =
-                    buffers
-                        .iter()
-                        .min_by_key(|(_, buf)| buf.created_at)
-                        .map(|(k, buf)| {
-                            warn!(
-                                "BLE reassembly buffer full; evicting oldest frame {} ({}/{} chunks)",
-                                short_id(&k[..8]),
-                                buf.received_chunks.len(),
-                                buf.total_chunks
-                            );
-                            *k
-                        })
-                {
-                    buffers.remove(&oldest_key);
-                    let _ = crate::storage::client_db::delete_frame_chunks(&oldest_key);
+                let oldest_key = buffers
+                    .iter()
+                    .min_by_key(|(_, buf)| buf.created_at)
+                    .map(|(k, _)| *k);
+                if let Some(key) = oldest_key {
+                    if let Some(evicted) = buffers.get(&key) {
+                        warn!(
+                            "BLE reassembly buffer full; evicting oldest frame {} ({}/{} chunks)",
+                            short_id(&key[..8]),
+                            evicted.received_chunks.len(),
+                            evicted.total_chunks
+                        );
+                    }
+                    buffers.remove(&key);
+                    let _ = crate::storage::client_db::delete_frame_chunks(&key);
                 }
             }
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bitcoin_invoke_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bitcoin_invoke_routes.rs
@@ -5440,11 +5440,11 @@ mod tests {
     #[serial]
     async fn bitcoin_withdraw_execute_persists_policy_commit_from_plan() {
         let router = init_withdrawal_invoke_test_router("withdraw_policy_commit");
-        let request_net_sats = 100_000;
+        let request_gross_sats = 150_000;
         let full_fee = crate::sdk::bitcoin_tap_sdk::estimated_full_withdrawal_fee_sats();
-        let source_amount = request_net_sats + full_fee;
+        let source_amount = request_gross_sats + full_fee;
 
-        seed_dbtc_balance(&router, request_net_sats * 3);
+        seed_dbtc_balance(&router, request_gross_sats * 3);
         put_active_vault("vault-policy", source_amount);
         put_active_vault_record("vault-policy", source_amount);
 
@@ -5457,7 +5457,7 @@ mod tests {
             .query(AppQuery {
                 path: "bitcoin.withdraw.plan".to_string(),
                 params: pack_proto(&generated::BitcoinWithdrawalPlanRequest {
-                    requested_net_sats: request_net_sats,
+                    requested_net_sats: request_gross_sats,
                     destination_address: "tb1qpolicy".to_string(),
                 }),
             })

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/bitcoin_tap_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/bitcoin_tap_sdk.rs
@@ -3975,15 +3975,12 @@ impl BitcoinTapSdk {
 
     pub async fn plan_withdrawal(
         &self,
-        requested_net_sats: u64,
+        requested_gross_sats: u64,
         destination_address: &str,
         planner_device_id: &[u8; 32],
     ) -> Result<WithdrawalPlan, DsmError> {
-        let plan = self
-            .prepare_withdrawal_plan(requested_net_sats, destination_address, planner_device_id)
-            .await?;
-
-        Ok(plan)
+        self.prepare_withdrawal_plan(requested_gross_sats, destination_address, planner_device_id)
+            .await
     }
 
     /// Fetch vault execution data from storage nodes by vault_id.
@@ -5152,19 +5149,20 @@ mod tests {
         init_withdrawal_test_db();
 
         let bridge = BitcoinTapSdk::new(Arc::new(DLVManager::new()));
-        let requested_net_sats = 150_000;
+        let desired_net_sats = 150_000;
         let full_fee = estimated_full_withdrawal_fee_sats();
-        put_active_vault("vault-route", requested_net_sats + full_fee);
-        put_active_vault_record("vault-route", requested_net_sats + full_fee, "btc_to_dbtc");
+        let gross = desired_net_sats + full_fee;
+        put_active_vault("vault-route", gross);
+        put_active_vault_record("vault-route", gross, "btc_to_dbtc");
 
         let plan = bridge
-            .plan_withdrawal(requested_net_sats, "tb1qexactroute", &[0x11; 32])
+            .plan_withdrawal(gross, "tb1qexactroute", &[0x11; 32])
             .await
             .unwrap_or_else(|e| panic!("plan withdrawal failed: {e}"));
 
         assert_eq!(plan.legs.len(), 1);
         assert!(!plan.plan_id.is_empty());
-        assert_eq!(plan.requested_net_sats, requested_net_sats);
+        assert_eq!(plan.requested_net_sats, desired_net_sats);
         assert_eq!(plan.legs[0].vault_id, "vault-route");
     }
 
@@ -5177,7 +5175,8 @@ mod tests {
         let bridge = BitcoinTapSdk::new(dlv.clone());
 
         let full_fee = estimated_full_withdrawal_fee_sats();
-        let requested_net_sats = 1_501_337;
+        let desired_net_sats = 1_501_337;
+        let gross = desired_net_sats + full_fee;
         let preferred_vault_id = "000-vault-a";
         let secondary_vault_id = "001-vault-b";
 
@@ -5188,7 +5187,7 @@ mod tests {
                 refund_hash_lock: [0x20; 32],
                 refund_iterations: 42,
                 bitcoin_pubkey: vec![0x03; 33],
-                expected_btc_amount_sats: requested_net_sats + full_fee,
+                expected_btc_amount_sats: gross,
                 network: 0,
                 min_confirmations: 1,
             },
@@ -5201,21 +5200,13 @@ mod tests {
             .await
             .unwrap_or_else(|e| panic!("add stale vault failed: {e}"));
 
-        put_active_vault(secondary_vault_id, requested_net_sats + full_fee);
-        put_active_vault_record(
-            secondary_vault_id,
-            requested_net_sats + full_fee,
-            "btc_to_dbtc",
-        );
-        put_active_vault(preferred_vault_id, requested_net_sats + full_fee);
-        put_active_vault_record(
-            preferred_vault_id,
-            requested_net_sats + full_fee,
-            "btc_to_dbtc",
-        );
+        put_active_vault(secondary_vault_id, gross);
+        put_active_vault_record(secondary_vault_id, gross, "btc_to_dbtc");
+        put_active_vault(preferred_vault_id, gross);
+        put_active_vault_record(preferred_vault_id, gross, "btc_to_dbtc");
 
         let plan = bridge
-            .plan_withdrawal(requested_net_sats, "tb1qexampledestination", &[0x11; 32])
+            .plan_withdrawal(gross, "tb1qexampledestination", &[0x11; 32])
             .await
             .unwrap_or_else(|e| panic!("plan withdrawal failed: {e}"));
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/bilateral_round_trip.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/bilateral_round_trip.rs
@@ -286,12 +286,7 @@ async fn setup_two_devices_era(a_id: u8, b_id: u8, a_era: u64, b_era: u64) -> Tw
     }
 }
 
-async fn setup_two_devices_dbtc(
-    a_id: u8,
-    b_id: u8,
-    a_dbtc: u64,
-    b_dbtc: u64,
-) -> TwoDeviceSetup {
+async fn setup_two_devices_dbtc(a_id: u8, b_id: u8, a_dbtc: u64, b_dbtc: u64) -> TwoDeviceSetup {
     assert_ne!(a_id, b_id, "Device IDs for A and B must be distinct");
     let a_dev = dev(a_id);
     let b_dev = dev(b_id);

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/smt_production_smoke.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/smt_production_smoke.rs
@@ -966,10 +966,7 @@ async fn contact_add_stores_device_tree_root() {
         let sigma =
             dsm::core::bilateral_transaction_manager::compute_precommit(&h0, &op_bytes, &nonce);
         dsm::core::bilateral_transaction_manager::compute_successor_tip(
-            &h0,
-            &op_bytes,
-            &nonce,
-            &sigma,
+            &h0, &op_bytes, &nonce, &sigma,
         )
     };
 


### PR DESCRIPTION
Add a Makefile release-preflight target to run lint, tests, security checks, CI scans, frontend build, formal verification and SBOM generation.

Android BLE changes: increase GATT connect timeouts in UnifiedBleBridge to accommodate a longer connect+scan window; introduce CONNECT_READY_TIMEOUT_MS and improve BleCoordinator connect logic to (1) mark sessions disconnected after pairing without removing session entries, (2) perform a brief scan to resolve rotated RPAs before connecting, (3) prefer any already-ready session address, and (4) poll for connection readiness (including peer-connected-to-server detection) with proper cleanup and logging.

Rust BLE reassembly: make LRU eviction clearer by computing the oldest key first, log evicted buffer details using the retrieved entry, then remove it and its stored chunks.

Bitcoin withdrawal API/tests: change plan_withdrawal to accept gross (requested_gross_sats) and update tests to compute gross = desired_net + full_fee, adjust vault seeding and assertions accordingly so plans record requested_net_sats consistently.

Misc: small test formatting and whitespace cleanups in deterministic_state_machine tests.

## Summary

<!-- What does this change do and why is it needed? -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Testing

- [x] `make lint` passes (clippy + fmt)
- [x] `make build` passes
- [x] `make typecheck` passes (if frontend affected)
- [x] Relevant targeted tests pass (`make test-rust`, `make test-frontend`, or focused `cargo test --package ...`)
- [x] `make android` produces a working APK (if Android/JNI affected)

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I used [conventional commits](../CONTRIBUTING.md#commit-style) (`fix:`, `feat:`, `chore:`, `docs:`)
- [x] I updated docs or comments when behavior changed
- [ ] I did not include secrets, local paths, or machine-specific config
- [ ] I kept unrelated changes out of this PR
- [ ] `git grep -r -E 'TODO|FIXME|HACK|XXX'` returns zero results

## Notes

<!-- Anything reviewers should pay special attention to? Follow-up work left out? -->
