### PR TITLE
docs(sdk): clarify bilateral confirm preimage comments (#17)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/bilateral_transaction_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/bilateral_transaction_manager.rs
@@ -513,7 +513,7 @@ impl BilateralTransactionManager {
     /// This is used by the BLE handler when registering a sender session for bilateral transfers.
     /// The signature is required for the commit phase.
     pub fn sign_commitment(&self, commitment_hash: &[u8; 32]) -> Vec<u8> {
-        // §ISSUE-B4 FIX: canonical "DSM/<domain>\0" domain separator format.
+        // Message: `DSM/bilateral-sign\0` || commitment_hash.
         let mut msg = Vec::with_capacity(22 + 32);
         msg.extend_from_slice(b"DSM/bilateral-sign\0");
         msg.extend_from_slice(commitment_hash);

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -1448,7 +1448,8 @@ impl BilateralBleHandler {
                     &self.device_id,
                     &counterparty_device_id,
                 );
-                let mut modal_locked = crate::security::shared_smt::is_pending_online(&smt_key).await;
+                let mut modal_locked =
+                    crate::security::shared_smt::is_pending_online(&smt_key).await;
                 if modal_locked {
                     log::warn!(
                         "[BilateralBleHandler] ⚠️ §5.4 in-memory modal lock set for ({}, {}). Checking SQLite recovery before rejecting.",

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -2378,8 +2378,7 @@ impl BilateralBleHandler {
                 .public_key
                 .clone()
         };
-        // §ISSUE-B4 FIX: use canonical "DSM/<domain>\0" format consistent with every
-        // other domain separator in the codebase.
+        // Bilateral confirm signature: `DSM/bilateral-sign\0` || commitment_hash (canonical domain tag).
         let mut signature_msg = Vec::with_capacity(22 + 32);
         signature_msg.extend_from_slice(b"DSM/bilateral-sign\0");
         signature_msg.extend_from_slice(&commitment_hash);
@@ -2917,7 +2916,7 @@ impl BilateralBleHandler {
                 .clone()
         };
 
-        // §ISSUE-B4 FIX: use canonical "DSM/<domain>\0" format.
+        // Confirm-request sender sig: `DSM/bilateral-sign\0` || commitment_hash.
         let mut signature_msg = Vec::with_capacity(22 + 32);
         signature_msg.extend_from_slice(b"DSM/bilateral-sign\0");
         signature_msg.extend_from_slice(&commitment_hash);


### PR DESCRIPTION
### Summary

Replaces internal tracker-style comments (`§ISSUE-B4 FIX`, generic `DSM/<domain>\0` wording) with **neutral, explicit** notes describing the actual signed message for bilateral confirm paths: **`DSM/bilateral-sign\0` || `commitment_hash`**.

Touches the same layout in the core `BilateralTransactionManager::sign_commitment` path and in `bilateral_ble_handler.rs` where confirm signatures are built.

### Scope

- **Comment-only change** — no change to bytes hashed or signed; `b"DSM/bilateral-sign\0"` + 32-byte hash was already used in the edited sites.
- Aligns documentation in-code with what #17 calls out in `bilateral_ble_handler.rs` (clear, consistent description of the domain tag / preimage).

### Files

- `dsm_client/deterministic_state_machine/dsm/src/core/bilateral_transaction_manager.rs`
- `dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs`

Closes #17