### PR TITLE
build(android): restore ABI-aligned NDK validation across Rust, Gradle, and CI

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -51,6 +51,19 @@ info "Checking proto guards..."
 bash scripts/guard_protos.sh
 pass "Proto guards"
 
+# ---------------------------------------------------------------------------
+# 4. Android NDK validation (when configured locally)
+# ---------------------------------------------------------------------------
+if [[ -n "${ANDROID_NDK_HOME:-}" || -n "${ANDROID_NDK_ROOT:-}" ]]; then
+  info "Running Android NDK validation..."
+  if ! make android-ndk-check 2>&1; then
+    fail "make android-ndk-check failed — fix Android NDK build errors before pushing"
+  fi
+  pass "Android NDK validation"
+else
+  info "Skipping Android NDK validation (ANDROID_NDK_HOME / ANDROID_NDK_ROOT not set locally)"
+fi
+
 echo ""
 echo -e "${GREEN}All pre-push checks passed.${NC}"
 echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,42 @@ jobs:
           cargo audit
 
   # --------------------------------------------------------------------------
+  # Android NDK: native Rust mobile build validation
+  # --------------------------------------------------------------------------
+  android-ndk:
+    name: Android NDK
+    runs-on: ubuntu-latest
+    needs: [rust]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android, armv7-linux-androideabi
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: android-actions/setup-android@v3
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Android NDK validation deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          cargo install cargo-ndk --locked --quiet || true
+          sdkmanager --install "ndk;27.0.12077973"
+          echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/27.0.12077973" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/27.0.12077973" >> "$GITHUB_ENV"
+          echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" >> "$GITHUB_ENV"
+
+      - name: Validate Android Rust NDK build
+        run: make android-ndk-check
+
+  # --------------------------------------------------------------------------
   # Formal validation: TLA+ model checking + real-code bridge harness
   # --------------------------------------------------------------------------
   formal-validation:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 #   make doctor       — check local prerequisites without changing files
 #   make setup        — first-time onboarding
 #   make build        — Rust workspace build
+#   make android-ndk-check — validate Rust Android NDK build for shipping ABIs
 #   make nodes-up     — start local storage nodes
 #   make android      — build debug APK (includes native libs)
 #   make install      — build + install APK on all connected adb devices
@@ -24,6 +25,9 @@
 # Prefer homebrew bash (4+) for associative arrays used by SBOM scripts.
 # Fall back to system bash if homebrew isn't installed.
 SHELL := $(shell command -v /opt/homebrew/bin/bash 2>/dev/null || echo /bin/bash)
+empty :=
+space := $(empty) $(empty)
+comma := ,
 REPO_ROOT := $(shell cd "$(dir $(abspath $(lastword $(MAKEFILE_LIST))))" && pwd)
 ANDROID_DIR := $(REPO_ROOT)/dsm_client/android
 NDK_DIR := $(REPO_ROOT)/dsm_client/deterministic_state_machine
@@ -36,6 +40,12 @@ CARGO_CONFIG_TEMPLATE := $(NDK_DIR)/dsm_sdk/.cargo/config.toml.template
 ANDROID_LOCAL_PROPERTIES := $(ANDROID_DIR)/local.properties
 RUST_TOOLCHAIN_FILE := $(REPO_ROOT)/rust-toolchain.toml
 ANDROID_APP_GRADLE := $(ANDROID_DIR)/app/build.gradle.kts
+ANDROID_ABIS ?= arm64-v8a armeabi-v7a
+ANDROID_ABIS_CSV := $(subst $(space),$(comma),$(strip $(ANDROID_ABIS)))
+define android_rust_target
+$(if $(filter arm64-v8a,$1),aarch64-linux-android,$(if $(filter armeabi-v7a,$1),armv7-linux-androideabi,$(if $(filter x86_64,$1),x86_64-linux-android,unsupported:$1)))
+endef
+ANDROID_RUST_TARGETS := $(strip $(foreach abi,$(ANDROID_ABIS),$(call android_rust_target,$(abi))))
 
 .DEFAULT_GOAL := help
 
@@ -86,7 +96,7 @@ doctor: ## Check local prerequisites and repo state without changing files
 	@command -v adb >/dev/null 2>&1 && echo "    adb: available" || echo "    adb: optional (needed only for device install/debug)"
 	@command -v psql >/dev/null 2>&1 && echo "    psql: available" || echo "    psql: optional until you run local storage nodes"
 	@command -v java >/dev/null 2>&1 && echo "    java: $$(java -version 2>&1 | head -1)" || echo "    java: optional until Android builds"
-	@command -v cargo-ndk >/dev/null 2>&1 && echo "    cargo-ndk: $$(cargo ndk --version)" || echo "    cargo-ndk: optional until Android builds (install via cargo install cargo-ndk)"
+	@command -v rustup >/dev/null 2>&1 && echo "    rustup: $$(rustup --version | head -1)" || echo "    MISSING: rustup (install from https://rustup.rs)"
 	@GRADLE_NDK_VERSION="$$(sed -n 's/.*ndkVersion = \"\([^\"]*\)\".*/\1/p' "$(ANDROID_APP_GRADLE)" | head -1)"; \
 	NDK=""; \
 	NDK_SOURCE=""; \
@@ -179,6 +189,30 @@ android-sdk-config: ## Detect Android SDK and write ignored local.properties for
 	printf 'sdk.dir=%s\n' "$$ESCAPED_SDK" > "$(ANDROID_LOCAL_PROPERTIES)"; \
 	echo "    Android SDK configured for Gradle (local.properties updated)"
 
+.PHONY: android-rust-targets
+android-rust-targets: ## Ensure Rust Android targets exist for configured ABIs
+	@command -v rustup >/dev/null 2>&1 || { echo "ERROR: rustup not found. Install rustup from https://rustup.rs first."; exit 1; }
+	@missing_targets=""; \
+	for rust_target in $(ANDROID_RUST_TARGETS); do \
+		case "$$rust_target" in \
+			unsupported:*) \
+				echo "ERROR: Unsupported Android ABI '$${rust_target#unsupported:}' in ANDROID_ABIS ($(ANDROID_ABIS))"; \
+				exit 1; \
+				;; \
+			*) \
+				if ! rustup target list --installed | grep -Fxq "$$rust_target"; then \
+					missing_targets="$$missing_targets $$rust_target"; \
+				fi; \
+				;; \
+		esac; \
+	done; \
+	if [ -n "$$missing_targets" ]; then \
+		echo "==> Installing missing Rust Android targets:$${missing_targets}"; \
+		rustup target add $$missing_targets; \
+	else \
+		echo "    Rust Android targets already installed: $(ANDROID_RUST_TARGETS)"; \
+	fi
+
 .PHONY: setup
 setup: ## First-time developer setup: check deps, auto-configure Android, install frontend deps
 	@echo "==> Checking prerequisites..."
@@ -209,8 +243,7 @@ setup: ## First-time developer setup: check deps, auto-configure Android, instal
 		if [ -n "$$GRADLE_NDK_VERSION" ] && [ "$$NDK_VERSION" != "$$GRADLE_NDK_VERSION" ]; then \
 			echo "WARNING: configured NDK version ($$NDK_VERSION) does not match Gradle ndkVersion ($$GRADLE_NDK_VERSION)."; \
 		fi; \
-		command -v cargo-ndk >/dev/null 2>&1 || { echo "Installing cargo-ndk..."; cargo install cargo-ndk; }; \
-		echo "    cargo-ndk: $$(cargo ndk --version)"; \
+		$(MAKE) android-rust-targets; \
 		mkdir -p "$$(dirname "$(CARGO_CONFIG)")"; \
 		echo "==> Refreshing dsm_client/deterministic_state_machine/dsm_sdk/.cargo/config.toml from template..."; \
 		sed \
@@ -246,7 +279,7 @@ build-release: ## Build Rust workspace in release mode
 	cargo build --locked --workspace --all-features --release
 
 .PHONY: android-libs
-android-libs: ## Build native .so libs for all Android ABIs (requires NDK)
+android-libs: ## Build native .so libs for configured Android ABIs (requires NDK)
 	@echo "==> Building Android native libs..."
 	@rm -f $(JNILIBS_DIR)/arm64-v8a/libdsm_sdk.so \
 	        $(JNILIBS_DIR)/armeabi-v7a/libdsm_sdk.so \
@@ -254,20 +287,64 @@ android-libs: ## Build native .so libs for all Android ABIs (requires NDK)
 	        $(REPO_JNILIBS_DIR)/arm64-v8a/libdsm_sdk.so \
 	        $(REPO_JNILIBS_DIR)/armeabi-v7a/libdsm_sdk.so \
 	        $(REPO_JNILIBS_DIR)/x86_64/libdsm_sdk.so
-	@mkdir -p $(REPO_JNILIBS_DIR)/arm64-v8a \
+	@mkdir -p $(JNILIBS_DIR)/arm64-v8a \
+	          $(JNILIBS_DIR)/armeabi-v7a \
+	          $(JNILIBS_DIR)/x86_64 \
+	          $(REPO_JNILIBS_DIR)/arm64-v8a \
 	          $(REPO_JNILIBS_DIR)/armeabi-v7a \
 	          $(REPO_JNILIBS_DIR)/x86_64
 	cd $(NDK_DIR) && \
-		DSM_PROTO_ROOT=$(REPO_ROOT)/proto \
-		cargo ndk \
-			-t arm64-v8a -t armeabi-v7a -t x86_64 \
-			-o $(JNILIBS_DIR) \
-			--platform 23 \
-			build --release --package dsm_sdk --features=jni,bluetooth
-	@cp $(NDK_DIR)/target/aarch64-linux-android/release/libdsm_sdk.so $(REPO_JNILIBS_DIR)/arm64-v8a/
-	@cp $(NDK_DIR)/target/armv7-linux-androideabi/release/libdsm_sdk.so $(REPO_JNILIBS_DIR)/armeabi-v7a/
-	@cp $(NDK_DIR)/target/x86_64-linux-android/release/libdsm_sdk.so $(REPO_JNILIBS_DIR)/x86_64/
+		NDK_ROOT="$${ANDROID_NDK_HOME:-$$ANDROID_NDK_ROOT}"; \
+		HOST_TAG="$$(ls "$$NDK_ROOT/toolchains/llvm/prebuilt" | head -1)"; \
+		TOOLCHAIN="$$NDK_ROOT/toolchains/llvm/prebuilt/$$HOST_TAG/bin"; \
+		export DSM_PROTO_ROOT=$(REPO_ROOT)/proto; \
+		export CC_aarch64_linux_android="$$TOOLCHAIN/aarch64-linux-android23-clang"; \
+		export CXX_aarch64_linux_android="$$TOOLCHAIN/aarch64-linux-android23-clang++"; \
+		export AR_aarch64_linux_android="$$TOOLCHAIN/llvm-ar"; \
+		export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$$TOOLCHAIN/aarch64-linux-android23-clang"; \
+		export CC_armv7_linux_androideabi="$$TOOLCHAIN/armv7a-linux-androideabi23-clang"; \
+		export CXX_armv7_linux_androideabi="$$TOOLCHAIN/armv7a-linux-androideabi23-clang++"; \
+		export AR_armv7_linux_androideabi="$$TOOLCHAIN/llvm-ar"; \
+		export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$$TOOLCHAIN/armv7a-linux-androideabi23-clang"; \
+		export CC_x86_64_linux_android="$$TOOLCHAIN/x86_64-linux-android23-clang"; \
+		export CXX_x86_64_linux_android="$$TOOLCHAIN/x86_64-linux-android23-clang++"; \
+		export AR_x86_64_linux_android="$$TOOLCHAIN/llvm-ar"; \
+		export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$$TOOLCHAIN/x86_64-linux-android23-clang"; \
+		for abi in $(ANDROID_ABIS); do \
+			case "$$abi" in \
+				arm64-v8a) rust_target="aarch64-linux-android" ;; \
+				armeabi-v7a) rust_target="armv7-linux-androideabi" ;; \
+				x86_64) rust_target="x86_64-linux-android" ;; \
+				*) echo "ERROR: Unsupported Android ABI '$$abi'"; exit 1 ;; \
+			esac; \
+			cargo build --release --target "$$rust_target" --package dsm_sdk --features=jni,bluetooth || exit $$?; \
+		done
+	@for abi in $(ANDROID_ABIS); do \
+		case "$$abi" in \
+			arm64-v8a) \
+				cp $(NDK_DIR)/target/aarch64-linux-android/release/libdsm_sdk.so $(JNILIBS_DIR)/arm64-v8a/; \
+				cp $(NDK_DIR)/target/aarch64-linux-android/release/libdsm_sdk.so $(REPO_JNILIBS_DIR)/arm64-v8a/ ;; \
+			armeabi-v7a) \
+				cp $(NDK_DIR)/target/armv7-linux-androideabi/release/libdsm_sdk.so $(JNILIBS_DIR)/armeabi-v7a/; \
+				cp $(NDK_DIR)/target/armv7-linux-androideabi/release/libdsm_sdk.so $(REPO_JNILIBS_DIR)/armeabi-v7a/ ;; \
+			x86_64) \
+				cp $(NDK_DIR)/target/x86_64-linux-android/release/libdsm_sdk.so $(JNILIBS_DIR)/x86_64/; \
+				cp $(NDK_DIR)/target/x86_64-linux-android/release/libdsm_sdk.so $(REPO_JNILIBS_DIR)/x86_64/ ;; \
+			*) echo "ERROR: Unsupported Android ABI '$$abi'"; exit 1 ;; \
+		esac; \
+	done
 	@echo "==> Native libs built."
+
+.PHONY: android-ndk-check
+android-ndk-check: ## Validate Rust Android NDK build for configured ABIs (override ANDROID_ABIS=...)
+	@if [ -z "$$ANDROID_NDK_HOME" ] && [ -z "$$ANDROID_NDK_ROOT" ]; then \
+		echo "ERROR: ANDROID_NDK_HOME or ANDROID_NDK_ROOT must be set for Android NDK validation."; \
+		exit 1; \
+	fi
+	@$(MAKE) android-rust-targets
+	@echo "==> Validating Android NDK Rust build (ABIs: $(ANDROID_ABIS))..."
+	@$(MAKE) android-libs
+	@echo "==> Android NDK validation passed."
 
 .PHONY: frontend
 frontend: ## Build the React frontend (copies assets into Android)
@@ -281,13 +358,13 @@ frontend: ## Build the React frontend (copies assets into Android)
 .PHONY: android
 android: android-sdk-config android-libs frontend ## Build fresh debug APK (native libs + frontend + clean gradle)
 	@echo "==> Assembling fresh Android debug APK..."
-	cd $(ANDROID_DIR) && ./gradlew clean :app:assembleDebug --no-daemon --console=plain
+	cd $(ANDROID_DIR) && DSM_ANDROID_ABIS=$(ANDROID_ABIS_CSV) ./gradlew clean :app:assembleDebug --no-daemon --console=plain
 	@echo "==> APK: $(ANDROID_DIR)/app/build/outputs/apk/debug/app-debug.apk"
 
 .PHONY: android-release
 android-release: android-sdk-config android-libs frontend ## Build fresh release APK
 	@echo "==> Assembling fresh Android release APK..."
-	cd $(ANDROID_DIR) && ./gradlew clean :app:assembleRelease --no-daemon --console=plain
+	cd $(ANDROID_DIR) && DSM_ANDROID_ABIS=$(ANDROID_ABIS_CSV) ./gradlew clean :app:assembleRelease --no-daemon --console=plain
 	@echo "==> APK: $(ANDROID_DIR)/app/build/outputs/apk/release/app-release.apk"
 
 # ---------------------------------------------------------------------------

--- a/dsm_client/android/app/build.gradle.kts
+++ b/dsm_client/android/app/build.gradle.kts
@@ -12,6 +12,24 @@ plugins {
     id("com.google.protobuf")
 }
 
+val supportedRustAbis = mapOf(
+    "arm64-v8a" to "aarch64-linux-android",
+    "armeabi-v7a" to "armv7-linux-androideabi",
+    "x86_64" to "x86_64-linux-android",
+)
+
+val configuredRustAbis = (providers.gradleProperty("dsm.android.abis").orNull
+    ?: providers.environmentVariable("DSM_ANDROID_ABIS").orNull)
+    ?.split(",")
+    ?.map { it.trim() }
+    ?.filter { it.isNotEmpty() }
+    ?.ifEmpty { null }
+    ?: supportedRustAbis.keys.toList()
+
+require(configuredRustAbis.all { it in supportedRustAbis }) {
+    "Unsupported DSM_ANDROID_ABIS value: ${configuredRustAbis.joinToString(", ")}"
+}
+
 android {
     namespace = "com.dsm.wallet"
     compileSdk = 35
@@ -34,7 +52,7 @@ android {
         // Benefits: 3-8% faster app launch, 4.5% lower power draw, 4-6% faster camera
         // If you bundle prebuilt JNI libs in src/main/jniLibs/**, keep ABI listing explicit
         ndk {
-            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+            abiFilters += configuredRustAbis
         }
 
         // CMake build flags for Silicon Fingerprint NDK library
@@ -249,11 +267,9 @@ val refreshDsmJniLibs = tasks.register("refreshDsmJniLibs") {
     val repoJniLibs = project.file("../../deterministic_state_machine/jniLibs")
 
     // ABI -> Rust target triple
-    val abiToTriple = mapOf(
-        "arm64-v8a"   to "aarch64-linux-android",
-        "armeabi-v7a" to "armv7-linux-androideabi",
-        "x86_64"      to "x86_64-linux-android",
-    )
+    val abiToTriple = configuredRustAbis.associateWith { abi ->
+        supportedRustAbis.getValue(abi)
+    }
 
     // Resolve .so path: prefer cargo target release/debug, then accept direct
     // cargo-ndk `-o` output already written into jniLibs.

--- a/dsm_client/deterministic_state_machine/Cargo.lock
+++ b/dsm_client/deterministic_state_machine/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -25,8 +25,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -158,7 +158,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -173,6 +173,45 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"
@@ -474,16 +513,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -493,6 +532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array 0.4.10",
 ]
 
 [[package]]
@@ -594,8 +642,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.1",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -605,8 +665,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
- "cipher",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -644,9 +704,20 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -747,10 +818,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -857,6 +946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array 0.4.10",
+]
+
+[[package]]
 name = "ctor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,8 +976,14 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -893,6 +997,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,21 +1021,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
  "unicode-xid",
 ]
@@ -928,9 +1048,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -988,6 +1108,7 @@ dependencies = [
  "bitflags 2.10.0",
  "blake3",
  "bytes",
+ "chacha20 0.10.0",
  "chacha20poly1305",
  "clap",
  "constant_time_eq",
@@ -1019,13 +1140,14 @@ dependencies = [
  "parking_lot 0.12.5",
  "pbkdf2",
  "proptest",
- "prost 0.13.5",
+ "prost 0.14.3",
  "prost-build 0.14.3",
  "prost-types 0.12.6",
  "protoc-bin-vendored",
  "quickcheck",
- "rand 0.8.5",
+ "rand 0.10.0",
  "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "rocksdb",
  "rstest",
  "serde",
@@ -1065,6 +1187,7 @@ dependencies = [
  "blake3",
  "bytes",
  "cbindgen",
+ "chacha20 0.10.0",
  "chacha20poly1305",
  "crc32fast",
  "criterion",
@@ -1096,13 +1219,13 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.5",
  "proptest",
- "prost 0.13.5",
+ "prost 0.14.3",
  "prost-build 0.14.3",
  "prost-types 0.12.6",
  "protoc-bin-vendored",
  "quickcheck",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.10.0",
+ "rand_core 0.6.4",
  "rcgen",
  "reqwest",
  "rstest",
@@ -1120,7 +1243,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "toml_edit 0.22.27",
  "tonic-build",
  "tracing",
@@ -1538,6 +1661,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1671,13 +1795,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows-link",
 ]
 
 [[package]]
@@ -1758,6 +1882,15 @@ name = "hybrid-array"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -1998,6 +2131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array 0.4.10",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,7 +2232,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2099,9 +2241,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2129,7 +2293,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2287,12 +2451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,7 +2603,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcaee19a45f916d98f24a551cc9a2cdae705a040e66f3cbc4f3a282ea6a2e982"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.2.3",
  "kem",
  "rand_core 0.6.4",
  "sha3",
@@ -2613,6 +2771,15 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2852,7 +3019,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2864,7 +3031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3314,8 +3481,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3327,6 +3492,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3383,6 +3559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,13 +3604,15 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.12.1"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48406db8ac1f3cbc7dcdb56ec355343817958a356ff430259bb07baf7607e1e1"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "pem",
  "ring",
+ "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
@@ -3644,6 +3828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,18 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3904,7 +4088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4206,10 +4390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4217,6 +4403,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -4316,25 +4512,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -4342,13 +4526,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml_datetime"
@@ -4361,9 +4557,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4375,8 +4571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.13.0",
- "serde",
- "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.14",
@@ -4389,16 +4583,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.0",
 ]
@@ -4411,9 +4605,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic-build"
@@ -4578,6 +4772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4589,7 +4789,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -5210,6 +5410,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -15,4 +15,4 @@ chmod +x .githooks/pre-commit .githooks/pre-push
 
 echo "Git hooks installed — .githooks/ is now active."
 echo "  pre-commit : fmt, protocol purity, forbidden symbols, bilateral gates"
-echo "  pre-push   : clippy, tests, codegen enforcement, proto guards"
+echo "  pre-push   : clippy, tests, codegen enforcement, proto guards, Android NDK build (when NDK is configured)"


### PR DESCRIPTION
## Summary

This PR restores and hardens the Android NDK build path by aligning the Rust native build, Gradle ABI packaging, and CI validation around the same configured ABI set.

## What Changed

- pin JNI-related Rust dependencies to an NDK-compatible version line
- add ABI-aware Android Rust build targets in the Makefile
- add `android-ndk-check` to validate native Android builds explicitly
- align Gradle `abiFilters` with the configured Rust output ABIs
- pass the configured ABI list into Android debug and release packaging
- run Android NDK validation in CI
- run Android NDK validation from the pre-push hook when a local NDK is configured


## Why

Before this change, the Android build path could drift between:
- Rust native targets being built
- Gradle ABIs being packaged
- CI validation coverage

That mismatch made it possible to build extra `.so` outputs that were not actually shipped, or to miss NDK-related breakages until later in the release flow.

This PR makes those paths consistent and adds earlier validation.

## Validation

- branch rebased into function/file-grouped commits
- local branch diff verified against `main`
- branch pushed successfully
- pre-push checks passed during cherry-pick/commit flow

## Notes

- local pre-push Android NDK validation runs only when `ANDROID_NDK_HOME` or `ANDROID_NDK_ROOT` is configured
- CI installs the required Android NDK and validates the Rust Android build with `make android-ndk-check`