### PR TITLE
docs(sdk): clarify deferred proof_data on transaction persist (#19)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -1448,7 +1448,8 @@ impl BilateralBleHandler {
                     &self.device_id,
                     &counterparty_device_id,
                 );
-                let mut modal_locked = crate::security::shared_smt::is_pending_online(&smt_key).await;
+                let mut modal_locked =
+                    crate::security::shared_smt::is_pending_online(&smt_key).await;
                 if modal_locked {
                     log::warn!(
                         "[BilateralBleHandler] ⚠️ §5.4 in-memory modal lock set for ({}, {}). Checking SQLite recovery before rejecting.",

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/wallet_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/wallet_sdk.rs
@@ -980,10 +980,9 @@ impl WalletSDK {
                 chain_height: new_state.state_number,
                 step_index: tx_copy.tick,
                 commitment_hash: None,
-                // §ISSUE-W1 FIX: proof_data must carry relationship chain tips h_n / h_{n+1},
-                // NOT entity-level state hashes. The real ReceiptCommit with correct SMT
-                // proofs is built and stored by the caller (app_router_impl.rs) after this
-                // function returns. Set None so the subsequent upsert preserves authority.
+                // `proof_data` is filled when the receipt is available: `app_router_impl` calls
+                // `update_transaction_proof_data` with canonical receipt bytes (relationship-level
+                // chain context). None here avoids persisting the wrong preimage before that step.
                 proof_data: None,
                 metadata: meta,
                 created_at: 0,


### PR DESCRIPTION
## Summary

Replaces the `§ISSUE-W1 FIX` comment above `proof_data: None` in `wallet_sdk.rs` with a neutral description: proof data is populated when the receipt exists and `app_router_impl` updates it with canonical relationship-level context.

## Scope

Comment-only; persistence behavior unchanged.

Closes #19