### PR TITLE
ci: add nightly cargo-audit workflow (#29)

### DIFF
--- a/.github/workflows/nightly-security-audit.yml
+++ b/.github/workflows/nightly-security-audit.yml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: Nightly security audit
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo audit
+        run: |
+          cargo install cargo-audit --quiet || true
+          cargo audit

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -1448,7 +1448,8 @@ impl BilateralBleHandler {
                     &self.device_id,
                     &counterparty_device_id,
                 );
-                let mut modal_locked = crate::security::shared_smt::is_pending_online(&smt_key).await;
+                let mut modal_locked =
+                    crate::security::shared_smt::is_pending_online(&smt_key).await;
                 if modal_locked {
                     log::warn!(
                         "[BilateralBleHandler] ⚠️ §5.4 in-memory modal lock set for ({}, {}). Checking SQLite recovery before rejecting.",


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Actions workflow to run `cargo audit` every night at **06:00 UTC** (`0 6 * * *`), plus `workflow_dispatch` for manual runs.

## Details

- Installs `cargo-audit` if needed, then runs `cargo audit` from the repo root (same tool family as CI).
- Permissions: `contents: read`.

## Note

GitHub #29 suggested the filename `security-audit.yml`; this PR uses `nightly-security-audit.yml` for clarity. Rename in a follow-up if you want an exact match.

Closes #29