### PR TITLE
test(dsm): run random walk precommitment E2E in CI (#7)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/tests/dsm_end_to_end_test.rs
+++ b/dsm_client/deterministic_state_machine/dsm/tests/dsm_end_to_end_test.rs
@@ -230,8 +230,8 @@ fn create_next_state(
 }
 
 #[test]
-#[ignore] // Skip due to batch manager access issues
 fn test_random_walk_verification() -> Result<(), DsmError> {
+    // Pre-commitment random-walk positions via StateMachine (no external batch service).
     // This test focuses solely on random walk verification which appears to be working correctly
     // initialize() removed; core has no global init.
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -1448,7 +1448,8 @@ impl BilateralBleHandler {
                     &self.device_id,
                     &counterparty_device_id,
                 );
-                let mut modal_locked = crate::security::shared_smt::is_pending_online(&smt_key).await;
+                let mut modal_locked =
+                    crate::security::shared_smt::is_pending_online(&smt_key).await;
                 if modal_locked {
                     log::warn!(
                         "[BilateralBleHandler] ⚠️ §5.4 in-memory modal lock set for ({}, {}). Checking SQLite recovery before rejecting.",


### PR DESCRIPTION
## Summary

Re-enables `test_random_walk_verification` in `dsm_end_to_end_test.rs` by removing a stale `#[ignore]`. The test exercises `StateMachine::generate_precommitment` / `verify_precommitment` (random-walk positions only). The old “batch manager access” rationale did not match the code path; there is no separate batch manager involved.

Includes a small `rustfmt` line wrap in `bilateral_ble_handler.rs` so `cargo fmt --check` stays green.


Closes #7