### PR TITLE
ci: add stale issue/PR workflow (#27)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: Stale issues and PRs
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue has been marked stale due to inactivity."
+          stale-pr-message: "This pull request has been marked stale due to inactivity."
+          close-issue-message: "Closing due to inactivity. Reopen if still relevant."
+          close-pr-message: "Closing due to inactivity."
+          days-before-stale: 60
+          days-before-close: 14
+          exempt-issue-labels: "security,critical,priority:high"
+          exempt-pr-labels: "security,critical,priority:high"

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -1448,7 +1448,8 @@ impl BilateralBleHandler {
                     &self.device_id,
                     &counterparty_device_id,
                 );
-                let mut modal_locked = crate::security::shared_smt::is_pending_online(&smt_key).await;
+                let mut modal_locked =
+                    crate::security::shared_smt::is_pending_online(&smt_key).await;
                 if modal_locked {
                     log::warn!(
                         "[BilateralBleHandler] ⚠️ §5.4 in-memory modal lock set for ({}, {}). Checking SQLite recovery before rejecting.",


### PR DESCRIPTION
## Summary

Adds `.github/workflows/stale.yml` using [actions/stale](https://github.com/actions/stale) to mark inactive issues and PRs, then close them after a quiet period unless they carry exempt labels.

## Behavior

- **Schedule:** daily (`cron`); **manual:** `workflow_dispatch`
- **Stale:** after 60 days of inactivity; **close:** 14 days after stale (no further activity)
- **Exempt labels:** `security`, `critical`, `priority:high`

## Permissions

`issues: write` and `pull-requests: write` for labeling/closing.

Closes #27