### PR TITLE
refactor(frontend): consolidate BitcoinTapTab into a single module (#14)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -1448,7 +1448,8 @@ impl BilateralBleHandler {
                     &self.device_id,
                     &counterparty_device_id,
                 );
-                let mut modal_locked = crate::security::shared_smt::is_pending_online(&smt_key).await;
+                let mut modal_locked =
+                    crate::security::shared_smt::is_pending_online(&smt_key).await;
                 if modal_locked {
                     log::warn!(
                         "[BilateralBleHandler] ⚠️ §5.4 in-memory modal lock set for ({}, {}). Checking SQLite recovery before rejecting.",

--- a/dsm_client/frontend/src/components/screens/BitcoinTapTab.tsx
+++ b/dsm_client/frontend/src/components/screens/BitcoinTapTab.tsx
@@ -1,3 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Re-export from decomposed bitcoin/ directory.
-export { default } from './bitcoin/BitcoinTapTab';

--- a/dsm_client/frontend/src/components/screens/EnhancedWalletScreen.tsx
+++ b/dsm_client/frontend/src/components/screens/EnhancedWalletScreen.tsx
@@ -6,7 +6,7 @@ import OverviewTab from './wallet/OverviewTab';
 import SendTab from './wallet/SendTab';
 import HistoryTab from './wallet/HistoryTab';
 import InboxOverlay from './wallet/InboxOverlay';
-import BitcoinTapTab from './BitcoinTapTab';
+import BitcoinTapTab from './bitcoin/BitcoinTapTab';
 import { ensureBleAdvertisingIfContacts } from '../../contexts/ContactsContext';
 import { stopBleAdvertisingViaRouter } from '../../dsm/WebViewBridge';
 import { bridgeEvents } from '../../bridge/bridgeEvents';

--- a/dsm_client/frontend/src/components/screens/__tests__/BitcoinTapTab.disabled.test.tsx
+++ b/dsm_client/frontend/src/components/screens/__tests__/BitcoinTapTab.disabled.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import BitcoinTapTab from '../BitcoinTapTab';
+import BitcoinTapTab from '../bitcoin/BitcoinTapTab';
 
 const mockGetDbtcBalance = jest.fn();
 const mockGetNativeBtcBalance = jest.fn();


### PR DESCRIPTION
## Summary

Removes the duplicate `BitcoinTapTab` entry point under `screens/` and keeps a **single** implementation at `src/components/screens/bitcoin/BitcoinTapTab.tsx`. All imports now reference that path.

## Motivation

Two copies of the same screen (top-level `screens/BitcoinTapTab.tsx` vs `screens/bitcoin/BitcoinTapTab.tsx`) made it unclear which file was authoritative and increased merge risk. GitHub #14 asks for one canonical location, deletion of the duplicate, and updated imports.

## Changes

- Delete `dsm_client/frontend/src/components/screens/BitcoinTapTab.tsx` (duplicate removed; no re-export shim).
- Import `BitcoinTapTab` from `./bitcoin/BitcoinTapTab` in `EnhancedWalletScreen.tsx`.
- Point `BitcoinTapTab.disabled.test.tsx` at `../bitcoin/BitcoinTapTab`.

Closes #14