### PR TITLE
test(frontend): add unit coverage for wallet, hooks, services, and utils

### DIFF
--- a/dsm_client/frontend/src/components/screens/wallet/__tests__/helpers.test.ts
+++ b/dsm_client/frontend/src/components/screens/wallet/__tests__/helpers.test.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { DomainContact, DomainTransaction } from '../../../../domain/types';
+import {
+  buildAliasLookup,
+  b32,
+  resolveAlias,
+  shortStr,
+  txTypeDetail,
+  txTypeLabel,
+  txTypeNumber,
+} from '../helpers';
+
+describe('wallet helpers', () => {
+  describe('txTypeLabel / txTypeDetail', () => {
+    it('maps known numeric types', () => {
+      expect(txTypeLabel(1)).toBe('FAUCET');
+      expect(txTypeLabel(2)).toBe('OFFLINE');
+      expect(txTypeLabel(4)).toBe('ONLINE');
+      expect(txTypeLabel(5)).toBe('dBTC MINT');
+      expect(txTypeDetail(5)).toContain('Deposit');
+    });
+
+    it('returns UNKNOWN for unrecognized codes', () => {
+      expect(txTypeLabel(99)).toBe('UNKNOWN');
+      expect(txTypeDetail(99)).toBe('Unknown');
+    });
+  });
+
+  describe('txTypeNumber', () => {
+    it('maps domain txType strings to proto numbers', () => {
+      const base = {
+        txId: 'x',
+        type: 'online' as const,
+        amount: 0n,
+        recipient: '',
+        status: 'confirmed',
+      };
+      expect(txTypeNumber({ ...base, txType: 'faucet' } as DomainTransaction)).toBe(1);
+      expect(txTypeNumber({ ...base, txType: 'online' } as DomainTransaction)).toBe(4);
+      expect(txTypeNumber({ ...base, txType: 'dbtc_mint' } as DomainTransaction)).toBe(5);
+    });
+  });
+
+  describe('b32', () => {
+    it('passes through non-empty strings', () => {
+      expect(b32('already_b32')).toBe('already_b32');
+    });
+
+    it('encodes Uint8Array', () => {
+      const u = new Uint8Array([0, 1, 2]);
+      expect(b32(u).length).toBeGreaterThan(0);
+    });
+
+    it('returns empty for empty input', () => {
+      expect(b32(new Uint8Array(0))).toBe('');
+    });
+  });
+
+  describe('shortStr', () => {
+    it('returns short strings unchanged', () => {
+      expect(shortStr('abc')).toBe('abc');
+    });
+
+    it('truncates long strings with ellipsis', () => {
+      const s = 'a'.repeat(40);
+      expect(shortStr(s, 4, 4)).toBe('aaaa...aaaa');
+    });
+  });
+
+  describe('resolveAlias / buildAliasLookup', () => {
+    it('resolves alias from map', () => {
+      const m = new Map([['dev1', 'Alice']]);
+      expect(resolveAlias('dev1', m)).toBe('Alice');
+    });
+
+    it('falls back to shortened id', () => {
+      const longId = 'B'.repeat(30);
+      const r = resolveAlias(longId, new Map());
+      expect(r).toContain('...');
+    });
+
+    it('buildAliasLookup collects deviceId → alias', () => {
+      const contacts: DomainContact[] = [
+        {
+          alias: 'Bob',
+          deviceId: 'd1',
+          genesisHash: 'g',
+          chainTip: '',
+        } as DomainContact,
+      ];
+      const map = buildAliasLookup(contacts);
+      expect(map.get('d1')).toBe('Bob');
+    });
+  });
+});

--- a/dsm_client/frontend/src/contexts/contacts/__tests__/utils.test.ts
+++ b/dsm_client/frontend/src/contexts/contacts/__tests__/utils.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+import { toBase32Crockford } from '../../../dsm/decoding';
+import { bytesToDisplay, parseBinary32, parseBinary64 } from '../utils';
+
+describe('contacts utils', () => {
+  const bytes32 = new Uint8Array(32);
+  for (let i = 0; i < 32; i += 1) bytes32[i] = i;
+
+  describe('parseBinary32', () => {
+    it('accepts Uint8Array of length 32', () => {
+      expect(parseBinary32(bytes32, 'id')).toBe(bytes32);
+    });
+
+    it('rejects Uint8Array with wrong length', () => {
+      expect(() => parseBinary32(new Uint8Array(31), 'id')).toThrow(/must be 32 bytes/);
+    });
+
+    it('parses base32 string of 32 bytes', () => {
+      const b32 = toBase32Crockford(bytes32);
+      const out = parseBinary32(b32, 'id');
+      expect(out).toEqual(bytes32);
+    });
+
+    it('rejects empty string', () => {
+      expect(() => parseBinary32('', 'label')).toThrow(/empty/);
+    });
+  });
+
+  describe('parseBinary64', () => {
+    const b64 = new Uint8Array(64);
+    b64[0] = 0xff;
+    b64[63] = 0x01;
+
+    it('accepts Uint8Array of length 64', () => {
+      expect(parseBinary64(b64, 'h')).toBe(b64);
+    });
+
+    it('rejects wrong Uint8Array length', () => {
+      expect(() => parseBinary64(new Uint8Array(63), 'h')).toThrow(/must be 64 bytes/);
+    });
+
+    it('parses base32 string of 64 bytes', () => {
+      const s = toBase32Crockford(b64);
+      expect(parseBinary64(s, 'h')).toEqual(b64);
+    });
+  });
+
+  describe('bytesToDisplay', () => {
+    it('returns crockford base32 for Uint8Array', () => {
+      expect(bytesToDisplay(bytes32)).toBe(toBase32Crockford(bytes32));
+    });
+
+    it('returns empty string for non-Uint8Array', () => {
+      expect(bytesToDisplay(null as unknown as Uint8Array)).toBe('');
+    });
+  });
+});

--- a/dsm_client/frontend/src/domain/__tests__/mappers.test.ts
+++ b/dsm_client/frontend/src/domain/__tests__/mappers.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  mapBalanceList,
+  mapIdentity,
+  mapTransactions,
+  normalizeBleAddress,
+  toBigint,
+} from '../mappers';
+
+describe('domain mappers', () => {
+  describe('toBigint', () => {
+    it('passes through bigint', () => {
+      expect(toBigint(7n)).toBe(7n);
+    });
+
+    it('truncates numbers', () => {
+      expect(toBigint(3.9)).toBe(3n);
+    });
+
+    it('parses decimal strings', () => {
+      expect(toBigint('  42  ')).toBe(42n);
+    });
+
+    it('returns 0n for empty or invalid', () => {
+      expect(toBigint('')).toBe(0n);
+      expect(toBigint(undefined)).toBe(0n);
+    });
+  });
+
+  describe('normalizeBleAddress', () => {
+    it('uppercases colon-separated MAC', () => {
+      expect(normalizeBleAddress('aa:bb:cc:dd:ee:ff')).toBe('AA:BB:CC:DD:EE:FF');
+    });
+
+    it('formats 12 hex chars without colons', () => {
+      expect(normalizeBleAddress('aabbccddeeff')).toBe('AA:BB:CC:DD:EE:FF');
+    });
+
+    it('returns undefined for invalid input', () => {
+      expect(normalizeBleAddress('')).toBeUndefined();
+      expect(normalizeBleAddress('not-mac')).toBeUndefined();
+      expect(normalizeBleAddress(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('mapIdentity', () => {
+    it('maps camelCase protobuf fields', () => {
+      const id = {
+        genesisHash: new Uint8Array(32).fill(1),
+        deviceId: new Uint8Array(32).fill(2),
+      };
+      const out = mapIdentity(id);
+      expect(out).not.toBeNull();
+      expect(out!.genesisHash.length).toBeGreaterThan(0);
+      expect(out!.deviceId.length).toBeGreaterThan(0);
+    });
+
+    it('returns null when required fields missing', () => {
+      expect(mapIdentity({ genesisHash: '', deviceId: '' })).toBeNull();
+    });
+  });
+
+  describe('mapBalanceList', () => {
+    it('rewrites spaced tokenId to ERA', () => {
+      const out = mapBalanceList([
+        { tokenId: 'bad id', symbol: 'X', balance: 1n, decimals: 0, tokenName: 'T' },
+      ]);
+      expect(out[0].tokenId).toBe('ERA');
+    });
+  });
+
+  describe('mapTransactions', () => {
+    it('maps numeric txType to domain string', () => {
+      const out = mapTransactions([
+        {
+          txType: 4,
+          txId: 'id',
+          toDeviceId: new Uint8Array(32),
+          amount: 100n,
+        },
+      ]);
+      expect(out[0].txType).toBe('online');
+      expect(out[0].type).toBe('online');
+    });
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/contacts.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/contacts.test.ts
@@ -1,0 +1,273 @@
+jest.mock('../WebViewBridge', () => ({
+  getContactsStrictBridge: jest.fn(),
+  normalizeToBytes: jest.fn((data: unknown) => {
+    if (data instanceof Uint8Array) return data;
+    if (data instanceof ArrayBuffer) return new Uint8Array(data);
+    if (Array.isArray(data)) return new Uint8Array(data);
+    throw new Error('normalizeToBytes: expected Uint8Array or number[]');
+  }),
+  appRouterInvokeBin: jest.fn(),
+  requestBlePermissions: jest.fn(),
+}));
+
+import * as pb from '../../proto/dsm_app_pb';
+import { getContacts, addContact, requestBlePermissions } from '../contacts';
+import {
+  getContactsStrictBridge,
+  appRouterInvokeBin,
+  requestBlePermissions as bridgeRequestBlePermissions,
+} from '../WebViewBridge';
+
+function frameEnvelope(envelope: pb.Envelope): Uint8Array {
+  const bytes = envelope.toBinary();
+  const framed = new Uint8Array(1 + bytes.length);
+  framed[0] = 0x03;
+  framed.set(bytes, 1);
+  return framed;
+}
+
+describe('contacts.ts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── getContacts ────────────────────────────────────────────────────
+
+  describe('getContacts', () => {
+    test('maps contacts from ContactsListResponse', async () => {
+      const deviceId = new Uint8Array(32).fill(0x01);
+      const signingPk = new Uint8Array(64).fill(0x02);
+      const gh = new Uint8Array(32).fill(0x03);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'contactsListResponse',
+          value: new pb.ContactsListResponse({
+            contacts: [
+              new pb.ContactAddResponse({
+                deviceId: deviceId as any,
+                alias: 'Alice',
+                signingPublicKey: signingPk as any,
+                genesisHash: { v: gh } as any,
+                verifyCounter: 5n,
+                bleAddress: 'AA:BB:CC:DD:EE:FF',
+                genesisVerifiedOnline: true,
+                addedCounter: 10n,
+              }),
+            ],
+          }),
+        },
+      });
+      (getContactsStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getContacts();
+      expect(result.total).toBe(1);
+      expect(result.contacts).toHaveLength(1);
+      expect(result.contacts[0].alias).toBe('Alice');
+      expect(result.contacts[0].deviceId).toEqual(deviceId);
+      expect(result.contacts[0].publicKey).toEqual(signingPk);
+      expect(result.contacts[0].lastSeenTick).toBe(5n);
+      expect(result.contacts[0].bleAddress).toBe('AA:BB:CC:DD:EE:FF');
+      expect(result.contacts[0].genesisVerifiedOnline).toBe(true);
+      expect(result.contacts[0].addedCounter).toBe(10n);
+    });
+
+    test('returns empty contacts list', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'contactsListResponse',
+          value: new pb.ContactsListResponse({ contacts: [] }),
+        },
+      });
+      (getContactsStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getContacts();
+      expect(result.total).toBe(0);
+      expect(result.contacts).toEqual([]);
+    });
+
+    test('handles contact with missing optional fields', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'contactsListResponse',
+          value: new pb.ContactsListResponse({
+            contacts: [new pb.ContactAddResponse({})],
+          }),
+        },
+      });
+      (getContactsStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getContacts();
+      expect(result.contacts[0].alias).toBe('');
+      expect(result.contacts[0].deviceId).toEqual(new Uint8Array());
+      expect(result.contacts[0].publicKey).toEqual(new Uint8Array());
+    });
+
+    test('throws on empty response bytes', async () => {
+      (getContactsStrictBridge as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      await expect(getContacts()).rejects.toThrow(/empty response/);
+    });
+
+    test('throws on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ code: 7, message: 'contacts denied' }) },
+      });
+      (getContactsStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getContacts()).rejects.toThrow(/DSM native error.*contacts denied/);
+    });
+
+    test('throws on unexpected payload case', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'balancesListResponse', value: new pb.BalancesListResponse() },
+      });
+      (getContactsStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getContacts()).rejects.toThrow(/Unexpected payload case for contacts/);
+    });
+
+    test('returns empty contacts when payload serializes as empty message', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'contactsListResponse', value: undefined as any },
+      });
+      (getContactsStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getContacts();
+      expect(result.contacts).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    test('maps chainTip when present in nested v format', async () => {
+      const tipHash = new Uint8Array(32).fill(0xAA);
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'contactsListResponse',
+          value: new pb.ContactsListResponse({
+            contacts: [
+              new pb.ContactAddResponse({
+                alias: 'Bob',
+                chainTip: { v: tipHash } as any,
+              }),
+            ],
+          }),
+        },
+      });
+      (getContactsStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getContacts();
+      expect(result.contacts[0].chainTip).toBeDefined();
+      expect(result.contacts[0].chainTip?.tipHash).toEqual(tipHash);
+    });
+  });
+
+  // ── addContact ─────────────────────────────────────────────────────
+
+  describe('addContact', () => {
+    test('throws when alias is missing', async () => {
+      await expect(addContact({
+        alias: '',
+        deviceId: new Uint8Array(32),
+        genesisHash: new Uint8Array(32),
+        signingPublicKey: new Uint8Array(64),
+      })).rejects.toThrow(/alias required/);
+    });
+
+    test('throws when genesisHash is not 32 bytes', async () => {
+      await expect(addContact({
+        alias: 'Test',
+        deviceId: new Uint8Array(32),
+        genesisHash: new Uint8Array(16),
+        signingPublicKey: new Uint8Array(64),
+      })).rejects.toThrow(/genesisHash must be 32 bytes/);
+    });
+
+    test('throws when signingPublicKey is not 64 bytes', async () => {
+      await expect(addContact({
+        alias: 'Test',
+        deviceId: new Uint8Array(32),
+        genesisHash: new Uint8Array(32),
+        signingPublicKey: new Uint8Array(32),
+      })).rejects.toThrow(/signingPublicKey must be 64 bytes/);
+    });
+
+    test('returns accepted on success', async () => {
+      const deviceId = new Uint8Array(32).fill(1);
+      const genesisHash = new Uint8Array(32).fill(2);
+      const signingPublicKey = new Uint8Array(64).fill(3);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'contactAddResponse',
+          value: new pb.ContactAddResponse({ alias: 'TestContact', deviceId: deviceId as any }),
+        },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await addContact({ alias: 'TestContact', deviceId, genesisHash, signingPublicKey });
+      expect(result.accepted).toBe(true);
+    });
+
+    test('returns not accepted when response has empty alias', async () => {
+      const deviceId = new Uint8Array(32).fill(1);
+      const genesisHash = new Uint8Array(32).fill(2);
+      const signingPublicKey = new Uint8Array(64).fill(3);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'contactAddResponse',
+          value: new pb.ContactAddResponse({ alias: '' }),
+        },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await addContact({ alias: 'Test', deviceId, genesisHash, signingPublicKey });
+      expect(result.accepted).toBe(false);
+      expect(result.error).toBe('Empty response or failure');
+    });
+
+    test('returns error on error envelope', async () => {
+      const deviceId = new Uint8Array(32).fill(1);
+      const genesisHash = new Uint8Array(32).fill(2);
+      const signingPublicKey = new Uint8Array(64).fill(3);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ code: 9, message: 'duplicate' }) },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await addContact({ alias: 'Test', deviceId, genesisHash, signingPublicKey });
+      expect(result.accepted).toBe(false);
+      expect(result.error).toMatch(/duplicate/);
+    });
+
+    test('returns error when bridge throws', async () => {
+      const deviceId = new Uint8Array(32).fill(1);
+      const genesisHash = new Uint8Array(32).fill(2);
+      const signingPublicKey = new Uint8Array(64).fill(3);
+
+      (appRouterInvokeBin as jest.Mock).mockRejectedValue(new Error('bridge fail'));
+
+      const result = await addContact({ alias: 'Test', deviceId, genesisHash, signingPublicKey });
+      expect(result.accepted).toBe(false);
+      expect(result.error).toBe('bridge fail');
+    });
+  });
+
+  // ── requestBlePermissions ──────────────────────────────────────────
+
+  describe('requestBlePermissions', () => {
+    test('delegates to bridge', async () => {
+      (bridgeRequestBlePermissions as jest.Mock).mockResolvedValue(undefined);
+      await requestBlePermissions();
+      expect(bridgeRequestBlePermissions).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/dbrw.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/dbrw.test.ts
@@ -1,0 +1,180 @@
+jest.mock('../WebViewBridge', () => ({
+  appRouterQueryBin: jest.fn(),
+}));
+
+import * as pb from '../../proto/dsm_app_pb';
+import { getDbrwStatus } from '../dbrw';
+import { appRouterQueryBin } from '../WebViewBridge';
+
+function frameEnvelope(envelope: pb.Envelope): Uint8Array {
+  const bytes = envelope.toBinary();
+  const framed = new Uint8Array(1 + bytes.length);
+  framed[0] = 0x03;
+  framed.set(bytes, 1);
+  return framed;
+}
+
+function makeDbrwStatusResponse(overrides: Record<string, unknown> = {}): pb.DbrwStatusResponse {
+  return new pb.DbrwStatusResponse({
+    enrolled: true,
+    bindingKeyPresent: true,
+    verifierKeypairPresent: true,
+    storageBaseDirSet: true,
+    observeOnly: false,
+    accessMode: 'full',
+    enrollmentRevision: 3,
+    arenaBytes: 4096,
+    probes: 9,
+    stepsPerProbe: 512,
+    histogramBins: 64,
+    rotationBits: 16,
+    epsilonIntra: 0.05,
+    meanHistogramLen: 42,
+    referenceAnchorPrefix: new Uint8Array(8).fill(0xAA),
+    bindingKeyPrefix: new Uint8Array(8).fill(0xBB),
+    verifierPublicKeyPrefix: new Uint8Array(8).fill(0xCC),
+    verifierPublicKeyLen: 1952,
+    storageBaseDir: '/data/dbrw',
+    statusNote: 'healthy',
+    runtimeMetricsPresent: true,
+    runtimeAccessLevel: 'full',
+    runtimeTrustScore: 0.95,
+    runtimeHealthCheckRan: true,
+    runtimeHealthCheckPassed: true,
+    runtimeHHat: 0.98,
+    runtimeRhoHat: 0.02,
+    runtimeLHat: 4.5,
+    runtimeMatchScore: 0.99,
+    runtimeW1Distance: 0.01,
+    runtimeW1Threshold: 0.05,
+    runtimeAnchorPrefix: new Uint8Array(8).fill(0xDD),
+    runtimeError: '',
+    runtimeH0Eff: 0.96,
+    runtimeRecommendedN: 1024,
+    runtimeResonantStatus: 'PASS',
+    ...overrides,
+  } as any);
+}
+
+describe('dbrw.ts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('getDbrwStatus', () => {
+    test('maps all DbrwStatusResponse fields', async () => {
+      const resp = makeDbrwStatusResponse();
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'dbrwStatusResponse', value: resp },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const status = await getDbrwStatus();
+      expect(status.enrolled).toBe(true);
+      expect(status.bindingKeyPresent).toBe(true);
+      expect(status.verifierKeypairPresent).toBe(true);
+      expect(status.storageBaseDirSet).toBe(true);
+      expect(status.observeOnly).toBe(false);
+      expect(status.accessMode).toBe('full');
+      expect(status.enrollmentRevision).toBe(3);
+      expect(status.arenaBytes).toBe(4096);
+      expect(status.probes).toBe(9);
+      expect(status.stepsPerProbe).toBe(512);
+      expect(status.histogramBins).toBe(64);
+      expect(status.rotationBits).toBe(16);
+      expect(status.verifierPublicKeyLen).toBe(1952);
+      expect(status.storageBaseDir).toBe('/data/dbrw');
+      expect(status.statusNote).toBe('healthy');
+      expect(status.runtimeMetricsPresent).toBe(true);
+      expect(status.runtimeResonantStatus).toBe('PASS');
+      expect(status.runtimeError).toBe('');
+    });
+
+    test('passes "live" params when live=true', async () => {
+      const resp = makeDbrwStatusResponse();
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'dbrwStatusResponse', value: resp },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await getDbrwStatus(true);
+      const [route, params] = (appRouterQueryBin as jest.Mock).mock.calls[0];
+      expect(route).toBe('dbrw.status');
+      expect(new TextDecoder().decode(params)).toBe('live');
+    });
+
+    test('passes empty params when live=false', async () => {
+      const resp = makeDbrwStatusResponse();
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'dbrwStatusResponse', value: resp },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await getDbrwStatus(false);
+      const [, params] = (appRouterQueryBin as jest.Mock).mock.calls[0];
+      expect(params.length).toBe(0);
+    });
+
+    test('throws on empty response', async () => {
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      await expect(getDbrwStatus()).rejects.toThrow(/empty response/);
+    });
+
+    test('throws on null response', async () => {
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(null);
+      await expect(getDbrwStatus()).rejects.toThrow(/empty response/);
+    });
+
+    test('throws on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ message: 'dbrw not enrolled' }) },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getDbrwStatus()).rejects.toThrow(/dbrw not enrolled/);
+    });
+
+    test('throws on unexpected payload case', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'balancesListResponse', value: new pb.BalancesListResponse() },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getDbrwStatus()).rejects.toThrow(/unexpected payload/);
+    });
+
+    test('returns default values when dbrwStatusResponse payload has no fields', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'dbrwStatusResponse', value: new pb.DbrwStatusResponse() },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const status = await getDbrwStatus();
+      expect(status.enrolled).toBe(false);
+      expect(status.accessMode).toBe('');
+      expect(status.arenaBytes).toBe(0);
+    });
+
+    test('maps unenrolled status correctly', async () => {
+      const resp = makeDbrwStatusResponse({
+        enrolled: false,
+        runtimeMetricsPresent: false,
+        runtimeResonantStatus: 'FAIL',
+      });
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'dbrwStatusResponse', value: resp },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const status = await getDbrwStatus();
+      expect(status.enrolled).toBe(false);
+      expect(status.runtimeMetricsPresent).toBe(false);
+      expect(status.runtimeResonantStatus).toBe('FAIL');
+    });
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/detfi.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/detfi.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+import { encodeBase32Crockford } from '../../utils/textId';
+
+jest.mock('../WebViewBridge', () => ({
+  appRouterInvokeBin: jest.fn(),
+}));
+jest.mock('../decoding', () => ({
+  decodeFramedEnvelopeV3: jest.fn(),
+}));
+
+import { parseDeTFiHeader } from '../detfi';
+
+function makeBlob(bytes: number[]): string {
+  return encodeBase32Crockford(new Uint8Array(bytes));
+}
+
+describe('parseDeTFiHeader', () => {
+  it('parses a valid vault/local header (version=1, mode=0, type=0)', () => {
+    const blob = makeBlob([1, 0, 0, 0xff, 0xff]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(true);
+    expect(result.header).toEqual({
+      version: 1,
+      mode: 'local',
+      type: 'vault',
+      sizeBytes: 5,
+    });
+  });
+
+  it('parses a valid policy/posted header (version=1, mode=1, type=1)', () => {
+    const blob = makeBlob([1, 1, 1, 0xaa]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(true);
+    expect(result.header).toEqual({
+      version: 1,
+      mode: 'posted',
+      type: 'policy',
+      sizeBytes: 4,
+    });
+  });
+
+  it('parses vault/posted (version=1, mode=1, type=0)', () => {
+    const blob = makeBlob([1, 1, 0]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(true);
+    expect(result.header).toEqual({
+      version: 1,
+      mode: 'posted',
+      type: 'vault',
+      sizeBytes: 3,
+    });
+  });
+
+  it('parses policy/local (version=1, mode=0, type=1)', () => {
+    const blob = makeBlob([1, 0, 1]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(true);
+    expect(result.header).toEqual({
+      version: 1,
+      mode: 'local',
+      type: 'policy',
+      sizeBytes: 3,
+    });
+  });
+
+  it('returns error for empty string', () => {
+    const result = parseDeTFiHeader('');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('blob is empty');
+  });
+
+  it('returns error for whitespace-only string', () => {
+    const result = parseDeTFiHeader('   \t\n  ');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('blob is empty');
+  });
+
+  it('returns error for blob shorter than 3 header bytes', () => {
+    const blob = makeBlob([1, 0]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/too short/);
+  });
+
+  it('returns error for unsupported version', () => {
+    const blob = makeBlob([2, 0, 0]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/unsupported version: 2/);
+  });
+
+  it('returns error for version 0', () => {
+    const blob = makeBlob([0, 0, 0]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/unsupported version: 0/);
+  });
+
+  it('returns error for invalid mode (2)', () => {
+    const blob = makeBlob([1, 2, 0]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid mode: 2/);
+  });
+
+  it('returns error for invalid type (2)', () => {
+    const blob = makeBlob([1, 0, 2]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid type: 2/);
+  });
+
+  it('handles non-string input gracefully', () => {
+    const result = parseDeTFiHeader(undefined as unknown as string);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('blob is empty');
+  });
+
+  it('handles null input gracefully', () => {
+    const result = parseDeTFiHeader(null as unknown as string);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('blob is empty');
+  });
+
+  it('trims leading/trailing whitespace before decoding', () => {
+    const blob = makeBlob([1, 0, 0, 0x42]);
+    const result = parseDeTFiHeader(`  ${blob}  `);
+    expect(result.success).toBe(true);
+    expect(result.header?.version).toBe(1);
+    expect(result.header?.mode).toBe('local');
+    expect(result.header?.type).toBe('vault');
+  });
+
+  it('reports sizeBytes matching the full decoded length', () => {
+    const payload = new Array(100).fill(0xab);
+    const blob = makeBlob([1, 1, 0, ...payload]);
+    const result = parseDeTFiHeader(blob);
+    expect(result.success).toBe(true);
+    expect(result.header!.sizeBytes).toBe(103);
+  });
+
+  it('returns error for invalid base32 characters', () => {
+    const result = parseDeTFiHeader('!!!INVALID!!!');
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/dlv.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/dlv.test.ts
@@ -1,0 +1,172 @@
+jest.mock('../WebViewBridge', () => ({
+  appRouterInvokeBin: jest.fn(),
+}));
+
+import * as pb from '../../proto/dsm_app_pb';
+import { createCustomDlv } from '../dlv';
+import { appRouterInvokeBin } from '../WebViewBridge';
+import { encodeBase32Crockford } from '../../utils/textId';
+
+function frameEnvelope(envelope: pb.Envelope): Uint8Array {
+  const bytes = envelope.toBinary();
+  const framed = new Uint8Array(1 + bytes.length);
+  framed[0] = 0x03;
+  framed.set(bytes, 1);
+  return framed;
+}
+
+function makeValidDlvCreate(): pb.DlvCreateV3 {
+  return new pb.DlvCreateV3({
+    deviceId: new Uint8Array(32).fill(0x01) as any,
+    policyDigest: new Uint8Array(32).fill(0x02) as any,
+    precommit: new Uint8Array(32).fill(0x03) as any,
+    vaultId: new Uint8Array(32).fill(0x04) as any,
+  });
+}
+
+function encodeDlvToBase32(dlv: pb.DlvCreateV3): string {
+  return encodeBase32Crockford(new Uint8Array(dlv.toBinary()));
+}
+
+describe('dlv.ts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('createCustomDlv', () => {
+    test('returns success with vault id on appStateResponse', async () => {
+      const dlv = makeValidDlvCreate();
+      const lockB32 = encodeDlvToBase32(dlv);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'appStateResponse',
+          value: new pb.AppStateResponse({ value: 'VAULT_ID_B32' }),
+        },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await createCustomDlv({ lock: lockB32 });
+      expect(result.success).toBe(true);
+      expect(result.id).toBe('VAULT_ID_B32');
+    });
+
+    test('uses empty string as id when appStateResponse.value is empty', async () => {
+      const dlv = makeValidDlvCreate();
+      const lockB32 = encodeDlvToBase32(dlv);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'appStateResponse',
+          value: new pb.AppStateResponse({ value: '' }),
+        },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await createCustomDlv({ lock: lockB32 });
+      expect(result.success).toBe(true);
+      // `??` doesn't trigger on empty string — returns '' directly
+      expect(result.id).toBe('');
+    });
+
+    test('falls back to vaultId encoding when appStateResponse.value is nullish', async () => {
+      const dlv = makeValidDlvCreate();
+      const lockB32 = encodeDlvToBase32(dlv);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'appStateResponse',
+          value: new pb.AppStateResponse({}),
+        },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await createCustomDlv({ lock: lockB32 });
+      expect(result.success).toBe(true);
+      expect(typeof result.id).toBe('string');
+      expect(result.id!.length).toBeGreaterThan(0);
+    });
+
+    test('returns error for empty lock string', async () => {
+      const result = await createCustomDlv({ lock: '' });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/lock.*required/i);
+    });
+
+    test('returns error for whitespace-only lock', async () => {
+      const result = await createCustomDlv({ lock: '   ' });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/lock.*required/i);
+    });
+
+    test('returns error on error envelope', async () => {
+      const dlv = makeValidDlvCreate();
+      const lockB32 = encodeDlvToBase32(dlv);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ message: 'vault limit reached' }) },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await createCustomDlv({ lock: lockB32 });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/vault limit reached/);
+    });
+
+    test('returns error on unexpected payload case', async () => {
+      const dlv = makeValidDlvCreate();
+      const lockB32 = encodeDlvToBase32(dlv);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'balancesListResponse', value: new pb.BalancesListResponse() },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await createCustomDlv({ lock: lockB32 });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Unexpected response payload/);
+    });
+
+    test('returns error when DlvCreateV3 has invalid deviceId length', async () => {
+      const dlv = new pb.DlvCreateV3({
+        deviceId: new Uint8Array(16).fill(0x01) as any,
+        policyDigest: new Uint8Array(32).fill(0x02) as any,
+        precommit: new Uint8Array(32).fill(0x03) as any,
+        vaultId: new Uint8Array(32).fill(0x04) as any,
+      });
+      const lockB32 = encodeDlvToBase32(dlv);
+
+      const result = await createCustomDlv({ lock: lockB32 });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/device_id must be 32 bytes/);
+    });
+
+    test('returns error when DlvCreateV3 has invalid policyDigest', async () => {
+      const dlv = new pb.DlvCreateV3({
+        deviceId: new Uint8Array(32).fill(0x01) as any,
+        policyDigest: new Uint8Array(16).fill(0x02) as any,
+        precommit: new Uint8Array(32).fill(0x03) as any,
+        vaultId: new Uint8Array(32).fill(0x04) as any,
+      });
+      const lockB32 = encodeDlvToBase32(dlv);
+
+      const result = await createCustomDlv({ lock: lockB32 });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/policy_digest must be 32 bytes/);
+    });
+
+    test('returns error when bridge throws', async () => {
+      const dlv = makeValidDlvCreate();
+      const lockB32 = encodeDlvToBase32(dlv);
+
+      (appRouterInvokeBin as jest.Mock).mockRejectedValue(new Error('network fail'));
+
+      const result = await createCustomDlv({ lock: lockB32 });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/network fail/);
+    });
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/events.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/events.test.ts
@@ -1,0 +1,91 @@
+jest.mock('../../bridge/bridgeEvents', () => {
+  const handlers = new Map<string, Set<(payload: any) => void>>();
+  return {
+    bridgeEvents: {
+      emit: jest.fn((event: string, payload: any) => {
+        const set = handlers.get(event);
+        if (set) {
+          for (const handler of Array.from(set)) {
+            handler(payload);
+          }
+        }
+      }),
+      on: jest.fn((event: string, handler: (payload: any) => void) => {
+        const set = handlers.get(event) ?? new Set();
+        set.add(handler);
+        handlers.set(event, set);
+        return () => set.delete(handler);
+      }),
+    },
+  };
+});
+
+import { emitWalletRefresh, emitBilateralCommitted, DSM_WALLET_REFRESH_EVENT } from '../events';
+import { bridgeEvents } from '../../bridge/bridgeEvents';
+
+describe('events.ts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('DSM_WALLET_REFRESH_EVENT', () => {
+    test('has the canonical event name', () => {
+      expect(DSM_WALLET_REFRESH_EVENT).toBe('dsm-wallet-refresh');
+    });
+  });
+
+  describe('emitWalletRefresh', () => {
+    test('emits wallet.refresh event with detail', () => {
+      const detail = { source: 'storage.sync' };
+      emitWalletRefresh(detail);
+      expect(bridgeEvents.emit).toHaveBeenCalledWith('wallet.refresh', detail);
+    });
+
+    test('passes extra fields through', () => {
+      const detail = { source: 'wallet.send', transactionHash: new Uint8Array(32) };
+      emitWalletRefresh(detail);
+      expect(bridgeEvents.emit).toHaveBeenCalledWith('wallet.refresh', detail);
+    });
+  });
+
+  describe('emitBilateralCommitted', () => {
+    test('emits wallet.bilateralCommitted with detail', () => {
+      const detail = {
+        commitmentHash: new Uint8Array(32).fill(0xAA),
+        counterpartyDeviceId: new Uint8Array(32).fill(0xBB),
+        accepted: true,
+        committed: true,
+        rejected: false,
+      };
+      emitBilateralCommitted(detail);
+      expect(bridgeEvents.emit).toHaveBeenCalledWith('wallet.bilateralCommitted', detail);
+    });
+
+    test('emits empty object when no detail provided', () => {
+      emitBilateralCommitted();
+      expect(bridgeEvents.emit).toHaveBeenCalledWith('wallet.bilateralCommitted', {});
+    });
+
+    test('emits empty object when undefined is passed', () => {
+      emitBilateralCommitted(undefined);
+      expect(bridgeEvents.emit).toHaveBeenCalledWith('wallet.bilateralCommitted', {});
+    });
+  });
+
+  describe('event integration with bridgeEvents listeners', () => {
+    test('wallet.refresh event is received by listeners', () => {
+      const listener = jest.fn();
+      bridgeEvents.on('wallet.refresh', listener);
+
+      emitWalletRefresh({ source: 'test' });
+      expect(listener).toHaveBeenCalledWith({ source: 'test' });
+    });
+
+    test('wallet.bilateralCommitted event is received by listeners', () => {
+      const listener = jest.fn();
+      bridgeEvents.on('wallet.bilateralCommitted', listener);
+
+      const detail = { accepted: true, committed: true };
+      emitBilateralCommitted(detail);
+      expect(listener).toHaveBeenCalledWith(detail);
+    });
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/identity.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/identity.test.ts
@@ -1,0 +1,218 @@
+jest.mock('../WebViewBridge', () => ({
+  queryTransportHeadersV3: jest.fn(),
+  getDeviceIdBinBridgeAsync: jest.fn(),
+  getPreference: jest.fn(),
+  setPreference: jest.fn(),
+}));
+
+jest.mock('../../runtime/nativeSessionStore', () => ({
+  nativeSessionStore: {
+    getSnapshot: jest.fn(() => ({
+      hardware_status: { ble: { enabled: false, advertising: false, scanning: false } },
+    })),
+  },
+}));
+
+import * as pb from '../../proto/dsm_app_pb';
+import {
+  getHeaders,
+  getIdentity,
+  getDeviceIdentity,
+  getBluetoothStatus,
+  isReady,
+  getPreference,
+  setPreference,
+} from '../identity';
+import {
+  queryTransportHeadersV3,
+  getDeviceIdBinBridgeAsync,
+  getPreference as getPreferenceBridge,
+  setPreference as setPreferenceBridge,
+} from '../WebViewBridge';
+import { nativeSessionStore } from '../../runtime/nativeSessionStore';
+import { encodeBase32Crockford } from '../../utils/textId';
+
+function makeValidDeviceId(): Uint8Array {
+  const id = new Uint8Array(32);
+  id.fill(0xAB);
+  return id;
+}
+
+function makeValidGenesisHash(): Uint8Array {
+  const gh = new Uint8Array(32);
+  gh.fill(0xCD);
+  return gh;
+}
+
+function makeHeadersBinary(deviceId: Uint8Array, genesisHash: Uint8Array): Uint8Array {
+  const headers = new pb.Headers({ deviceId: deviceId as any, genesisHash: genesisHash as any } as any);
+  return new Uint8Array(headers.toBinary());
+}
+
+describe('identity.ts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const g = globalThis as any;
+    g.__dsmLastGoodHeaders = { deviceId: undefined, genesisHash: undefined };
+  });
+
+  // ── getHeaders ─────────────────────────────────────────────────────
+
+  describe('getHeaders', () => {
+    test('returns Headers when bridge provides valid 32-byte fields', async () => {
+      const deviceId = makeValidDeviceId();
+      const genesisHash = makeValidGenesisHash();
+      (queryTransportHeadersV3 as jest.Mock).mockResolvedValue(makeHeadersBinary(deviceId, genesisHash));
+
+      const headers = await getHeaders();
+      expect(headers.deviceId).toEqual(deviceId);
+      expect(headers.genesisHash).toEqual(genesisHash);
+    });
+
+    test('caches valid headers for subsequent calls', async () => {
+      const deviceId = makeValidDeviceId();
+      const genesisHash = makeValidGenesisHash();
+      (queryTransportHeadersV3 as jest.Mock).mockResolvedValue(makeHeadersBinary(deviceId, genesisHash));
+
+      await getHeaders();
+      const headers2 = await getHeaders();
+      // Second call should use cache, only 1 bridge call total
+      expect(queryTransportHeadersV3).toHaveBeenCalledTimes(1);
+      expect(headers2.deviceId).toEqual(deviceId);
+    });
+
+    test('throws when bridge returns empty bytes', async () => {
+      (queryTransportHeadersV3 as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      await expect(getHeaders()).rejects.toThrow('DSM bridge identity not ready');
+    });
+
+    test('throws when bridge returns all-zero device id', async () => {
+      const deviceId = new Uint8Array(32); // all zeros
+      const genesisHash = makeValidGenesisHash();
+      (queryTransportHeadersV3 as jest.Mock).mockResolvedValue(makeHeadersBinary(deviceId, genesisHash));
+
+      await expect(getHeaders()).rejects.toThrow('DSM bridge identity not ready');
+    });
+
+    test('throws when response is too short (<16 bytes)', async () => {
+      (queryTransportHeadersV3 as jest.Mock).mockResolvedValue(new Uint8Array(8));
+      await expect(getHeaders()).rejects.toThrow('DSM bridge identity not ready');
+    });
+
+    test('throws when bridge rejects', async () => {
+      (queryTransportHeadersV3 as jest.Mock).mockRejectedValue(new Error('bridge not ready'));
+      await expect(getHeaders()).rejects.toThrow('DSM bridge identity not ready');
+    });
+  });
+
+  // ── getIdentity ────────────────────────────────────────────────────
+
+  describe('getIdentity', () => {
+    test('returns identity info on success', async () => {
+      const deviceId = makeValidDeviceId();
+      const genesisHash = makeValidGenesisHash();
+      (queryTransportHeadersV3 as jest.Mock).mockResolvedValue(makeHeadersBinary(deviceId, genesisHash));
+
+      const identity = await getIdentity();
+      expect(identity).not.toBeNull();
+      expect(identity!.deviceId).toBe(encodeBase32Crockford(deviceId));
+      expect(identity!.genesisHash).toBe(encodeBase32Crockford(genesisHash));
+      expect(identity!.isRegistered).toBe(true);
+      expect(identity!.networkId).toBe('dsm-main');
+    });
+
+    test('returns null after all retries fail', async () => {
+      (queryTransportHeadersV3 as jest.Mock).mockResolvedValue(new Uint8Array(0));
+
+      const identity = await getIdentity();
+      expect(identity).toBeNull();
+    }, 30_000);
+
+    test('succeeds on later retry attempt', async () => {
+      const deviceId = makeValidDeviceId();
+      const genesisHash = makeValidGenesisHash();
+      let callCount = 0;
+      (queryTransportHeadersV3 as jest.Mock).mockImplementation(async () => {
+        callCount++;
+        if (callCount < 3) return new Uint8Array(0);
+        return makeHeadersBinary(deviceId, genesisHash);
+      });
+
+      const identity = await getIdentity();
+      expect(identity).not.toBeNull();
+      expect(identity!.deviceId).toBe(encodeBase32Crockford(deviceId));
+    }, 30_000);
+  });
+
+  // ── getDeviceIdentity ──────────────────────────────────────────────
+
+  describe('getDeviceIdentity', () => {
+    test('returns base32-encoded device id', async () => {
+      const deviceId = makeValidDeviceId();
+      (getDeviceIdBinBridgeAsync as jest.Mock).mockResolvedValue(deviceId);
+
+      const result = await getDeviceIdentity();
+      expect(result).toBe(encodeBase32Crockford(deviceId));
+    });
+
+    test('returns null for empty bytes', async () => {
+      (getDeviceIdBinBridgeAsync as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      expect(await getDeviceIdentity()).toBeNull();
+    });
+
+    test('returns null on bridge error', async () => {
+      (getDeviceIdBinBridgeAsync as jest.Mock).mockRejectedValue(new Error('fail'));
+      expect(await getDeviceIdentity()).toBeNull();
+    });
+  });
+
+  // ── getBluetoothStatus ─────────────────────────────────────────────
+
+  describe('getBluetoothStatus', () => {
+    test('reads from native session store', async () => {
+      (nativeSessionStore.getSnapshot as jest.Mock).mockReturnValue({
+        hardware_status: { ble: { enabled: true, advertising: true, scanning: false } },
+      });
+
+      const status = await getBluetoothStatus();
+      expect(status).toEqual({ enabled: true, advertising: true, scanning: false });
+    });
+  });
+
+  // ── isReady ────────────────────────────────────────────────────────
+
+  describe('isReady', () => {
+    test('returns true when device identity exists', async () => {
+      (getDeviceIdBinBridgeAsync as jest.Mock).mockResolvedValue(makeValidDeviceId());
+      expect(await isReady()).toBe(true);
+    });
+
+    test('returns false when device identity is empty', async () => {
+      (getDeviceIdBinBridgeAsync as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      expect(await isReady()).toBe(false);
+    });
+
+    test('returns false on error', async () => {
+      (getDeviceIdBinBridgeAsync as jest.Mock).mockRejectedValue(new Error('nope'));
+      expect(await isReady()).toBe(false);
+    });
+  });
+
+  // ── Preferences ────────────────────────────────────────────────────
+
+  describe('getPreference', () => {
+    test('delegates to bridge', async () => {
+      (getPreferenceBridge as jest.Mock).mockResolvedValue('dark');
+      expect(await getPreference('theme')).toBe('dark');
+      expect(getPreferenceBridge).toHaveBeenCalledWith('theme');
+    });
+  });
+
+  describe('setPreference', () => {
+    test('delegates to bridge', async () => {
+      (setPreferenceBridge as jest.Mock).mockResolvedValue(undefined);
+      await setPreference('theme', 'dark');
+      expect(setPreferenceBridge).toHaveBeenCalledWith('theme', 'dark');
+    });
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/policies.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/policies.test.ts
@@ -1,0 +1,351 @@
+jest.mock('../WebViewBridge', () => ({
+  appRouterInvokeBin: jest.fn(),
+  getTokenPolicyBytes: jest.fn(),
+  listCachedTokenPolicies: jest.fn(),
+  publishTokenPolicyBytes: jest.fn(),
+}));
+
+import * as pb from '../../proto/dsm_app_pb';
+import {
+  createToken,
+  importTokenPolicy,
+  listPolicies,
+  publishTokenPolicyBytes,
+  getTokenPolicyBytes,
+  publishTokenPolicy,
+} from '../policies';
+import {
+  appRouterInvokeBin,
+  getTokenPolicyBytes as getTokenPolicyBytesBridge,
+  listCachedTokenPolicies,
+  publishTokenPolicyBytes as publishTokenPolicyBytesBridge,
+} from '../WebViewBridge';
+import { encodeBase32Crockford } from '../../utils/textId';
+
+function frameEnvelope(envelope: pb.Envelope): Uint8Array {
+  const bytes = envelope.toBinary();
+  const framed = new Uint8Array(1 + bytes.length);
+  framed[0] = 0x03;
+  framed.set(bytes, 1);
+  return framed;
+}
+
+describe('policies.ts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── createToken ────────────────────────────────────────────────────
+
+  describe('createToken', () => {
+    test('validates ticker length constraints', async () => {
+      const result = await createToken({ ticker: 'X', alias: 'test', decimals: 0, maxSupply: '1000' });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/ticker must be 2-8/);
+    });
+
+    test('rejects ticker longer than 8 chars', async () => {
+      const result = await createToken({ ticker: 'TOOLONGXX', alias: 'test', decimals: 0, maxSupply: '1000' });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/ticker must be 2-8/);
+    });
+
+    test('requires alias', async () => {
+      const result = await createToken({ ticker: 'TOK', alias: '', decimals: 0, maxSupply: '1000' });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/alias required/);
+    });
+
+    test('validates decimals range 0..18', async () => {
+      const result = await createToken({ ticker: 'TOK', alias: 'test', decimals: 20, maxSupply: '1000' });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/decimals must be 0\.\.18/);
+    });
+
+    test('validates negative decimals', async () => {
+      const result = await createToken({ ticker: 'TOK', alias: 'test', decimals: -1, maxSupply: '1000' });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/decimals must be 0\.\.18/);
+    });
+
+    test('validates maxSupply is a positive integer string', async () => {
+      const result = await createToken({ ticker: 'TOK', alias: 'test', decimals: 2, maxSupply: 'abc' });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/maxSupply must be a positive integer/);
+    });
+
+    test('successful creation returns token id and anchor', async () => {
+      const anchor = new Uint8Array(32).fill(0xAA);
+      (publishTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(anchor);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'tokenCreateResponse',
+          value: new pb.TokenCreateResponse({
+            success: true,
+            tokenId: 'MY_TOKEN',
+            policyAnchor: anchor as any,
+            message: 'created',
+          }),
+        },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await createToken({
+        ticker: 'MTK',
+        alias: 'My Token',
+        decimals: 8,
+        maxSupply: '1000000',
+      });
+      expect(result.success).toBe(true);
+      expect(result.tokenId).toBe('MY_TOKEN');
+      expect(result.anchorBase32).toBe(encodeBase32Crockford(anchor));
+    });
+
+    test('returns failure on error envelope', async () => {
+      const anchor = new Uint8Array(32).fill(0xBB);
+      (publishTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(anchor);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ message: 'token exists' }) },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await createToken({
+        ticker: 'DUP',
+        alias: 'Duplicate',
+        decimals: 0,
+        maxSupply: '100',
+      });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/token exists/);
+    });
+
+    test('returns failure when publish returns bad anchor', async () => {
+      (publishTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(new Uint8Array(16));
+
+      const result = await createToken({
+        ticker: 'TOK',
+        alias: 'test',
+        decimals: 0,
+        maxSupply: '1000',
+      });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/policy publish failed/);
+    });
+
+    test('handles default kind as FUNGIBLE', async () => {
+      const anchor = new Uint8Array(32).fill(0xCC);
+      (publishTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(anchor);
+
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'tokenCreateResponse',
+          value: new pb.TokenCreateResponse({ success: true, tokenId: 'FT', policyAnchor: anchor as any }),
+        },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await createToken({
+        ticker: 'FT',
+        alias: 'Fungible Token',
+        decimals: 2,
+        maxSupply: '5000',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ── importTokenPolicy ──────────────────────────────────────────────
+
+  describe('importTokenPolicy', () => {
+    test('returns success when policy bytes are found', async () => {
+      const anchor = new Uint8Array(32).fill(0xDD);
+      const b32 = encodeBase32Crockford(anchor);
+      (getTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(new Uint8Array(64));
+
+      const result = await importTokenPolicy(b32);
+      expect(result.success).toBe(true);
+    });
+
+    test('accepts object form with anchorBase32', async () => {
+      const anchor = new Uint8Array(32).fill(0xEE);
+      const b32 = encodeBase32Crockford(anchor);
+      (getTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(new Uint8Array(64));
+
+      const result = await importTokenPolicy({ anchorBase32: b32 });
+      expect(result.success).toBe(true);
+    });
+
+    test('returns error for empty anchor', async () => {
+      const result = await importTokenPolicy('');
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/anchor required/);
+    });
+
+    test('returns error when policy bytes are empty', async () => {
+      const anchor = new Uint8Array(32).fill(0xFF);
+      const b32 = encodeBase32Crockford(anchor);
+      (getTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(new Uint8Array(0));
+
+      const result = await importTokenPolicy(b32);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/empty policy bytes/);
+    });
+  });
+
+  // ── listPolicies ───────────────────────────────────────────────────
+
+  describe('listPolicies', () => {
+    test('maps policies from envelope', async () => {
+      const commit = new Uint8Array(32).fill(0x01);
+      const pBytes = new Uint8Array(16).fill(0x02);
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'tokenPolicyListResponse',
+          value: new pb.TokenPolicyListResponse({
+            policies: [
+              new pb.TokenPolicyCacheEntry({
+                policyCommit: commit as any,
+                policyBytes: pBytes as any,
+                ticker: 'ERA',
+                alias: 'Era Coin',
+                decimals: 8,
+                maxSupply: '1000000',
+              }),
+            ],
+          }),
+        },
+      });
+      (listCachedTokenPolicies as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await listPolicies();
+      expect(result).toHaveLength(1);
+      expect(result[0].policy_commit).toEqual(commit);
+      expect(result[0].policy_bytes).toEqual(pBytes);
+      expect(result[0].metadata).toEqual({
+        ticker: 'ERA',
+        alias: 'Era Coin',
+        decimals: 8,
+        maxSupply: '1000000',
+      });
+    });
+
+    test('returns empty array on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ message: 'nope' }) },
+      });
+      (listCachedTokenPolicies as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      expect(await listPolicies()).toEqual([]);
+    });
+
+    test('returns empty array on bridge error', async () => {
+      (listCachedTokenPolicies as jest.Mock).mockRejectedValue(new Error('fail'));
+      expect(await listPolicies()).toEqual([]);
+    });
+
+    test('metadata is undefined when no metadata fields are present', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'tokenPolicyListResponse',
+          value: new pb.TokenPolicyListResponse({
+            policies: [new pb.TokenPolicyCacheEntry({ policyCommit: new Uint8Array(32) as any, policyBytes: new Uint8Array(8) as any })],
+          }),
+        },
+      });
+      (listCachedTokenPolicies as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await listPolicies();
+      expect(result[0].metadata).toBeUndefined();
+    });
+  });
+
+  // ── publishTokenPolicyBytes ────────────────────────────────────────
+
+  describe('publishTokenPolicyBytes', () => {
+    test('returns anchor bytes and base32 on success', async () => {
+      const anchor = new Uint8Array(32).fill(0x11);
+      (publishTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(anchor);
+
+      const result = await publishTokenPolicyBytes(new Uint8Array(64));
+      expect(result.anchorBytes).toEqual(anchor);
+      expect(result.anchorBase32).toBe(encodeBase32Crockford(anchor));
+    });
+
+    test('throws on empty policy bytes', async () => {
+      await expect(publishTokenPolicyBytes(new Uint8Array(0))).rejects.toThrow(/policyBytes required/);
+    });
+
+    test('throws on null policy bytes', async () => {
+      await expect(publishTokenPolicyBytes(null as any)).rejects.toThrow(/policyBytes required/);
+    });
+  });
+
+  // ── getTokenPolicyBytes ────────────────────────────────────────────
+
+  describe('getTokenPolicyBytes', () => {
+    test('returns bytes from bridge', async () => {
+      const policyBytes = new Uint8Array(64);
+      (getTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(policyBytes);
+
+      const result = await getTokenPolicyBytes(new Uint8Array(32));
+      expect(result).toEqual(policyBytes);
+    });
+
+    test('throws when anchor is not 32 bytes', async () => {
+      await expect(getTokenPolicyBytes(new Uint8Array(16))).rejects.toThrow(/anchorBytes must be 32 bytes/);
+    });
+
+    test('throws when anchor is null', async () => {
+      await expect(getTokenPolicyBytes(null as any)).rejects.toThrow(/anchorBytes must be 32 bytes/);
+    });
+  });
+
+  // ── publishTokenPolicy ─────────────────────────────────────────────
+
+  describe('publishTokenPolicy', () => {
+    test('returns error for empty base32', async () => {
+      const result = await publishTokenPolicy({ policyBase32: '' });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/policy bytes required/);
+    });
+
+    test('returns error for null input', async () => {
+      const result = await publishTokenPolicy(null as any);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/policy bytes required/);
+    });
+
+    test('successful publish returns id', async () => {
+      const policyV3 = new pb.TokenPolicyV3({ policyBytes: new Uint8Array(16) as any });
+      const policyBin = policyV3.toBinary();
+      const { encodeBase32Crockford: enc } = await import('../../utils/textId');
+      const b32 = enc(new Uint8Array(policyBin));
+
+      const anchor = new Uint8Array(32).fill(0x22);
+      (publishTokenPolicyBytesBridge as jest.Mock).mockResolvedValue(anchor);
+
+      const result = await publishTokenPolicy({ policyBase32: b32 });
+      expect(result.success).toBe(true);
+      expect(result.id).toBe(encodeBase32Crockford(anchor));
+    });
+
+    test('returns error when bridge publish fails', async () => {
+      const policyV3 = new pb.TokenPolicyV3({ policyBytes: new Uint8Array(16) as any });
+      const policyBin = policyV3.toBinary();
+      const { encodeBase32Crockford: enc } = await import('../../utils/textId');
+      const b32 = enc(new Uint8Array(policyBin));
+
+      (publishTokenPolicyBytesBridge as jest.Mock).mockRejectedValue(new Error('publish boom'));
+
+      const result = await publishTokenPolicy({ policyBase32: b32 });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/publish boom/);
+    });
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/resolution.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/resolution.test.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+import { encodeBase32Crockford } from '../../utils/textId';
+
+jest.mock('../../bridge/bridgeEvents', () => ({
+  bridgeEvents: { emit: jest.fn(), on: jest.fn(() => jest.fn()) },
+}));
+jest.mock('../WebViewBridge', () => ({
+  resolveBleAddressForDeviceIdBridge: jest.fn(),
+}));
+
+import {
+  normalizeBleAddress,
+  persistBleMapping,
+  clearBleIdentityCache,
+  getBleIdentitySnapshot,
+  pruneBleIdentityMappings,
+} from '../resolution';
+
+describe('normalizeBleAddress', () => {
+  it('returns uppercase colon-separated form for valid colon address', () => {
+    expect(normalizeBleAddress('aa:bb:cc:dd:ee:ff')).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('passes through already-uppercase colon address', () => {
+    expect(normalizeBleAddress('11:22:33:44:55:66')).toBe('11:22:33:44:55:66');
+  });
+
+  it('converts contiguous 12-hex to colon-separated uppercase', () => {
+    expect(normalizeBleAddress('aabbccddeeff')).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('handles uppercase contiguous hex', () => {
+    expect(normalizeBleAddress('AABBCCDDEEFF')).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('handles mixed-case contiguous hex', () => {
+    expect(normalizeBleAddress('aAbBcCdDeEfF')).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(normalizeBleAddress('')).toBeUndefined();
+  });
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(normalizeBleAddress('   ')).toBeUndefined();
+  });
+
+  it('returns undefined for non-string input', () => {
+    expect(normalizeBleAddress(123 as unknown as string)).toBeUndefined();
+  });
+
+  it('returns undefined for too-short hex', () => {
+    expect(normalizeBleAddress('aabbcc')).toBeUndefined();
+  });
+
+  it('returns undefined for too-long hex', () => {
+    expect(normalizeBleAddress('aabbccddeeff00')).toBeUndefined();
+  });
+
+  it('returns undefined for partial colon format', () => {
+    expect(normalizeBleAddress('AA:BB:CC')).toBeUndefined();
+  });
+
+  it('returns undefined for invalid hex characters', () => {
+    expect(normalizeBleAddress('GG:HH:II:JJ:KK:LL')).toBeUndefined();
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(normalizeBleAddress('  aa:bb:cc:dd:ee:ff  ')).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('returns undefined for colon format with wrong byte count', () => {
+    expect(normalizeBleAddress('AA:BB:CC:DD:EE')).toBeUndefined();
+  });
+
+  it('returns undefined for colon format with extra byte', () => {
+    expect(normalizeBleAddress('AA:BB:CC:DD:EE:FF:00')).toBeUndefined();
+  });
+});
+
+describe('BLE identity cache operations', () => {
+  beforeEach(() => {
+    clearBleIdentityCache();
+  });
+
+  it('starts with an empty snapshot', () => {
+    const snap = getBleIdentitySnapshot();
+    expect(snap.deviceIds).toEqual({});
+    expect(snap.genesis).toEqual({});
+  });
+
+  it('persistBleMapping stores deviceId mapping', () => {
+    const devId = new Uint8Array(32).fill(0x01);
+    persistBleMapping({ bleAddress: 'AA:BB:CC:DD:EE:FF', deviceId: devId });
+    const snap = getBleIdentitySnapshot();
+    const key = encodeBase32Crockford(devId);
+    expect(snap.deviceIds[key]).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('persistBleMapping stores genesisHash mapping', () => {
+    const gen = new Uint8Array(32).fill(0x02);
+    persistBleMapping({ bleAddress: 'aabbccddeeff', genesisHash: gen });
+    const snap = getBleIdentitySnapshot();
+    const key = encodeBase32Crockford(gen);
+    expect(snap.genesis[key]).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('persistBleMapping accepts string deviceIdStr', () => {
+    persistBleMapping({ bleAddress: '11:22:33:44:55:66', deviceIdStr: 'MYDEVICE' });
+    const snap = getBleIdentitySnapshot();
+    expect(snap.deviceIds['MYDEVICE']).toBe('11:22:33:44:55:66');
+  });
+
+  it('persistBleMapping ignores invalid bleAddress', () => {
+    const devId = new Uint8Array(32).fill(0x03);
+    persistBleMapping({ bleAddress: 'invalid', deviceId: devId });
+    const snap = getBleIdentitySnapshot();
+    expect(Object.keys(snap.deviceIds).length).toBe(0);
+  });
+
+  it('persistBleMapping ignores empty Uint8Array deviceId', () => {
+    persistBleMapping({ bleAddress: 'AA:BB:CC:DD:EE:FF', deviceId: new Uint8Array(0) });
+    const snap = getBleIdentitySnapshot();
+    expect(Object.keys(snap.deviceIds).length).toBe(0);
+  });
+
+  it('clearBleIdentityCache empties both maps', () => {
+    const devId = new Uint8Array(32).fill(0x04);
+    const gen = new Uint8Array(32).fill(0x05);
+    persistBleMapping({ bleAddress: 'AA:BB:CC:DD:EE:FF', deviceId: devId, genesisHash: gen });
+    expect(Object.keys(getBleIdentitySnapshot().deviceIds).length).toBe(1);
+
+    clearBleIdentityCache();
+    const snap = getBleIdentitySnapshot();
+    expect(snap.deviceIds).toEqual({});
+    expect(snap.genesis).toEqual({});
+  });
+
+  it('pruneBleIdentityMappings removes specified deviceIds', () => {
+    const devA = new Uint8Array(32).fill(0x0a);
+    const devB = new Uint8Array(32).fill(0x0b);
+    persistBleMapping({ bleAddress: 'AA:BB:CC:DD:EE:01', deviceId: devA });
+    persistBleMapping({ bleAddress: 'AA:BB:CC:DD:EE:02', deviceId: devB });
+    expect(Object.keys(getBleIdentitySnapshot().deviceIds).length).toBe(2);
+
+    pruneBleIdentityMappings({ deviceIds: [devA] });
+    const snap = getBleIdentitySnapshot();
+    expect(Object.keys(snap.deviceIds).length).toBe(1);
+    expect(snap.deviceIds[encodeBase32Crockford(devB)]).toBe('AA:BB:CC:DD:EE:02');
+  });
+
+  it('pruneBleIdentityMappings removes specified genesisHashes', () => {
+    const gen = new Uint8Array(32).fill(0x0c);
+    persistBleMapping({ bleAddress: 'AA:BB:CC:DD:EE:FF', genesisHash: gen });
+    expect(Object.keys(getBleIdentitySnapshot().genesis).length).toBe(1);
+
+    pruneBleIdentityMappings({ genesisHashes: [gen] });
+    expect(Object.keys(getBleIdentitySnapshot().genesis).length).toBe(0);
+  });
+
+  it('pruneBleIdentityMappings with empty arrays is a no-op', () => {
+    const devId = new Uint8Array(32).fill(0x0d);
+    persistBleMapping({ bleAddress: 'AA:BB:CC:DD:EE:FF', deviceId: devId });
+    pruneBleIdentityMappings({ deviceIds: [], genesisHashes: [] });
+    expect(Object.keys(getBleIdentitySnapshot().deviceIds).length).toBe(1);
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/storage.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/storage.test.ts
@@ -1,0 +1,436 @@
+jest.mock('../WebViewBridge', () => ({
+  syncWithStorageStrictBridge: jest.fn(),
+  appRouterQueryBin: jest.fn(),
+  appRouterInvokeBin: jest.fn(),
+}));
+
+jest.mock('../events', () => ({
+  emitWalletRefresh: jest.fn(),
+}));
+
+import * as pb from '../../proto/dsm_app_pb';
+import {
+  syncWithStorage,
+  getStorageStatus,
+  getNodeHealth,
+  addStorageNode,
+  removeStorageNode,
+  listLocalDlvs,
+  checkDlvPresence,
+  createBackup,
+} from '../storage';
+import { syncWithStorageStrictBridge, appRouterQueryBin, appRouterInvokeBin } from '../WebViewBridge';
+import { emitWalletRefresh } from '../events';
+
+function frameEnvelope(envelope: pb.Envelope): Uint8Array {
+  const bytes = envelope.toBinary();
+  const framed = new Uint8Array(1 + bytes.length);
+  framed[0] = 0x03;
+  framed.set(bytes, 1);
+  return framed;
+}
+
+describe('storage.ts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── syncWithStorage ────────────────────────────────────────────────
+
+  describe('syncWithStorage', () => {
+    test('returns success with sync stats', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'storageSyncResponse',
+          value: new pb.StorageSyncResponse({
+            success: true,
+            pulled: 3,
+            processed: 2,
+            pushed: 1,
+            errors: [],
+          }),
+        },
+      });
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await syncWithStorage();
+      expect(result.success).toBe(true);
+      expect(result.pulled).toBe(3);
+      expect(result.processed).toBe(2);
+      expect(result.pushed).toBe(1);
+    });
+
+    test('emits wallet refresh when processed > 0', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'storageSyncResponse',
+          value: new pb.StorageSyncResponse({ success: true, processed: 5, errors: [] }),
+        },
+      });
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await syncWithStorage();
+      expect(emitWalletRefresh).toHaveBeenCalledWith({ source: 'storage.sync' });
+    });
+
+    test('does not emit wallet refresh when processed is 0', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'storageSyncResponse',
+          value: new pb.StorageSyncResponse({ success: true, processed: 0, errors: [] }),
+        },
+      });
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await syncWithStorage();
+      expect(emitWalletRefresh).not.toHaveBeenCalled();
+    });
+
+    test('returns failure for empty response bytes', async () => {
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(new Uint8Array(0));
+
+      const result = await syncWithStorage();
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('Empty response from bridge');
+    });
+
+    test('returns failure on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ code: 5, message: 'sync denied' }) },
+      });
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await syncWithStorage();
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/sync denied/);
+    });
+
+    test('returns failure on unexpected payload case', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'balancesListResponse', value: new pb.BalancesListResponse() },
+      });
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await syncWithStorage();
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Unexpected response type/);
+    });
+
+    test('returns failure on decode error', async () => {
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(new Uint8Array([0xFF, 0x01]));
+
+      const result = await syncWithStorage();
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Decode failed/);
+    });
+
+    test('returns failure when bridge throws', async () => {
+      (syncWithStorageStrictBridge as jest.Mock).mockRejectedValue(new Error('network error'));
+
+      const result = await syncWithStorage();
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('network error');
+    });
+
+    test('merges default params', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'storageSyncResponse',
+          value: new pb.StorageSyncResponse({ success: true, errors: [] }),
+        },
+      });
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await syncWithStorage({ pullInbox: false });
+      const call = (syncWithStorageStrictBridge as jest.Mock).mock.calls[0][0];
+      expect(call.pullInbox).toBe(false);
+      expect(call.pushPending).toBe(false);
+      expect(call.limit).toBe(50);
+    });
+
+    test('includes first error in message when errors array is non-empty', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'storageSyncResponse',
+          value: new pb.StorageSyncResponse({ success: true, processed: 0, errors: ['partial fail'] }),
+        },
+      });
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await syncWithStorage();
+      expect(result.message).toBe('partial fail');
+    });
+
+    test('returns failure for null storageSyncResponse', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'storageSyncResponse', value: undefined as any },
+      });
+      (syncWithStorageStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await syncWithStorage();
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ── getStorageStatus ───────────────────────────────────────────────
+
+  describe('getStorageStatus', () => {
+    test('maps StorageStatusResponse fields', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'storageStatusResponse',
+          value: new pb.StorageStatusResponse({
+            connectedNodes: 3,
+            totalNodes: 5,
+            lastSyncIter: 42n,
+            dataSize: '1.2GB',
+            backupStatus: 'ok',
+          }),
+        },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const status = await getStorageStatus();
+      expect(status.nodeId).toBe('storage');
+      expect(status.isReachable).toBe(true);
+      expect(status.lastSyncTick).toBe(42n);
+      expect(status.totalNodes).toBe(5);
+      expect(status.connectedNodes).toBe(3);
+      expect(status.dataSize).toBe('1.2GB');
+      expect(status.backupStatus).toBe('ok');
+      expect(status.isPaid).toBe(true);
+    });
+
+    test('isReachable is false when connectedNodes is 0', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'storageStatusResponse',
+          value: new pb.StorageStatusResponse({ connectedNodes: 0 }),
+        },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const status = await getStorageStatus();
+      expect(status.isReachable).toBe(false);
+    });
+
+    test('throws on empty response', async () => {
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      await expect(getStorageStatus()).rejects.toThrow(/empty response/);
+    });
+
+    test('throws on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ message: 'denied' }) },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+      await expect(getStorageStatus()).rejects.toThrow(/denied/);
+    });
+
+    test('throws on unexpected payload', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'balancesListResponse', value: new pb.BalancesListResponse() },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+      await expect(getStorageStatus()).rejects.toThrow(/unexpected payload/);
+    });
+  });
+
+  // ── getNodeHealth ──────────────────────────────────────────────────
+
+  describe('getNodeHealth', () => {
+    test('returns storageNodeStatsResponse payload', async () => {
+      const statsResp = new pb.StorageNodeStatsResponse();
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'storageNodeStatsResponse', value: statsResp },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getNodeHealth();
+      expect(result).toBeDefined();
+    });
+
+    test('throws on empty response', async () => {
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      await expect(getNodeHealth()).rejects.toThrow(/empty response/);
+    });
+
+    test('throws on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ message: 'health err' }) },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+      await expect(getNodeHealth()).rejects.toThrow(/health err/);
+    });
+  });
+
+  // ── addStorageNode / removeStorageNode ─────────────────────────────
+
+  describe('addStorageNode', () => {
+    test('returns storageNodeManageResponse payload', async () => {
+      const manageResp = new pb.StorageNodeManageResponse({ success: true, assignedUrl: 'https://node1.example.com' });
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'storageNodeManageResponse', value: manageResp },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await addStorageNode();
+      expect(result.success).toBe(true);
+    });
+
+    test('throws on empty response', async () => {
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      await expect(addStorageNode()).rejects.toThrow(/empty response/);
+    });
+
+    test('throws on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ message: 'add failed' }) },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+      await expect(addStorageNode()).rejects.toThrow(/add failed/);
+    });
+  });
+
+  describe('removeStorageNode', () => {
+    test('returns storageNodeManageResponse on success', async () => {
+      const manageResp = new pb.StorageNodeManageResponse({ success: true });
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'storageNodeManageResponse', value: manageResp },
+      });
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await removeStorageNode('https://node1.example.com');
+      expect(result.success).toBe(true);
+    });
+
+    test('throws on empty response', async () => {
+      (appRouterInvokeBin as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      await expect(removeStorageNode('url')).rejects.toThrow(/empty response/);
+    });
+  });
+
+  // ── listLocalDlvs ─────────────────────────────────────────────────
+
+  describe('listLocalDlvs', () => {
+    test('maps vault entries with status and labels', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'bitcoinVaultListResponse',
+          value: new pb.BitcoinVaultListResponse({
+            vaults: [
+              new pb.BitcoinVaultSummary({ vaultId: 'v1', state: 'limbo', amountSats: 100000n, direction: 'btc_to_dbtc' }),
+              new pb.BitcoinVaultSummary({ vaultId: 'v2', state: 'unlocked', amountSats: 200000n, direction: 'dbtc_to_btc' }),
+              new pb.BitcoinVaultSummary({ vaultId: 'v3', state: 'claimed', amountSats: 50000n, direction: '' }),
+            ],
+          }),
+        },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const dlvs = await listLocalDlvs();
+      expect(dlvs).toHaveLength(3);
+      expect(dlvs[0].status).toBe('LOCKED');
+      expect(dlvs[0].localLabel).toBe('BTC → dBTC');
+      expect(dlvs[0].balance.baseUnits).toBe(100000n);
+      expect(dlvs[0].kind).toBe('dBTC');
+
+      expect(dlvs[1].status).toBe('UNLOCKABLE');
+      expect(dlvs[1].localLabel).toBe('dBTC → BTC');
+
+      expect(dlvs[2].status).toBe('SPENT');
+      expect(dlvs[2].localLabel).toBe('dBTC Vault');
+    });
+
+    test('maps invalidated state to EXPIRED', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'bitcoinVaultListResponse',
+          value: new pb.BitcoinVaultListResponse({
+            vaults: [new pb.BitcoinVaultSummary({ vaultId: 'v4', state: 'invalidated', amountSats: 0n })],
+          }),
+        },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const dlvs = await listLocalDlvs();
+      expect(dlvs[0].status).toBe('EXPIRED');
+    });
+
+    test('defaults unknown state to LOCKED', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'bitcoinVaultListResponse',
+          value: new pb.BitcoinVaultListResponse({
+            vaults: [new pb.BitcoinVaultSummary({ vaultId: 'v5', state: 'mystery', amountSats: 0n })],
+          }),
+        },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const dlvs = await listLocalDlvs();
+      expect(dlvs[0].status).toBe('LOCKED');
+    });
+
+    test('returns empty array on empty response', async () => {
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(new Uint8Array(0));
+      expect(await listLocalDlvs()).toEqual([]);
+    });
+
+    test('returns empty array on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ message: 'nope' }) },
+      });
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(frameEnvelope(env));
+      expect(await listLocalDlvs()).toEqual([]);
+    });
+
+    test('returns empty array on bridge throw', async () => {
+      (appRouterQueryBin as jest.Mock).mockRejectedValue(new Error('bridge down'));
+      expect(await listLocalDlvs()).toEqual([]);
+    });
+
+    test('returns empty array on decode error', async () => {
+      (appRouterQueryBin as jest.Mock).mockResolvedValue(new Uint8Array([0xFF, 0x01]));
+      expect(await listLocalDlvs()).toEqual([]);
+    });
+  });
+
+  // ── checkDlvPresence / createBackup ────────────────────────────────
+
+  describe('checkDlvPresence', () => {
+    test('returns true for non-empty anchor', async () => {
+      expect(await checkDlvPresence('abc')).toBe(true);
+    });
+
+    test('returns false for empty anchor', async () => {
+      expect(await checkDlvPresence('')).toBe(false);
+    });
+  });
+
+  describe('createBackup', () => {
+    test('returns backup path', async () => {
+      const result = await createBackup();
+      expect(result).toContain('dsm_backup');
+    });
+  });
+});

--- a/dsm_client/frontend/src/dsm/__tests__/wallet.test.ts
+++ b/dsm_client/frontend/src/dsm/__tests__/wallet.test.ts
@@ -1,0 +1,415 @@
+jest.mock('../WebViewBridge', () => ({
+  getAllBalancesStrictBridge: jest.fn(),
+  getWalletHistoryStrictBridge: jest.fn(),
+  getInboxStrictBridge: jest.fn(),
+}));
+
+jest.mock('../../domain/mappers', () => ({
+  mapTransactions: jest.fn((list: any[]) => list.map((t: any) => ({ txId: t.txId ?? 'mapped', amount: t.amount ?? 0n }))),
+}));
+
+import * as pb from '../../proto/dsm_app_pb';
+import {
+  getAllBalances,
+  getWalletBalance,
+  getWalletHistory,
+  getTransactions,
+  getInbox,
+  listB0xMessages,
+  getTokens,
+  getToken,
+} from '../wallet';
+import {
+  getAllBalancesStrictBridge,
+  getWalletHistoryStrictBridge,
+  getInboxStrictBridge,
+} from '../WebViewBridge';
+
+function frameEnvelope(envelope: pb.Envelope): Uint8Array {
+  const bytes = envelope.toBinary();
+  const framed = new Uint8Array(1 + bytes.length);
+  framed[0] = 0x03;
+  framed.set(bytes, 1);
+  return framed;
+}
+
+describe('wallet.ts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── getAllBalances ──────────────────────────────────────────────────
+
+  describe('getAllBalances', () => {
+    test('maps BalancesListResponse fields correctly', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'balancesListResponse',
+          value: new pb.BalancesListResponse({
+            balances: [
+              new pb.BalanceGetResponse({ tokenId: 'ERA', available: 1000n, symbol: 'ERA', decimals: 8, tokenName: 'Era Token' }),
+              new pb.BalanceGetResponse({ tokenId: 'dBTC', available: 50n, symbol: 'dBTC', decimals: 8 }),
+            ],
+          }),
+        },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getAllBalances();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        tokenId: 'ERA',
+        ticker: 'ERA',
+        balance: '1000',
+        baseUnits: 1000n,
+        decimals: 8,
+        symbol: 'ERA',
+        tokenName: 'Era Token',
+      });
+      expect(result[1].tokenId).toBe('dBTC');
+      expect(result[1].baseUnits).toBe(50n);
+    });
+
+    test('returns empty array for empty balances list', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'balancesListResponse',
+          value: new pb.BalancesListResponse({ balances: [] }),
+        },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getAllBalances();
+      expect(result).toEqual([]);
+    });
+
+    test('handles missing optional fields with fallback defaults', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'balancesListResponse',
+          value: new pb.BalancesListResponse({
+            balances: [new pb.BalanceGetResponse({})],
+          }),
+        },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getAllBalances();
+      expect(result).toHaveLength(1);
+      expect(result[0].tokenId).toBe('ERA');
+      expect(result[0].ticker).toBe('ERA');
+      expect(result[0].symbol).toBe('ERA');
+      expect(result[0].baseUnits).toBe(0n);
+      expect(result[0].decimals).toBe(0);
+    });
+
+    test('throws on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ code: 42, message: 'denied' }) },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getAllBalances()).rejects.toThrow(/DSM native error.*denied/);
+    });
+
+    test('throws on unexpected payload case', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'walletHistoryResponse', value: new pb.WalletHistoryResponse() },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getAllBalances()).rejects.toThrow(/Unexpected payload case for balances/);
+    });
+
+    test('throws when bridge rejects', async () => {
+      (getAllBalancesStrictBridge as jest.Mock).mockRejectedValue(new Error('bridge down'));
+      await expect(getAllBalances()).rejects.toThrow('bridge down');
+    });
+  });
+
+  // ── getWalletBalance ───────────────────────────────────────────────
+
+  describe('getWalletBalance', () => {
+    test('returns first balance as string', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'balancesListResponse',
+          value: new pb.BalancesListResponse({
+            balances: [new pb.BalanceGetResponse({ tokenId: 'ERA', available: 999n })],
+          }),
+        },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      expect(await getWalletBalance()).toBe('999');
+    });
+
+    test('returns "0" when balances list is empty', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'balancesListResponse',
+          value: new pb.BalancesListResponse({ balances: [] }),
+        },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      expect(await getWalletBalance()).toBe('0');
+    });
+  });
+
+  // ── getWalletHistory ───────────────────────────────────────────────
+
+  describe('getWalletHistory', () => {
+    test('decodes walletHistoryResponse and maps transactions', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'walletHistoryResponse',
+          value: new pb.WalletHistoryResponse({
+            transactions: [{ txId: 'tx1', amount: 100n } as any],
+          }),
+        },
+      });
+      (getWalletHistoryStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getWalletHistory();
+      expect(result.transactions).toBeDefined();
+      expect(Array.isArray(result.transactions)).toBe(true);
+    });
+
+    test('throws on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ code: 1, message: 'history fail' }) },
+      });
+      (getWalletHistoryStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getWalletHistory()).rejects.toThrow(/DSM native error.*history fail/);
+    });
+
+    test('throws on unexpected payload case', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'balancesListResponse', value: new pb.BalancesListResponse() },
+      });
+      (getWalletHistoryStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getWalletHistory()).rejects.toThrow(/Unexpected payload case for wallet history/);
+    });
+
+    test('returns empty transactions when payload serializes as empty message', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'walletHistoryResponse', value: undefined as any },
+      });
+      (getWalletHistoryStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getWalletHistory();
+      expect(result.transactions).toEqual([]);
+    });
+
+    test('handles empty transactions list', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'walletHistoryResponse',
+          value: new pb.WalletHistoryResponse({ transactions: [] }),
+        },
+      });
+      (getWalletHistoryStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getWalletHistory();
+      expect(result.transactions).toEqual([]);
+    });
+  });
+
+  // ── getTransactions ────────────────────────────────────────────────
+
+  describe('getTransactions', () => {
+    test('returns transactions array from wallet history', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'walletHistoryResponse',
+          value: new pb.WalletHistoryResponse({ transactions: [] }),
+        },
+      });
+      (getWalletHistoryStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getTransactions();
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  // ── getInbox ───────────────────────────────────────────────────────
+
+  describe('getInbox', () => {
+    test('maps inbox items correctly', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'inboxResponse',
+          value: new pb.InboxResponse({
+            items: [
+              new pb.InboxItem({ id: 'msg1', preview: 'Hello', senderId: 'alice', tick: 5n, isStaleRoute: false }),
+              new pb.InboxItem({ id: 'msg2', preview: 'World', isStaleRoute: true }),
+            ],
+          }),
+        },
+      });
+      (getInboxStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getInbox(10);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]).toMatchObject({ id: 'msg1', preview: 'Hello', sender_id: 'alice', isStaleRoute: false });
+      expect(result.items[1]).toMatchObject({ id: 'msg2', preview: 'World', isStaleRoute: true });
+    });
+
+    test('returns empty items when response has no items', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'inboxResponse',
+          value: new pb.InboxResponse({ items: [] }),
+        },
+      });
+      (getInboxStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getInbox();
+      expect(result.items).toEqual([]);
+    });
+
+    test('throws on error envelope', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'error', value: new pb.Error({ code: 3, message: 'inbox fail' }) },
+      });
+      (getInboxStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getInbox()).rejects.toThrow(/Native error.*inbox fail/);
+    });
+
+    test('throws on unexpected payload case', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'balancesListResponse', value: new pb.BalancesListResponse() },
+      });
+      (getInboxStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      await expect(getInbox()).rejects.toThrow(/Unexpected payload case for inbox/);
+    });
+
+    test('returns empty items when payload serializes as empty message', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: { case: 'inboxResponse', value: undefined as any },
+      });
+      (getInboxStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getInbox();
+      expect(result.items).toEqual([]);
+    });
+
+    test('defaults empty fields in inbox items', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'inboxResponse',
+          value: new pb.InboxResponse({
+            items: [new pb.InboxItem({})],
+          }),
+        },
+      });
+      (getInboxStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await getInbox();
+      expect(result.items[0].id).toBe('');
+      expect(result.items[0].preview).toBe('');
+    });
+  });
+
+  // ── listB0xMessages ────────────────────────────────────────────────
+
+  describe('listB0xMessages', () => {
+    test('re-maps inbox items to expected shape', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'inboxResponse',
+          value: new pb.InboxResponse({
+            items: [new pb.InboxItem({ id: 'b0x1', preview: 'hi', senderId: 'bob', tick: 3n, isStaleRoute: true })],
+          }),
+        },
+      });
+      (getInboxStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const result = await listB0xMessages();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: 'b0x1',
+        preview: 'hi',
+        senderId: 'bob',
+        tick: 3n,
+        isStaleRoute: true,
+      });
+    });
+  });
+
+  // ── getTokens / getToken ───────────────────────────────────────────
+
+  describe('getTokens', () => {
+    test('maps balances to token list', async () => {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'balancesListResponse',
+          value: new pb.BalancesListResponse({
+            balances: [
+              new pb.BalanceGetResponse({ tokenId: 'ERA', available: 100n, decimals: 8, symbol: 'ERA' }),
+            ],
+          }),
+        },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+
+      const tokens = await getTokens();
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0]).toEqual({ tokenId: 'ERA', balance: '100', decimals: 8, symbol: 'ERA' });
+    });
+  });
+
+  describe('getToken', () => {
+    function setupBalances() {
+      const env = new pb.Envelope({
+        version: 3,
+        payload: {
+          case: 'balancesListResponse',
+          value: new pb.BalancesListResponse({
+            balances: [
+              new pb.BalanceGetResponse({ tokenId: 'ERA', available: 100n, decimals: 8, symbol: 'ERA' }),
+              new pb.BalanceGetResponse({ tokenId: 'dBTC', available: 50n, decimals: 8, symbol: 'dBTC' }),
+            ],
+          }),
+        },
+      });
+      (getAllBalancesStrictBridge as jest.Mock).mockResolvedValue(frameEnvelope(env));
+    }
+
+    test('returns matching token by id', async () => {
+      setupBalances();
+      const token = await getToken('dBTC');
+      expect(token).toEqual({ tokenId: 'dBTC', balance: '50', decimals: 8, symbol: 'dBTC' });
+    });
+
+    test('returns null for unknown token id', async () => {
+      setupBalances();
+      const token = await getToken('UNKNOWN');
+      expect(token).toBeNull();
+    });
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useBottomNav.test.tsx
+++ b/dsm_client/frontend/src/hooks/__tests__/useBottomNav.test.tsx
@@ -1,0 +1,167 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useBottomNav } from '../useBottomNav';
+import type { ScreenType } from '../../types/app';
+
+jest.mock('../../dsm/WebViewBridge', () => ({
+  openBluetoothSettings: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { openBluetoothSettings } from '../../dsm/WebViewBridge';
+
+const mockedOpenBluetooth = openBluetoothSettings as jest.MockedFunction<typeof openBluetoothSettings>;
+
+function Harness({ currentScreen, navigate }: { currentScreen: ScreenType; navigate: (to: ScreenType) => void }) {
+  useBottomNav({ currentScreen, navigate });
+  return null;
+}
+
+function createNavIcon(navKey: string): HTMLDivElement {
+  const el = document.createElement('div');
+  el.classList.add('screen-nav-icon');
+  el.setAttribute('data-nav', navKey);
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('useBottomNav', () => {
+  let navElements: HTMLDivElement[] = [];
+
+  afterEach(() => {
+    navElements.forEach(el => {
+      if (el.parentNode) el.parentNode.removeChild(el);
+    });
+    navElements = [];
+    jest.clearAllMocks();
+  });
+
+  describe('click navigation', () => {
+    it('navigates to wallet when wallet icon is clicked', () => {
+      const walletEl = createNavIcon('wallet');
+      navElements.push(walletEl);
+      const navigate = jest.fn();
+
+      render(<Harness currentScreen="home" navigate={navigate} />);
+      act(() => { walletEl.click(); });
+
+      expect(navigate).toHaveBeenCalledWith('wallet');
+    });
+
+    it('opens Bluetooth settings when bluetooth icon is clicked', () => {
+      const bleEl = createNavIcon('bluetooth');
+      navElements.push(bleEl);
+      const navigate = jest.fn();
+
+      render(<Harness currentScreen="wallet" navigate={navigate} />);
+      act(() => { bleEl.click(); });
+
+      expect(mockedOpenBluetooth).toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates to contacts when qr icon is clicked', () => {
+      const qrEl = createNavIcon('qr');
+      navElements.push(qrEl);
+      const navigate = jest.fn();
+
+      render(<Harness currentScreen="wallet" navigate={navigate} />);
+      act(() => { qrEl.click(); });
+
+      expect(navigate).toHaveBeenCalledWith('contacts');
+    });
+
+    it('navigates to the navKey for generic icons', () => {
+      const settingsEl = createNavIcon('settings');
+      navElements.push(settingsEl);
+      const navigate = jest.fn();
+
+      render(<Harness currentScreen="wallet" navigate={navigate} />);
+      act(() => { settingsEl.click(); });
+
+      expect(navigate).toHaveBeenCalledWith('settings');
+    });
+
+    it('does nothing when element has no data-nav attribute', () => {
+      const el = document.createElement('div');
+      el.classList.add('screen-nav-icon');
+      document.body.appendChild(el);
+      navElements.push(el);
+      const navigate = jest.fn();
+
+      render(<Harness currentScreen="wallet" navigate={navigate} />);
+      act(() => { el.click(); });
+
+      expect(navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('active state highlighting', () => {
+    it('adds active class to matching nav icon', () => {
+      const walletEl = createNavIcon('wallet');
+      const settingsEl = createNavIcon('settings');
+      navElements.push(walletEl, settingsEl);
+
+      render(<Harness currentScreen="wallet" navigate={jest.fn()} />);
+
+      expect(walletEl.classList.contains('active')).toBe(true);
+      expect(settingsEl.classList.contains('active')).toBe(false);
+    });
+
+    it('maps vault screen to wallet nav key', () => {
+      const walletEl = createNavIcon('wallet');
+      navElements.push(walletEl);
+
+      render(<Harness currentScreen="vault" navigate={jest.fn()} />);
+
+      expect(walletEl.classList.contains('active')).toBe(true);
+    });
+
+    it('updates active state on screen change', () => {
+      const walletEl = createNavIcon('wallet');
+      const settingsEl = createNavIcon('settings');
+      navElements.push(walletEl, settingsEl);
+      const navigate = jest.fn();
+
+      const { rerender } = render(<Harness currentScreen="wallet" navigate={navigate} />);
+      expect(walletEl.classList.contains('active')).toBe(true);
+      expect(settingsEl.classList.contains('active')).toBe(false);
+
+      rerender(<Harness currentScreen="settings" navigate={navigate} />);
+      expect(walletEl.classList.contains('active')).toBe(false);
+      expect(settingsEl.classList.contains('active')).toBe(true);
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    it('removes click handlers on unmount', () => {
+      const walletEl = createNavIcon('wallet');
+      navElements.push(walletEl);
+      const navigate = jest.fn();
+
+      const { unmount } = render(<Harness currentScreen="wallet" navigate={navigate} />);
+      unmount();
+
+      act(() => { walletEl.click(); });
+      expect(navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('bluetooth error handling', () => {
+    it('catches error from openBluetoothSettings', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockedOpenBluetooth.mockRejectedValueOnce(new Error('no ble'));
+
+      const bleEl = createNavIcon('bluetooth');
+      navElements.push(bleEl);
+      const navigate = jest.fn();
+
+      render(<Harness currentScreen="wallet" navigate={navigate} />);
+      act(() => { bleEl.click(); });
+
+      expect(mockedOpenBluetooth).toHaveBeenCalled();
+    });
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useBridgeEvents.test.ts
+++ b/dsm_client/frontend/src/hooks/__tests__/useBridgeEvents.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+
+const bridgeHandlers = new Map<string, Set<Function>>();
+jest.mock('../../bridge/bridgeEvents', () => ({
+  bridgeEvents: {
+    on: jest.fn((event: string, handler: Function) => {
+      const set = bridgeHandlers.get(event) ?? new Set();
+      set.add(handler);
+      bridgeHandlers.set(event, set);
+      return () => { set.delete(handler); };
+    }),
+  },
+}));
+
+import { useBridgeEvent } from '../useBridgeEvents';
+
+function emitBridge(event: string, payload?: any) {
+  const set = bridgeHandlers.get(event);
+  if (set) set.forEach(fn => fn(payload));
+}
+
+beforeEach(() => {
+  bridgeHandlers.clear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useBridgeEvent', () => {
+  it('subscribes to the named event and invokes handler', () => {
+    const handler = jest.fn();
+    renderHook(() => useBridgeEvent('wallet.refresh', handler));
+
+    act(() => { emitBridge('wallet.refresh', { source: 'test' }); });
+
+    expect(handler).toHaveBeenCalledWith({ source: 'test' });
+  });
+
+  it('unsubscribes on unmount', () => {
+    const handler = jest.fn();
+    const { unmount } = renderHook(() => useBridgeEvent('wallet.refresh', handler));
+
+    unmount();
+
+    act(() => { emitBridge('wallet.refresh', { source: 'test' }); });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('uses latest handler via ref (no re-subscribe on handler change)', () => {
+    const handler1 = jest.fn();
+    const handler2 = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ handler }) => useBridgeEvent('wallet.refresh', handler),
+      { initialProps: { handler: handler1 } },
+    );
+
+    rerender({ handler: handler2 });
+
+    act(() => { emitBridge('wallet.refresh', { source: 'test' }); });
+
+    expect(handler1).not.toHaveBeenCalled();
+    expect(handler2).toHaveBeenCalledWith({ source: 'test' });
+  });
+
+  it('re-subscribes when eventName changes', () => {
+    const handler = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ eventName }) => useBridgeEvent(eventName, handler),
+      { initialProps: { eventName: 'wallet.refresh' } },
+    );
+
+    rerender({ eventName: 'identity.ready' });
+
+    // Old event should no longer trigger
+    act(() => { emitBridge('wallet.refresh', { source: 'test' }); });
+    expect(handler).not.toHaveBeenCalled();
+
+    // New event should work
+    act(() => { emitBridge('identity.ready'); });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles event with no payload', () => {
+    const handler = jest.fn();
+    renderHook(() => useBridgeEvent('identity.ready', handler));
+
+    act(() => { emitBridge('identity.ready'); });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(undefined);
+  });
+
+  it('supports typed payloads', () => {
+    const handler = jest.fn();
+    renderHook(() => useBridgeEvent<{ address: string }>('ble.deviceConnected', handler));
+
+    act(() => { emitBridge('ble.deviceConnected', { address: 'AA:BB:CC' }); });
+
+    expect(handler).toHaveBeenCalledWith({ address: 'AA:BB:CC' });
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useDiagnostics.test.ts
+++ b/dsm_client/frontend/src/hooks/__tests__/useDiagnostics.test.ts
@@ -1,0 +1,382 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+
+const mockGetPreference = jest.fn();
+const mockSetPreference = jest.fn();
+jest.mock('../../services/dsmClient', () => ({
+  dsmClient: {
+    getPreference: (...args: any[]) => mockGetPreference(...args),
+    setPreference: (...args: any[]) => mockSetPreference(...args),
+  },
+}));
+
+const bridgeHandlers = new Map<string, Set<Function>>();
+jest.mock('../../bridge/bridgeEvents', () => ({
+  bridgeEvents: {
+    on: jest.fn((event: string, handler: Function) => {
+      const set = bridgeHandlers.get(event) ?? new Set();
+      set.add(handler);
+      bridgeHandlers.set(event, set);
+      return () => { set.delete(handler); };
+    }),
+    emit: jest.fn((event: string, payload: any) => {
+      const set = bridgeHandlers.get(event);
+      if (set) set.forEach(fn => fn(payload));
+    }),
+  },
+}));
+
+jest.mock('../../utils/githubIssue', () => ({
+  BETA_BUG_TEMPLATE: 'bug-report-beta.yml',
+  BETA_FEEDBACK_TEMPLATE: 'general-feedback-beta.yml',
+  buildGitHubIssueUrl: jest.fn(() => 'https://github.com/test/issues/new'),
+}));
+
+jest.mock('../../runtime/nativeSessionStore', () => ({
+  nativeSessionStore: {
+    getSnapshot: jest.fn(() => ({ received: true, phase: 'wallet_ready' })),
+  },
+}));
+
+jest.mock('../../dsm/WebViewBridge', () => ({
+  runNativeBridgeSelfTest: jest.fn(() => 'PASS'),
+  getLastError: jest.fn(() => ''),
+  getArchitectureInfo: jest.fn(async () => ({
+    status: 'COMPATIBLE',
+    deviceArch: 'arm64',
+    supportedAbis: 'arm64-v8a',
+    message: 'OK',
+    recommendation: '',
+  })),
+}));
+
+jest.mock('../../services/telemetry', () => ({
+  sendDiagnostics: jest.fn(async () => {}),
+  exportDiagnosticsReport: jest.fn(async () => new Uint8Array(0)),
+}));
+
+import { bridgeEvents } from '../../bridge/bridgeEvents';
+import { useDiagnostics } from '../useDiagnostics';
+
+const mockedBridgeEvents = bridgeEvents as any;
+
+function emitBridge(event: string, payload: any) {
+  const set = bridgeHandlers.get(event);
+  if (set) set.forEach(fn => fn(payload));
+}
+
+beforeEach(() => {
+  bridgeHandlers.clear();
+  mockGetPreference.mockReset();
+  mockSetPreference.mockReset();
+  mockGetPreference.mockResolvedValue(null);
+  mockSetPreference.mockResolvedValue(undefined);
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  delete (window as any).__envConfigErrorDetail;
+  delete (window as any).__lastBridgeError;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useDiagnostics', () => {
+  it('returns initial state', async () => {
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    expect(result.current.envConfigError).toBeNull();
+    expect(result.current.showDiagnostics).toBe(false);
+    expect(result.current.diagLoading).toBe(false);
+    expect(result.current.diagnostics).toBeNull();
+    expect(result.current.telemetryConsent).toBe(false);
+    expect(result.current.lastBridgeError).toBeNull();
+  });
+
+  it('loads telemetry consent from preferences on mount', async () => {
+    mockGetPreference.mockResolvedValueOnce('1');
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    expect(mockGetPreference).toHaveBeenCalledWith('diagnostics_consent');
+    expect(result.current.telemetryConsent).toBe(true);
+  });
+
+  it('treats "true" as consent enabled', async () => {
+    mockGetPreference.mockResolvedValueOnce('true');
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    expect(result.current.telemetryConsent).toBe(true);
+  });
+
+  it('defaults consent to false on preference error', async () => {
+    mockGetPreference.mockRejectedValueOnce(new Error('fail'));
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    expect(result.current.telemetryConsent).toBe(false);
+  });
+
+  it('handles env.config.error events', async () => {
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    act(() => {
+      emitBridge('env.config.error', { message: 'Missing config', type: 'MISSING_FILE', help: 'reinstall' });
+    });
+
+    expect(result.current.envConfigError).toBe('Missing config');
+    expect((window as any).__envConfigErrorDetail).toEqual({
+      message: 'Missing config',
+      type: 'MISSING_FILE',
+      help: 'reinstall',
+    });
+  });
+
+  it('handles env.config.error with missing message', async () => {
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    act(() => {
+      emitBridge('env.config.error', {});
+    });
+
+    expect(result.current.envConfigError).toBe('Environment configuration error');
+  });
+
+  it('handles bridge.error events', async () => {
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    act(() => {
+      emitBridge('bridge.error', { code: 42, message: 'decode fail', debugB32: 'ABC123' });
+    });
+
+    expect(result.current.lastBridgeError).toEqual({
+      code: 42,
+      message: 'decode fail',
+      debugB32: 'ABC123',
+    });
+    expect((window as any).__lastBridgeError).toEqual({
+      code: 42,
+      message: 'decode fail',
+      debugB32: 'ABC123',
+    });
+  });
+
+  it('updates telemetry consent and persists preference', async () => {
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.setTelemetryConsent(true);
+    });
+
+    expect(result.current.telemetryConsent).toBe(true);
+    expect(mockSetPreference).toHaveBeenCalledWith('diagnostics_consent', '1');
+  });
+
+  it('notifies error when consent save fails', async () => {
+    mockSetPreference.mockRejectedValueOnce(new Error('save fail'));
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.setTelemetryConsent(false);
+    });
+
+    expect(notifyToast).toHaveBeenCalledWith('error', 'Failed to save diagnostics consent');
+  });
+
+  it('gatherDiagnostics populates diagnostics string', async () => {
+    const notifyToast = jest.fn();
+    mockGetPreference.mockResolvedValue('');
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.gatherDiagnostics();
+    });
+
+    expect(result.current.diagLoading).toBe(false);
+    expect(result.current.showDiagnostics).toBe(true);
+    expect(result.current.diagnostics).toContain('DSM diagnostics (clockless)');
+    expect(result.current.diagnostics).toContain('bridgeStatus=');
+    expect(result.current.diagnostics).toContain('archStatus=COMPATIBLE');
+  });
+
+  it('sendDiagnosticsTelemetry calls telemetry service', async () => {
+    const telemetryMod = await import('../../services/telemetry');
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    // First gather so diagnostics is not null
+    await act(async () => {
+      await result.current.gatherDiagnostics();
+    });
+
+    await act(async () => {
+      await result.current.sendDiagnosticsTelemetry();
+    });
+
+    expect(telemetryMod.sendDiagnostics).toHaveBeenCalled();
+    expect(notifyToast).toHaveBeenCalledWith('success', 'Diagnostics saved to local log');
+  });
+
+  it('sendDiagnosticsTelemetry does nothing when diagnostics is null', async () => {
+    const telemetryMod = await import('../../services/telemetry');
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.sendDiagnosticsTelemetry();
+    });
+
+    expect(telemetryMod.sendDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it('copyDiagnostics writes to clipboard', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.gatherDiagnostics();
+    });
+
+    await act(async () => {
+      await result.current.copyDiagnostics();
+    });
+
+    expect(writeText).toHaveBeenCalled();
+    expect(notifyToast).toHaveBeenCalledWith('success', 'Diagnostics copied to clipboard');
+  });
+
+  it('copyDiagnostics does nothing when diagnostics is null', async () => {
+    const writeText = jest.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.copyDiagnostics();
+    });
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('downloadDiagnostics creates and clicks a link', async () => {
+    const notifyToast = jest.fn();
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.gatherDiagnostics();
+    });
+
+    const mockClick = jest.fn();
+    const mockRemove = jest.fn();
+    const mockCreateElement = jest.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click: mockClick,
+      remove: mockRemove,
+    } as any);
+    jest.spyOn(document.body, 'appendChild').mockImplementation((n) => n);
+    const mockCreateObjectURL = jest.fn(() => 'blob:test');
+    const mockRevokeObjectURL = jest.fn();
+    global.URL.createObjectURL = mockCreateObjectURL;
+    global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    await act(async () => {
+      result.current.downloadDiagnostics();
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(mockClick).toHaveBeenCalled();
+    expect(mockRemove).toHaveBeenCalled();
+    expect(mockRevokeObjectURL).toHaveBeenCalled();
+
+    mockCreateElement.mockRestore();
+  });
+
+  it('responds to dsm-open-diagnostics custom event', async () => {
+    const notifyToast = jest.fn();
+    mockGetPreference.mockResolvedValue('');
+    const { result } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('dsm-open-diagnostics', { detail: { autoGather: true } }));
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(result.current.showDiagnostics).toBe(true);
+  });
+
+  it('unsubscribes bridge events on unmount', async () => {
+    const notifyToast = jest.fn();
+    const { unmount } = renderHook(() => useDiagnostics(notifyToast));
+
+    await act(async () => {});
+
+    const envHandlers = bridgeHandlers.get('env.config.error');
+    const bridgeErrHandlers = bridgeHandlers.get('bridge.error');
+
+    unmount();
+
+    expect(envHandlers?.size ?? 0).toBe(0);
+    expect(bridgeErrHandlers?.size ?? 0).toBe(0);
+  });
+
+  it('cancelled flag prevents stale consent updates', async () => {
+    let resolvePreference!: (v: string) => void;
+    mockGetPreference.mockReturnValueOnce(new Promise<string>(r => { resolvePreference = r; }));
+
+    const notifyToast = jest.fn();
+    const { result, unmount } = renderHook(() => useDiagnostics(notifyToast));
+
+    unmount();
+    resolvePreference('1');
+    await act(async () => {});
+
+    // After unmount, consent should remain false (cancelled=true prevents setState)
+    expect(result.current.telemetryConsent).toBe(false);
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useDpadNav.test.tsx
+++ b/dsm_client/frontend/src/hooks/__tests__/useDpadNav.test.tsx
@@ -1,0 +1,164 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react';
+import { useDpadNav } from '../useDpadNav';
+
+type HookResult = ReturnType<typeof useDpadNav>;
+let hookResult: HookResult;
+
+function Harness(props: { itemCount: number; onSelect?: (i: number) => void; initialIndex?: number }) {
+  hookResult = useDpadNav(props);
+  return null;
+}
+
+describe('useDpadNav', () => {
+  afterEach(() => {
+    delete (window as any).__dsmScreenNavActive;
+    delete (window as any).__dsmComboEntryActive;
+  });
+
+  it('initializes focused index to 0 by default', () => {
+    render(<Harness itemCount={5} />);
+    expect(hookResult.focusedIndex).toBe(0);
+  });
+
+  it('initializes focused index to initialIndex', () => {
+    render(<Harness itemCount={5} initialIndex={3} />);
+    expect(hookResult.focusedIndex).toBe(3);
+  });
+
+  it('sets __dsmScreenNavActive on mount and clears on unmount', () => {
+    const { unmount } = render(<Harness itemCount={3} />);
+    expect((window as any).__dsmScreenNavActive).toBe(true);
+    unmount();
+    expect((window as any).__dsmScreenNavActive).toBe(false);
+  });
+
+  describe('keyboard navigation', () => {
+    it('ArrowDown increments focused index', () => {
+      render(<Harness itemCount={3} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowDown' }); });
+      expect(hookResult.focusedIndex).toBe(1);
+    });
+
+    it('ArrowUp decrements focused index', () => {
+      render(<Harness itemCount={3} initialIndex={2} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowUp' }); });
+      expect(hookResult.focusedIndex).toBe(1);
+    });
+
+    it('ArrowRight increments focused index', () => {
+      render(<Harness itemCount={3} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowRight' }); });
+      expect(hookResult.focusedIndex).toBe(1);
+    });
+
+    it('ArrowLeft decrements focused index', () => {
+      render(<Harness itemCount={3} initialIndex={1} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowLeft' }); });
+      expect(hookResult.focusedIndex).toBe(0);
+    });
+
+    it('wraps around when going past the last item', () => {
+      render(<Harness itemCount={3} initialIndex={2} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowDown' }); });
+      expect(hookResult.focusedIndex).toBe(0);
+    });
+
+    it('wraps around when going before the first item', () => {
+      render(<Harness itemCount={3} initialIndex={0} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowUp' }); });
+      expect(hookResult.focusedIndex).toBe(2);
+    });
+
+    it('Enter calls onSelect with current index', () => {
+      const onSelect = jest.fn();
+      render(<Harness itemCount={3} onSelect={onSelect} initialIndex={1} />);
+      act(() => { fireEvent.keyDown(document, { key: 'Enter' }); });
+      expect(onSelect).toHaveBeenCalledWith(1);
+    });
+
+    it('Space calls onSelect with current index', () => {
+      const onSelect = jest.fn();
+      render(<Harness itemCount={3} onSelect={onSelect} />);
+      act(() => { fireEvent.keyDown(document, { key: ' ' }); });
+      expect(onSelect).toHaveBeenCalledWith(0);
+    });
+
+    it('does not navigate when itemCount is 0', () => {
+      render(<Harness itemCount={0} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowDown' }); });
+      expect(hookResult.focusedIndex).toBe(0);
+    });
+  });
+
+  describe('combo entry suppression', () => {
+    it('does not call onSelect when __dsmComboEntryActive is true', () => {
+      const onSelect = jest.fn();
+      render(<Harness itemCount={3} onSelect={onSelect} />);
+      (window as any).__dsmComboEntryActive = true;
+      act(() => { fireEvent.keyDown(document, { key: 'Enter' }); });
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept arrow keys when __dsmComboEntryActive is true', () => {
+      render(<Harness itemCount={3} />);
+      (window as any).__dsmComboEntryActive = true;
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowDown' }); });
+      // When combo entry active, handler returns early — index stays at 0
+      expect(hookResult.focusedIndex).toBe(0);
+    });
+  });
+
+  describe('clamping on itemCount change', () => {
+    it('clamps focused index when itemCount shrinks', () => {
+      const { rerender } = render(<Harness itemCount={5} initialIndex={4} />);
+      expect(hookResult.focusedIndex).toBe(4);
+      rerender(<Harness itemCount={3} />);
+      expect(hookResult.focusedIndex).toBe(2);
+    });
+
+    it('does not clamp when index is within bounds', () => {
+      const { rerender } = render(<Harness itemCount={5} initialIndex={1} />);
+      rerender(<Harness itemCount={3} />);
+      expect(hookResult.focusedIndex).toBe(1);
+    });
+  });
+
+  describe('setFocusedIndex', () => {
+    it('allows manual override of focused index', () => {
+      render(<Harness itemCount={5} />);
+      act(() => { hookResult.setFocusedIndex(3); });
+      expect(hookResult.focusedIndex).toBe(3);
+    });
+  });
+
+  describe('D-pad button click handlers', () => {
+    it('handles click on .dpad-down element', () => {
+      const el = document.createElement('div');
+      el.classList.add('dpad-down');
+      document.body.appendChild(el);
+
+      render(<Harness itemCount={5} />);
+      act(() => { el.click(); });
+      expect(hookResult.focusedIndex).toBe(1);
+
+      document.body.removeChild(el);
+    });
+
+    it('handles click on .button-a element (select)', () => {
+      const onSelect = jest.fn();
+      const el = document.createElement('div');
+      el.classList.add('button-a');
+      document.body.appendChild(el);
+
+      render(<Harness itemCount={3} onSelect={onSelect} />);
+      act(() => { el.click(); });
+      expect(onSelect).toHaveBeenCalledWith(0);
+
+      document.body.removeChild(el);
+    });
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useGenesisFlow.test.ts
+++ b/dsm_client/frontend/src/hooks/__tests__/useGenesisFlow.test.ts
@@ -1,0 +1,280 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../dsm/decoding', () => ({
+  decodeFramedEnvelopeV3: jest.fn(),
+}));
+
+type DsmEventHandler = (evt: { topic: string; payload: Uint8Array }) => void;
+let dsmEventListeners: DsmEventHandler[] = [];
+const mockCreateGenesisViaRouter = jest.fn();
+
+jest.mock('../../dsm/WebViewBridge', () => ({
+  addDsmEventListener: jest.fn((handler: DsmEventHandler) => {
+    dsmEventListeners.push(handler);
+    return () => {
+      dsmEventListeners = dsmEventListeners.filter(h => h !== handler);
+    };
+  }),
+  createGenesisViaRouter: (...args: any[]) => mockCreateGenesisViaRouter(...args),
+}));
+
+import { decodeFramedEnvelopeV3 } from '../../dsm/decoding';
+import { useGenesisFlow } from '../useGenesisFlow';
+
+const mockedDecode = decodeFramedEnvelopeV3 as jest.Mock;
+
+function emitDsmEvent(topic: string, payload: Uint8Array = new Uint8Array(0)) {
+  dsmEventListeners.forEach(h => h({ topic, payload }));
+}
+
+beforeEach(() => {
+  dsmEventListeners = [];
+  mockCreateGenesisViaRouter.mockReset();
+  mockedDecode.mockReset();
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  // Provide crypto.getRandomValues for genesis entropy
+  if (!globalThis.crypto) {
+    (globalThis as any).crypto = {};
+  }
+  (globalThis.crypto as any).getRandomValues = (buf: Uint8Array) => {
+    for (let i = 0; i < buf.length; i++) buf[i] = i & 0xff;
+    return buf;
+  };
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function makeHookArgs() {
+  return {
+    appState: 'needs_genesis' as any,
+    setAppState: jest.fn(),
+    setError: jest.fn(),
+    setSecuringProgress: jest.fn(),
+  };
+}
+
+describe('useGenesisFlow', () => {
+  it('returns handleGenerateGenesis callback', () => {
+    const args = makeHookArgs();
+    const { result } = renderHook(() => useGenesisFlow(args));
+    expect(typeof result.current.handleGenerateGenesis).toBe('function');
+  });
+
+  it('successful genesis flow decodes envelope and completes', async () => {
+    const args = makeHookArgs();
+    const fakeEnvelope = new Uint8Array(64).fill(1);
+    mockCreateGenesisViaRouter.mockResolvedValue(fakeEnvelope);
+    mockedDecode.mockReturnValue({
+      payload: {
+        case: 'genesisCreatedResponse',
+        value: { ok: true },
+      },
+    });
+
+    const { result } = renderHook(() => useGenesisFlow(args));
+
+    await act(async () => {
+      await result.current.handleGenerateGenesis();
+    });
+
+    expect(mockCreateGenesisViaRouter).toHaveBeenCalledWith(
+      expect.any(String),
+      'mainnet',
+      expect.any(Uint8Array),
+    );
+    expect(mockedDecode).toHaveBeenCalledWith(fakeEnvelope);
+    // No error set on success
+    expect(args.setError).not.toHaveBeenCalled();
+  });
+
+  it('prevents concurrent genesis calls', async () => {
+    const args = makeHookArgs();
+    let resolveGenesis!: (v: Uint8Array) => void;
+    mockCreateGenesisViaRouter.mockReturnValue(new Promise<Uint8Array>(r => { resolveGenesis = r; }));
+
+    const { result } = renderHook(() => useGenesisFlow(args));
+
+    // Start first call
+    let firstPromise: Promise<void>;
+    act(() => {
+      firstPromise = result.current.handleGenerateGenesis();
+    });
+
+    // Second call while first is in flight — should be a no-op
+    await act(async () => {
+      await result.current.handleGenerateGenesis();
+    });
+
+    expect(mockCreateGenesisViaRouter).toHaveBeenCalledTimes(1);
+
+    // Clean up
+    const fakeEnvelope = new Uint8Array(64).fill(1);
+    mockedDecode.mockReturnValue({ payload: { case: 'genesisCreatedResponse', value: {} } });
+    resolveGenesis(fakeEnvelope);
+    await act(async () => { await firstPromise!; });
+  });
+
+  it('handles error envelope case', async () => {
+    const args = makeHookArgs();
+    mockCreateGenesisViaRouter.mockResolvedValue(new Uint8Array(64).fill(1));
+    mockedDecode.mockReturnValue({
+      payload: { case: 'error', value: { message: 'Entropy invalid' } },
+    });
+
+    const { result } = renderHook(() => useGenesisFlow(args));
+
+    await act(async () => {
+      await result.current.handleGenerateGenesis();
+    });
+
+    expect(args.setError).toHaveBeenCalledWith('Genesis creation failed: Entropy invalid');
+    expect(args.setAppState).toHaveBeenCalledWith('error');
+  });
+
+  it('handles empty/too-small envelope', async () => {
+    const args = makeHookArgs();
+    mockCreateGenesisViaRouter.mockResolvedValue(new Uint8Array(5));
+
+    const { result } = renderHook(() => useGenesisFlow(args));
+
+    await act(async () => {
+      await result.current.handleGenerateGenesis();
+    });
+
+    expect(args.setError).toHaveBeenCalledWith('Genesis envelope is empty or too small');
+    expect(args.setAppState).toHaveBeenCalledWith('error');
+  });
+
+  it('handles invalid envelope case', async () => {
+    const args = makeHookArgs();
+    mockCreateGenesisViaRouter.mockResolvedValue(new Uint8Array(64).fill(1));
+    mockedDecode.mockReturnValue({
+      payload: { case: 'somethingElse', value: {} },
+    });
+
+    const { result } = renderHook(() => useGenesisFlow(args));
+
+    await act(async () => {
+      await result.current.handleGenerateGenesis();
+    });
+
+    expect(args.setError).toHaveBeenCalledWith(expect.stringContaining('Invalid GenesisCreated envelope'));
+    expect(args.setAppState).toHaveBeenCalledWith('error');
+  });
+
+  it('aborts on visibility change during securing_device', () => {
+    const args = { ...makeHookArgs(), appState: 'securing_device' as any };
+    renderHook(() => useGenesisFlow(args));
+
+    // Simulate tab hidden
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', writable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(args.setError).toHaveBeenCalledWith(expect.stringContaining('Do not leave the screen'));
+    expect(args.setAppState).toHaveBeenCalledWith('needs_genesis');
+    expect(args.setSecuringProgress).toHaveBeenCalledWith(0);
+
+    // Restore
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true });
+  });
+
+  it('does not listen for visibility change when not securing_device', () => {
+    const args = makeHookArgs();
+    renderHook(() => useGenesisFlow(args));
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', writable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(args.setError).not.toHaveBeenCalled();
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true });
+  });
+
+  it('responds to genesis.securing-device DSM event', () => {
+    const args = makeHookArgs();
+    renderHook(() => useGenesisFlow(args));
+
+    act(() => {
+      emitDsmEvent('genesis.securing-device');
+    });
+
+    expect(args.setSecuringProgress).toHaveBeenCalledWith(0);
+    expect(args.setAppState).toHaveBeenCalledWith('securing_device');
+  });
+
+  it('responds to genesis.securing-device-progress DSM event', () => {
+    const args = makeHookArgs();
+    renderHook(() => useGenesisFlow(args));
+
+    act(() => {
+      emitDsmEvent('genesis.securing-device-progress', new Uint8Array([75]));
+    });
+
+    expect(args.setSecuringProgress).toHaveBeenCalledWith(75);
+  });
+
+  it('responds to genesis.securing-device-complete DSM event', () => {
+    const args = makeHookArgs();
+    renderHook(() => useGenesisFlow(args));
+
+    act(() => {
+      emitDsmEvent('genesis.securing-device-complete');
+    });
+
+    expect(args.setSecuringProgress).toHaveBeenCalledWith(100);
+  });
+
+  it('responds to genesis.securing-device-aborted DSM event', () => {
+    const args = makeHookArgs();
+    renderHook(() => useGenesisFlow(args));
+
+    act(() => {
+      emitDsmEvent('genesis.securing-device-aborted');
+    });
+
+    expect(args.setSecuringProgress).toHaveBeenCalledWith(0);
+    expect(args.setError).toHaveBeenCalledWith(expect.stringContaining('Do not leave the screen'));
+    expect(args.setAppState).toHaveBeenCalledWith('needs_genesis');
+  });
+
+  it('cleans up DSM event listeners on unmount', () => {
+    const args = makeHookArgs();
+    const { unmount } = renderHook(() => useGenesisFlow(args));
+
+    expect(dsmEventListeners.length).toBeGreaterThan(0);
+    unmount();
+    expect(dsmEventListeners.length).toBe(0);
+  });
+
+  it('error with "Do not leave the screen" resets to needs_genesis', async () => {
+    const args = makeHookArgs();
+    mockCreateGenesisViaRouter.mockRejectedValue(
+      new Error('Do not leave the screen until finished')
+    );
+
+    const { result } = renderHook(() => useGenesisFlow(args));
+
+    await act(async () => {
+      await result.current.handleGenerateGenesis();
+    });
+
+    expect(args.setSecuringProgress).toHaveBeenCalledWith(0);
+    expect(args.setAppState).toHaveBeenCalledWith('needs_genesis');
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useKeyboardBindings.test.tsx
+++ b/dsm_client/frontend/src/hooks/__tests__/useKeyboardBindings.test.tsx
@@ -1,0 +1,222 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react';
+import { useKeyboardBindings } from '../useKeyboardBindings';
+
+type Intents = Parameters<typeof useKeyboardBindings>[0];
+
+function Harness({ intents }: { intents: Intents }) {
+  useKeyboardBindings(intents);
+  return null;
+}
+
+function makeIntents(): Intents & { [K in keyof Intents]: jest.Mock } {
+  return {
+    prevItem: jest.fn(),
+    nextItem: jest.fn(),
+    select: jest.fn(),
+    back: jest.fn(),
+    toggleTheme: jest.fn(),
+    start: jest.fn(),
+  };
+}
+
+describe('useKeyboardBindings', () => {
+  afterEach(() => {
+    delete (window as any).__dsmScreenNavActive;
+    delete (window as any).__dsmComboEntryActive;
+  });
+
+  describe('keyboard events', () => {
+    it('ArrowUp calls prevItem', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowUp' }); });
+      expect(intents.prevItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('ArrowDown calls nextItem', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowDown' }); });
+      expect(intents.nextItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('ArrowLeft calls prevItem', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowLeft' }); });
+      expect(intents.prevItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('ArrowRight calls nextItem', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowRight' }); });
+      expect(intents.nextItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('Enter calls select', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: 'Enter' }); });
+      expect(intents.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('Space calls select', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: ' ' }); });
+      expect(intents.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('Escape calls back', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: 'Escape' }); });
+      expect(intents.back).toHaveBeenCalledTimes(1);
+    });
+
+    it('Tab calls toggleTheme', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: 'Tab' }); });
+      expect(intents.toggleTheme).toHaveBeenCalledTimes(1);
+    });
+
+    it('Shift calls start', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      act(() => { fireEvent.keyDown(document, { key: 'Shift' }); });
+      expect(intents.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('__dsmScreenNavActive deference', () => {
+    it('defers arrow keys when screen nav is active', () => {
+      const intents = makeIntents();
+      (window as any).__dsmScreenNavActive = true;
+      render(<Harness intents={intents} />);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowUp' });
+        fireEvent.keyDown(document, { key: 'ArrowDown' });
+        fireEvent.keyDown(document, { key: 'ArrowLeft' });
+        fireEvent.keyDown(document, { key: 'ArrowRight' });
+        fireEvent.keyDown(document, { key: 'Enter' });
+        fireEvent.keyDown(document, { key: ' ' });
+      });
+
+      expect(intents.prevItem).not.toHaveBeenCalled();
+      expect(intents.nextItem).not.toHaveBeenCalled();
+      expect(intents.select).not.toHaveBeenCalled();
+    });
+
+    it('still fires Escape when screen nav is active', () => {
+      const intents = makeIntents();
+      (window as any).__dsmScreenNavActive = true;
+      render(<Harness intents={intents} />);
+
+      act(() => { fireEvent.keyDown(document, { key: 'Escape' }); });
+      expect(intents.back).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('__dsmComboEntryActive suppression', () => {
+    it('suppresses select when combo entry is active', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      (window as any).__dsmComboEntryActive = true;
+
+      act(() => { fireEvent.keyDown(document, { key: 'Enter' }); });
+      expect(intents.select).not.toHaveBeenCalled();
+    });
+
+    it('suppresses back when combo entry is active', () => {
+      const intents = makeIntents();
+      render(<Harness intents={intents} />);
+      (window as any).__dsmComboEntryActive = true;
+
+      act(() => { fireEvent.keyDown(document, { key: 'Escape' }); });
+      expect(intents.back).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DOM button bindings', () => {
+    it('binds click on #dpad-up and #dpad-down', () => {
+      const intents = makeIntents();
+      const upEl = document.createElement('div');
+      upEl.id = 'dpad-up';
+      const downEl = document.createElement('div');
+      downEl.id = 'dpad-down';
+      document.body.appendChild(upEl);
+      document.body.appendChild(downEl);
+
+      render(<Harness intents={intents} />);
+
+      act(() => {
+        upEl.click();
+        downEl.click();
+      });
+
+      expect(intents.prevItem).toHaveBeenCalledTimes(1);
+      expect(intents.nextItem).toHaveBeenCalledTimes(1);
+
+      document.body.removeChild(upEl);
+      document.body.removeChild(downEl);
+    });
+
+    it('binds click on #button-a and #button-b', () => {
+      const intents = makeIntents();
+      const aEl = document.createElement('div');
+      aEl.id = 'button-a';
+      const bEl = document.createElement('div');
+      bEl.id = 'button-b';
+      document.body.appendChild(aEl);
+      document.body.appendChild(bEl);
+
+      render(<Harness intents={intents} />);
+
+      act(() => {
+        aEl.click();
+        bEl.click();
+      });
+
+      expect(intents.select).toHaveBeenCalledTimes(1);
+      expect(intents.back).toHaveBeenCalledTimes(1);
+
+      document.body.removeChild(aEl);
+      document.body.removeChild(bEl);
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    it('removes keydown listener on unmount', () => {
+      const intents = makeIntents();
+      const { unmount } = render(<Harness intents={intents} />);
+      unmount();
+
+      act(() => { fireEvent.keyDown(document, { key: 'ArrowUp' }); });
+      expect(intents.prevItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('optional intents', () => {
+    it('works when toggleTheme and start are undefined', () => {
+      const intents: Intents = {
+        prevItem: jest.fn(),
+        nextItem: jest.fn(),
+        select: jest.fn(),
+        back: jest.fn(),
+      };
+      render(<Harness intents={intents} />);
+      // Should not throw
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Tab' });
+        fireEvent.keyDown(document, { key: 'Shift' });
+      });
+    });
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useNativeSessionBridge.test.ts
+++ b/dsm_client/frontend/src/hooks/__tests__/useNativeSessionBridge.test.ts
@@ -1,0 +1,211 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+
+const mockGetPreference = jest.fn();
+jest.mock('../../services/dsmClient', () => ({
+  dsmClient: {
+    getPreference: (...args: any[]) => mockGetPreference(...args),
+  },
+}));
+
+jest.mock('../../utils/audio', () => ({
+  AudioManager: { enabled: false },
+}));
+
+const mockApplyTheme = jest.fn();
+jest.mock('../../utils/theme', () => ({
+  applyTheme: (...args: any[]) => mockApplyTheme(...args),
+}));
+
+const mockAppRuntimeStore = {
+  setAppState: jest.fn(),
+  setError: jest.fn(),
+  setTheme: jest.fn(),
+  setSoundEnabled: jest.fn(),
+};
+jest.mock('../../runtime/appRuntimeStore', () => ({
+  appRuntimeStore: mockAppRuntimeStore,
+}));
+
+const mockUseNativeSessionStore = jest.fn();
+jest.mock('../../runtime/nativeSessionStore', () => ({
+  useNativeSessionStore: () => mockUseNativeSessionStore(),
+}));
+
+import { AudioManager } from '../../utils/audio';
+import { useNativeSessionBridge } from '../useNativeSessionBridge';
+import type { NativeSessionSnapshot } from '../../runtime/nativeSessionTypes';
+import { DEFAULT_NATIVE_SESSION } from '../../runtime/nativeSessionTypes';
+
+function makeSession(overrides: Partial<NativeSessionSnapshot> = {}): NativeSessionSnapshot {
+  return { ...DEFAULT_NATIVE_SESSION, ...overrides };
+}
+
+beforeEach(() => {
+  mockGetPreference.mockReset();
+  mockApplyTheme.mockReset();
+  mockAppRuntimeStore.setAppState.mockReset();
+  mockAppRuntimeStore.setError.mockReset();
+  mockAppRuntimeStore.setTheme.mockReset();
+  mockAppRuntimeStore.setSoundEnabled.mockReset();
+  mockGetPreference.mockResolvedValue(null);
+  (AudioManager as any).enabled = false;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useNativeSessionBridge', () => {
+  it('returns current session snapshot', () => {
+    const session = makeSession({ received: true, phase: 'wallet_ready' });
+    mockUseNativeSessionStore.mockReturnValue(session);
+
+    const { result } = renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy', 'pocket'], setThemeIndex: jest.fn() })
+    );
+
+    expect(result.current).toEqual(session);
+  });
+
+  it('maps session.phase to appState when received', () => {
+    const session = makeSession({ received: true, phase: 'wallet_ready' });
+    mockUseNativeSessionStore.mockReturnValue(session);
+
+    renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy'], setThemeIndex: jest.fn() })
+    );
+
+    expect(mockAppRuntimeStore.setAppState).toHaveBeenCalledWith('wallet_ready');
+  });
+
+  it('maps appState to "loading" when session not received', () => {
+    const session = makeSession({ received: false });
+    mockUseNativeSessionStore.mockReturnValue(session);
+
+    renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy'], setThemeIndex: jest.fn() })
+    );
+
+    expect(mockAppRuntimeStore.setAppState).toHaveBeenCalledWith('loading');
+  });
+
+  it('sets fatal_error from session', () => {
+    const session = makeSession({ received: true, phase: 'error', fatal_error: 'crash' });
+    mockUseNativeSessionStore.mockReturnValue(session);
+
+    renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy'], setThemeIndex: jest.fn() })
+    );
+
+    expect(mockAppRuntimeStore.setError).toHaveBeenCalledWith('crash');
+  });
+
+  it('applies default theme when identity not ready', async () => {
+    const session = makeSession({ received: true, identity_status: 'missing' });
+    mockUseNativeSessionStore.mockReturnValue(session);
+    const setThemeIndex = jest.fn();
+
+    renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy', 'pocket'], setThemeIndex })
+    );
+
+    await act(async () => {});
+
+    expect(mockApplyTheme).toHaveBeenCalledWith('stateboy');
+    expect(mockAppRuntimeStore.setTheme).toHaveBeenCalledWith('stateboy');
+    expect(setThemeIndex).toHaveBeenCalledWith(0);
+    expect((AudioManager as any).enabled).toBe(true);
+  });
+
+  it('loads saved theme when identity is ready', async () => {
+    mockGetPreference.mockImplementation(async (key: string) => {
+      if (key === 'ui_theme') return 'pocket';
+      if (key === 'sfx_enabled') return 'true';
+      return null;
+    });
+    const session = makeSession({ received: true, identity_status: 'ready' });
+    mockUseNativeSessionStore.mockReturnValue(session);
+    const setThemeIndex = jest.fn();
+
+    renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy', 'pocket'], setThemeIndex })
+    );
+
+    await act(async () => {});
+
+    expect(mockApplyTheme).toHaveBeenCalledWith('pocket');
+    expect(mockAppRuntimeStore.setTheme).toHaveBeenCalledWith('pocket');
+    expect(setThemeIndex).toHaveBeenCalledWith(1);
+  });
+
+  it('disables sound when sfx_enabled is "false"', async () => {
+    mockGetPreference.mockImplementation(async (key: string) => {
+      if (key === 'sfx_enabled') return 'false';
+      return null;
+    });
+    const session = makeSession({ received: true, identity_status: 'ready' });
+    mockUseNativeSessionStore.mockReturnValue(session);
+
+    renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy'], setThemeIndex: jest.fn() })
+    );
+
+    await act(async () => {});
+
+    expect(mockAppRuntimeStore.setSoundEnabled).toHaveBeenCalledWith(false);
+    expect((AudioManager as any).enabled).toBe(false);
+  });
+
+  it('falls back to stateboy when saved theme is not in themes list', async () => {
+    mockGetPreference.mockImplementation(async (key: string) => {
+      if (key === 'ui_theme') return 'nonexistent_theme';
+      return null;
+    });
+    const session = makeSession({ received: true, identity_status: 'ready' });
+    mockUseNativeSessionStore.mockReturnValue(session);
+
+    renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy', 'pocket'], setThemeIndex: jest.fn() })
+    );
+
+    await act(async () => {});
+
+    expect(mockApplyTheme).toHaveBeenCalledWith('stateboy');
+  });
+
+  it('does not apply UI prefs when session.received is false', async () => {
+    const session = makeSession({ received: false });
+    mockUseNativeSessionStore.mockReturnValue(session);
+
+    renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy'], setThemeIndex: jest.fn() })
+    );
+
+    await act(async () => {});
+
+    expect(mockApplyTheme).not.toHaveBeenCalled();
+  });
+
+  it('cancels stale async pref loads on re-render', async () => {
+    const session1 = makeSession({ received: true, identity_status: 'ready' });
+    mockUseNativeSessionStore.mockReturnValue(session1);
+
+    let resolvePref!: (v: string) => void;
+    mockGetPreference.mockReturnValue(new Promise<string>(r => { resolvePref = r; }));
+
+    const setThemeIndex = jest.fn();
+    const { unmount } = renderHook(() =>
+      useNativeSessionBridge({ themes: ['stateboy', 'pocket'], setThemeIndex })
+    );
+
+    unmount();
+    resolvePref('pocket');
+    await act(async () => {});
+
+    // After unmount, setThemeIndex should not be called with the resolved value
+    expect(setThemeIndex).not.toHaveBeenCalledWith(1);
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useThemeAssets.test.ts
+++ b/dsm_client/frontend/src/hooks/__tests__/useThemeAssets.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+import { useThemeAssets } from '../useThemeAssets';
+import type { ThemeName } from '../../utils/theme';
+
+describe('useThemeAssets', () => {
+  it('returns correct assets for stateboy theme', () => {
+    const { result } = renderHook(() => useThemeAssets('stateboy'));
+
+    expect(result.current.chameleonSrc).toBe('images/vaulthunters/chameleon-lime.gif');
+    expect(result.current.introGifSrc).toBe('images/cutscenes/stateboy.gif');
+    expect(result.current.eraTokenSrc).toBe('images/logos/era_token_gb.gif');
+    expect(result.current.btcLogoSrc).toBe('images/logos/btc-logo.gif');
+    expect(result.current.bricksSrc).toBe('images/vaulthunters/bricks2.svg');
+    expect(result.current.dsmLogoSrc).toBe('images/logos/dsm-stateboy-on-screen-logo.svg');
+  });
+
+  it('returns correct assets for berry theme', () => {
+    const { result } = renderHook(() => useThemeAssets('berry'));
+
+    expect(result.current.chameleonSrc).toBe('images/vaulthunters/chameleon-pink.GIF');
+    expect(result.current.introGifSrc).toBe('images/cutscenes/stateboy_pink.gif');
+    expect(result.current.eraTokenSrc).toBe('images/logos/era_token_gb_pink.gif');
+    expect(result.current.btcLogoSrc).toBe('images/logos/btc-logo-pink.gif');
+    expect(result.current.bricksSrc).toBe('images/vaulthunters/bricks2_pink.png');
+    expect(result.current.dsmLogoSrc).toBe('images/logos/dsm-stateboy-on-screen-logo_pink.png');
+  });
+
+  it('updates assets when theme changes', () => {
+    const { result, rerender } = renderHook(
+      ({ theme }) => useThemeAssets(theme),
+      { initialProps: { theme: 'stateboy' as ThemeName } },
+    );
+
+    expect(result.current.chameleonSrc).toBe('images/vaulthunters/chameleon-lime.gif');
+
+    rerender({ theme: 'grape' });
+
+    expect(result.current.chameleonSrc).toBe('images/vaulthunters/chameleon-purple.GIF');
+    expect(result.current.introGifSrc).toBe('images/cutscenes/stateboy_purple.gif');
+    expect(result.current.eraTokenSrc).toBe('images/logos/era_token_gb_purple.gif');
+    expect(result.current.btcLogoSrc).toBe('images/logos/btc-logo-purple.gif');
+  });
+
+  it('sets --bricks-bg CSS variable on document', () => {
+    const setProperty = jest.spyOn(document.documentElement.style, 'setProperty');
+
+    renderHook(() => useThemeAssets('teal'));
+
+    expect(setProperty).toHaveBeenCalledWith(
+      '--bricks-bg',
+      "url('images/vaulthunters/bricks2_blue.png')",
+    );
+
+    setProperty.mockRestore();
+  });
+
+  it('updates CSS variable when theme changes', () => {
+    const setProperty = jest.spyOn(document.documentElement.style, 'setProperty');
+
+    const { rerender } = renderHook(
+      ({ theme }) => useThemeAssets(theme),
+      { initialProps: { theme: 'stateboy' as ThemeName } },
+    );
+
+    rerender({ theme: 'crimson' });
+
+    expect(setProperty).toHaveBeenCalledWith(
+      '--bricks-bg',
+      "url('images/vaulthunters/bricks2_red.png')",
+    );
+
+    setProperty.mockRestore();
+  });
+
+  it('allows manual chameleon override via setChameleonSrc', () => {
+    const { result } = renderHook(() => useThemeAssets('stateboy'));
+
+    act(() => {
+      result.current.setChameleonSrc('images/custom/chameleon.gif');
+    });
+
+    expect(result.current.chameleonSrc).toBe('images/custom/chameleon.gif');
+  });
+
+  it('resets chameleon to theme-correct asset on theme change', () => {
+    const { result, rerender } = renderHook(
+      ({ theme }) => useThemeAssets(theme),
+      { initialProps: { theme: 'stateboy' as ThemeName } },
+    );
+
+    act(() => {
+      result.current.setChameleonSrc('images/custom/override.gif');
+    });
+    expect(result.current.chameleonSrc).toBe('images/custom/override.gif');
+
+    rerender({ theme: 'orange' });
+
+    expect(result.current.chameleonSrc).toBe('images/vaulthunters/chameleon-orange.gif');
+  });
+
+  it('returns all 12 themes with valid assets', () => {
+    const themes: ThemeName[] = [
+      'stateboy', 'pocket', 'light', 'berry', 'grape', 'dandelion',
+      'orange', 'teal', 'kiwi', 'greyscale', 'inverted', 'crimson',
+    ];
+
+    for (const theme of themes) {
+      const { result } = renderHook(() => useThemeAssets(theme));
+      expect(result.current.chameleonSrc).toBeTruthy();
+      expect(result.current.introGifSrc).toBeTruthy();
+      expect(result.current.eraTokenSrc).toBeTruthy();
+      expect(result.current.btcLogoSrc).toBeTruthy();
+      expect(result.current.bricksSrc).toBeTruthy();
+      expect(result.current.dsmLogoSrc).toBeTruthy();
+    }
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useWalletRefreshListener.test.tsx
+++ b/dsm_client/frontend/src/hooks/__tests__/useWalletRefreshListener.test.tsx
@@ -1,0 +1,167 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+
+jest.mock('../../bridge/bridgeEvents', () => {
+  const handlers = new Map<string, Set<Function>>();
+  return {
+    bridgeEvents: {
+      on: jest.fn((event: string, handler: Function) => {
+        const set = handlers.get(event) ?? new Set();
+        set.add(handler);
+        handlers.set(event, set);
+        return () => { set.delete(handler); };
+      }),
+      emit: jest.fn((event: string, payload: any) => {
+        const set = handlers.get(event);
+        if (set) set.forEach(fn => fn(payload));
+      }),
+      _handlers: handlers,
+    },
+  };
+});
+
+import { bridgeEvents } from '../../bridge/bridgeEvents';
+import { useWalletRefreshListener } from '../useWalletRefreshListener';
+
+const mockedBridgeEvents = bridgeEvents as any;
+
+let rafCallbacks: Array<(ts: number) => void> = [];
+let rafId = 0;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  rafId = 0;
+  (globalThis as any).requestAnimationFrame = (cb: (ts: number) => void) => {
+    rafId++;
+    rafCallbacks.push(cb);
+    return rafId;
+  };
+  (globalThis as any).cancelAnimationFrame = jest.fn();
+  mockedBridgeEvents._handlers.clear();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function flushRaf() {
+  const batch = rafCallbacks.slice();
+  rafCallbacks = [];
+  batch.forEach(cb => cb(performance.now()));
+}
+
+function Harness({ refresh, deps }: { refresh: () => Promise<void> | void; deps?: unknown[] }) {
+  useWalletRefreshListener(refresh, deps);
+  return null;
+}
+
+describe('useWalletRefreshListener', () => {
+  it('subscribes to wallet.refresh on mount', () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    render(<Harness refresh={refresh} />);
+    expect(mockedBridgeEvents.on).toHaveBeenCalledWith('wallet.refresh', expect.any(Function));
+  });
+
+  it('unsubscribes on unmount', () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    const { unmount } = render(<Harness refresh={refresh} />);
+    unmount();
+    // After unmount, emitting should not schedule new refreshes
+    mockedBridgeEvents.emit('wallet.refresh', { source: 'test' });
+    flushRaf();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('calls refresh on wallet.refresh event after RAF', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    render(<Harness refresh={refresh} />);
+
+    act(() => { mockedBridgeEvents.emit('wallet.refresh', { source: 'test' }); });
+    expect(refresh).not.toHaveBeenCalled();
+
+    await act(async () => { flushRaf(); });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces rapid events into a single RAF callback', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    render(<Harness refresh={refresh} />);
+
+    act(() => {
+      mockedBridgeEvents.emit('wallet.refresh', { source: 'ble1' });
+      mockedBridgeEvents.emit('wallet.refresh', { source: 'ble2' });
+      mockedBridgeEvents.emit('wallet.refresh', { source: 'ble3' });
+    });
+
+    await act(async () => { flushRaf(); });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('priority source bypasses cooldown', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    render(<Harness refresh={refresh} />);
+
+    // First refresh
+    act(() => { mockedBridgeEvents.emit('wallet.refresh', { source: 'ble' }); });
+    await act(async () => { flushRaf(); });
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    // Non-priority during cooldown — should be skipped
+    act(() => { mockedBridgeEvents.emit('wallet.refresh', { source: 'ble.envelope' }); });
+    await act(async () => { flushRaf(); });
+    // Still 1 because cooldown blocks it (the scheduled RAF returns early)
+
+    // Priority source — should bypass cooldown
+    act(() => { mockedBridgeEvents.emit('wallet.refresh', { source: 'wallet.send' }); });
+    await act(async () => { flushRaf(); });
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('queues another frame when refresh is still running', async () => {
+    let resolveRefresh!: () => void;
+    const refresh = jest.fn().mockReturnValue(new Promise<void>(r => { resolveRefresh = r; }));
+    render(<Harness refresh={refresh} />);
+
+    // Start first refresh
+    act(() => { mockedBridgeEvents.emit('wallet.refresh', { source: 'a' }); });
+    await act(async () => { flushRaf(); });
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    // Emit while running — should queue
+    act(() => { mockedBridgeEvents.emit('wallet.refresh', { source: 'wallet.send' }); });
+    await act(async () => { flushRaf(); });
+    // refresh is still running, so this RAF re-scheduled
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    // Complete the first refresh
+    await act(async () => { resolveRefresh(); });
+
+    // Now flush the re-scheduled RAF
+    await act(async () => { flushRaf(); });
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles refresh errors without crashing', async () => {
+    const refresh = jest.fn().mockRejectedValue(new Error('boom'));
+    render(<Harness refresh={refresh} />);
+
+    act(() => { mockedBridgeEvents.emit('wallet.refresh', { source: 'test' }); });
+    await act(async () => { flushRaf(); });
+    expect(refresh).toHaveBeenCalledTimes(1);
+    // Should not throw — error is caught
+  });
+
+  it('cancels pending RAF on unmount', () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    const { unmount } = render(<Harness refresh={refresh} />);
+
+    act(() => { mockedBridgeEvents.emit('wallet.refresh', { source: 'test' }); });
+    unmount();
+
+    expect((globalThis as any).cancelAnimationFrame).toHaveBeenCalled();
+  });
+});

--- a/dsm_client/frontend/src/hooks/__tests__/useWalletSync.test.ts
+++ b/dsm_client/frontend/src/hooks/__tests__/useWalletSync.test.ts
@@ -1,0 +1,137 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+
+const bridgeHandlers = new Map<string, Set<Function>>();
+jest.mock('../../bridge/bridgeEvents', () => ({
+  bridgeEvents: {
+    on: jest.fn((event: string, handler: Function) => {
+      const set = bridgeHandlers.get(event) ?? new Set();
+      set.add(handler);
+      bridgeHandlers.set(event, set);
+      return () => { set.delete(handler); };
+    }),
+    emit: jest.fn((event: string, payload: any) => {
+      const set = bridgeHandlers.get(event);
+      if (set) set.forEach(fn => fn(payload));
+    }),
+  },
+}));
+
+import { useWalletSync, type WalletSyncHandlers } from '../useWalletSync';
+
+function emitBridge(event: string, payload?: any) {
+  const set = bridgeHandlers.get(event);
+  if (set) set.forEach(fn => fn(payload));
+}
+
+beforeEach(() => {
+  bridgeHandlers.clear();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useWalletSync', () => {
+  it('subscribes to wallet.historyUpdated and calls onRefreshTransactions', () => {
+    const onRefreshTransactions = jest.fn();
+    const handlers: WalletSyncHandlers = {
+      onRefreshAll: jest.fn(),
+      onRefreshTransactions,
+    };
+
+    renderHook(() => useWalletSync(handlers));
+
+    act(() => { emitBridge('wallet.historyUpdated'); });
+
+    expect(onRefreshTransactions).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes to wallet.balancesUpdated and calls onRefreshBalances', () => {
+    const onRefreshBalances = jest.fn();
+    const handlers: WalletSyncHandlers = {
+      onRefreshAll: jest.fn(),
+      onRefreshBalances,
+    };
+
+    renderHook(() => useWalletSync(handlers));
+
+    act(() => { emitBridge('wallet.balancesUpdated'); });
+
+    expect(onRefreshBalances).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes to wallet.sendCommitted and calls onRefreshAll', () => {
+    const onRefreshAll = jest.fn();
+    const handlers: WalletSyncHandlers = { onRefreshAll };
+
+    renderHook(() => useWalletSync(handlers));
+
+    act(() => { emitBridge('wallet.sendCommitted'); });
+
+    expect(onRefreshAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes to identity.ready and calls onIdentityReady', () => {
+    const onIdentityReady = jest.fn();
+    const handlers: WalletSyncHandlers = {
+      onRefreshAll: jest.fn(),
+      onIdentityReady,
+    };
+
+    renderHook(() => useWalletSync(handlers));
+
+    act(() => { emitBridge('identity.ready'); });
+
+    expect(onIdentityReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips onRefreshTransactions when not provided', () => {
+    const handlers: WalletSyncHandlers = { onRefreshAll: jest.fn() };
+
+    renderHook(() => useWalletSync(handlers));
+
+    // Should not throw
+    act(() => { emitBridge('wallet.historyUpdated'); });
+  });
+
+  it('skips onRefreshBalances when not provided', () => {
+    const handlers: WalletSyncHandlers = { onRefreshAll: jest.fn() };
+
+    renderHook(() => useWalletSync(handlers));
+
+    act(() => { emitBridge('wallet.balancesUpdated'); });
+  });
+
+  it('handles async handler rejection gracefully', async () => {
+    const onRefreshAll = jest.fn().mockRejectedValue(new Error('refresh boom'));
+    const handlers: WalletSyncHandlers = { onRefreshAll };
+
+    renderHook(() => useWalletSync(handlers));
+
+    act(() => { emitBridge('wallet.sendCommitted'); });
+
+    // Wait for the rejected promise to be caught
+    await act(async () => { await new Promise(r => setTimeout(r, 10)); });
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('wallet.sendCommitted'),
+      expect.any(Error),
+    );
+  });
+
+  it('unsubscribes on unmount', () => {
+    const onRefreshAll = jest.fn();
+    const handlers: WalletSyncHandlers = { onRefreshAll };
+
+    const { unmount } = renderHook(() => useWalletSync(handlers));
+    unmount();
+
+    act(() => { emitBridge('wallet.sendCommitted'); });
+
+    expect(onRefreshAll).not.toHaveBeenCalled();
+  });
+});

--- a/dsm_client/frontend/src/services/__tests__/headerService.test.ts
+++ b/dsm_client/frontend/src/services/__tests__/headerService.test.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const mockFromBinary = jest.fn();
+
+jest.mock('../../proto/dsm_app_pb', () => ({
+  Headers: Object.assign(
+    jest.fn().mockImplementation((data: Record<string, unknown>) => data),
+    { fromBinary: mockFromBinary },
+  ),
+}));
+
+jest.mock('../../dsm/WebViewBridge', () => ({
+  queryTransportHeadersV3: jest.fn(),
+}));
+
+jest.mock('../../utils/identity', () => ({
+  checkIdentityState: jest.fn(),
+}));
+
+import { headerService, TransportHeaders } from '../headerService';
+import { queryTransportHeadersV3 } from '../../dsm/WebViewBridge';
+import { checkIdentityState } from '../../utils/identity';
+
+const mockQueryHeaders = queryTransportHeadersV3 as jest.Mock;
+const mockCheckIdentity = checkIdentityState as jest.Mock;
+
+describe('HeaderService', () => {
+  beforeEach(() => {
+    headerService.invalidateCache();
+    delete (globalThis as Record<string, unknown>).DsmBridge;
+  });
+
+  describe('isBridgeAvailable', () => {
+    it('returns false when DsmBridge is absent', () => {
+      expect(headerService.isBridgeAvailable()).toBe(false);
+    });
+
+    it('returns true when DsmBridge.__binary is true', () => {
+      (globalThis as Record<string, unknown>).DsmBridge = { __binary: true };
+      expect(headerService.isBridgeAvailable()).toBe(true);
+    });
+
+    it('returns true when DsmBridge.__callBin is a function', () => {
+      (globalThis as Record<string, unknown>).DsmBridge = { __callBin: jest.fn() };
+      expect(headerService.isBridgeAvailable()).toBe(true);
+    });
+
+    it('returns false when DsmBridge is an empty object', () => {
+      (globalThis as Record<string, unknown>).DsmBridge = {};
+      expect(headerService.isBridgeAvailable()).toBe(false);
+    });
+  });
+
+  describe('ensureBridge', () => {
+    it('throws when bridge is not available', () => {
+      expect(() => headerService.ensureBridge()).toThrow('DSM bridge not available');
+    });
+
+    it('does not throw when bridge is available', () => {
+      (globalThis as Record<string, unknown>).DsmBridge = { __binary: true };
+      expect(() => headerService.ensureBridge()).not.toThrow();
+    });
+  });
+
+  describe('invalidateCache', () => {
+    it('forces next fetchHeaders to re-fetch', async () => {
+      const devId = new Uint8Array(32).fill(0x01);
+      const chainTip = new Uint8Array(32).fill(0x02);
+
+      mockCheckIdentity.mockResolvedValue('READY');
+      mockFromBinary.mockReturnValue({
+        deviceId: devId,
+        chainTip,
+        genesisHash: null,
+        seq: 1n,
+      });
+      mockQueryHeaders.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+      await headerService.fetchHeaders();
+      expect(mockQueryHeaders).toHaveBeenCalledTimes(1);
+
+      // Cached — should not re-fetch
+      await headerService.fetchHeaders();
+      expect(mockQueryHeaders).toHaveBeenCalledTimes(1);
+
+      // Invalidate — should re-fetch
+      headerService.invalidateCache();
+      await headerService.fetchHeaders();
+      expect(mockQueryHeaders).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('fetchHeaders', () => {
+    const devId = new Uint8Array(32).fill(0xaa);
+    const chainTip = new Uint8Array(32).fill(0xbb);
+    const genesisHash = new Uint8Array(32).fill(0xcc);
+
+    it('returns transport headers on success', async () => {
+      mockCheckIdentity.mockResolvedValue('READY');
+      mockFromBinary.mockReturnValue({
+        deviceId: devId,
+        chainTip,
+        genesisHash,
+        seq: 42n,
+      });
+      mockQueryHeaders.mockResolvedValue(new Uint8Array([10, 20]));
+
+      const h = await headerService.fetchHeaders();
+      expect(h.deviceId).toEqual(devId);
+      expect(h.chainTip).toEqual(chainTip);
+      expect(h.genesisHash).toEqual(genesisHash);
+      expect(h.seq).toBe('42');
+      // Verify it's a clone, not the same reference
+      expect(h.deviceId).not.toBe(devId);
+    });
+
+    it('sets seq to "0" when proto seq is falsy', async () => {
+      mockCheckIdentity.mockResolvedValue('READY');
+      mockFromBinary.mockReturnValue({
+        deviceId: devId,
+        chainTip,
+        genesisHash: null,
+        seq: 0n,
+      });
+      mockQueryHeaders.mockResolvedValue(new Uint8Array([1]));
+
+      const h = await headerService.fetchHeaders();
+      expect(h.seq).toBe('0');
+      expect(h.genesisHash).toBeNull();
+    });
+
+    it('throws when identity is not ready', async () => {
+      mockCheckIdentity.mockResolvedValue('PENDING');
+      await expect(headerService.fetchHeaders()).rejects.toThrow(/identity not ready/);
+    });
+
+    it('throws when header bytes are empty', async () => {
+      mockCheckIdentity.mockResolvedValue('READY');
+      mockQueryHeaders.mockResolvedValue(new Uint8Array(0));
+      await expect(headerService.fetchHeaders()).rejects.toThrow(/empty transport headers/);
+    });
+
+    it('throws when deviceId is wrong length', async () => {
+      mockCheckIdentity.mockResolvedValue('READY');
+      mockFromBinary.mockReturnValue({
+        deviceId: new Uint8Array(16),
+        chainTip,
+        genesisHash: null,
+        seq: 0n,
+      });
+      mockQueryHeaders.mockResolvedValue(new Uint8Array([1]));
+
+      await expect(headerService.fetchHeaders()).rejects.toThrow(/invalid deviceId length/);
+    });
+
+    it('throws when chainTip is wrong length', async () => {
+      mockCheckIdentity.mockResolvedValue('READY');
+      mockFromBinary.mockReturnValue({
+        deviceId: devId,
+        chainTip: new Uint8Array(8),
+        genesisHash: null,
+        seq: 0n,
+      });
+      mockQueryHeaders.mockResolvedValue(new Uint8Array([1]));
+
+      await expect(headerService.fetchHeaders()).rejects.toThrow(/invalid chainTip length/);
+    });
+  });
+
+  describe('createPbHeaders', () => {
+    it('constructs proto Headers with all fields', () => {
+      const h: TransportHeaders = {
+        deviceId: new Uint8Array(32).fill(0xdd),
+        chainTip: new Uint8Array(32).fill(0xee),
+        genesisHash: new Uint8Array(32).fill(0xff),
+        seq: '99',
+      };
+
+      const pbH = headerService.createPbHeaders(h);
+      expect(pbH).toBeDefined();
+      expect((pbH as Record<string, unknown>).seq).toBe(99n);
+    });
+
+    it('omits genesisHash when null', () => {
+      const h: TransportHeaders = {
+        deviceId: new Uint8Array(32).fill(0x11),
+        chainTip: new Uint8Array(32).fill(0x22),
+        genesisHash: null,
+        seq: '0',
+      };
+
+      const pbH = headerService.createPbHeaders(h);
+      expect((pbH as Record<string, unknown>).genesisHash).toBeUndefined();
+    });
+  });
+});

--- a/dsm_client/frontend/src/services/__tests__/identity.test.ts
+++ b/dsm_client/frontend/src/services/__tests__/identity.test.ts
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+const mockQueryTransportHeadersV3 = jest.fn();
+jest.mock('../../dsm/WebViewBridge', () => ({
+  queryTransportHeadersV3: (...args: any[]) => mockQueryTransportHeadersV3(...args),
+}));
+
+const mockFromBinary = jest.fn();
+jest.mock('../../proto/dsm_app_pb', () => ({
+  Headers: { fromBinary: (...args: any[]) => mockFromBinary(...args) },
+}));
+
+jest.mock('../../config/network', () => ({
+  getNetworkId: () => 'dsm-local',
+}));
+
+jest.mock('../../utils/textId', () => ({
+  bytesToBase32CrockfordPrefix: jest.fn(() => 'PREVIEW_B32'),
+}));
+
+import { IdentityService, bridgeReady } from '../identity';
+
+beforeEach(() => {
+  mockQueryTransportHeadersV3.mockReset();
+  mockFromBinary.mockReset();
+  delete (globalThis as any).DsmBridge;
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('bridgeReady', () => {
+  it('returns false when DsmBridge is absent', () => {
+    expect(bridgeReady()).toBe(false);
+  });
+
+  it('returns true when __binary + sendMessageBin present', () => {
+    (globalThis as any).DsmBridge = {
+      __binary: true,
+      sendMessageBin: jest.fn(),
+    };
+    expect(bridgeReady()).toBe(true);
+  });
+
+  it('returns true when __callBin present', () => {
+    (globalThis as any).DsmBridge = { __callBin: jest.fn() };
+    expect(bridgeReady()).toBe(true);
+  });
+
+  it('returns false when DsmBridge has no known methods', () => {
+    (globalThis as any).DsmBridge = { somethingElse: true };
+    expect(bridgeReady()).toBe(false);
+  });
+});
+
+describe('IdentityService', () => {
+  let svc: IdentityService;
+
+  beforeEach(() => {
+    svc = new IdentityService();
+    (globalThis as any).DsmBridge = {
+      __binary: true,
+      sendMessageBin: jest.fn(),
+    };
+  });
+
+  describe('hasIdentity', () => {
+    it('returns false when bridge is not ready', async () => {
+      delete (globalThis as any).DsmBridge;
+      expect(await svc.hasIdentity()).toBe(false);
+    });
+
+    it('returns false when headers are empty', async () => {
+      mockQueryTransportHeadersV3.mockResolvedValue(null);
+      expect(await svc.hasIdentity()).toBe(false);
+    });
+
+    it('returns true when genesis hash has non-zero bytes', async () => {
+      const genesisHash = new Uint8Array(32);
+      genesisHash[0] = 0xFF;
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockReturnValue({ genesisHash });
+
+      expect(await svc.hasIdentity()).toBe(true);
+    });
+
+    it('returns false when genesis hash is all zeros', async () => {
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockReturnValue({ genesisHash: new Uint8Array(32) });
+
+      // Falls through to appStateGet which checks has_identity flag
+      expect(await svc.hasIdentity()).toBe(false);
+    });
+
+    it('returns false when genesis hash is wrong length', async () => {
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockReturnValue({ genesisHash: new Uint8Array(16) });
+
+      expect(await svc.hasIdentity()).toBe(false);
+    });
+
+    it('returns false when Headers.fromBinary throws', async () => {
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockImplementation(() => { throw new Error('bad proto'); });
+
+      expect(await svc.hasIdentity()).toBe(false);
+    });
+
+    it('checks appStateGet flag when genesis hash is all-zero', async () => {
+      (globalThis as any).DsmBridge.getAppStateString = jest.fn(() => 'true');
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockReturnValue({ genesisHash: new Uint8Array(32) });
+
+      expect(await svc.hasIdentity()).toBe(true);
+    });
+
+    it('returns false when appStateGet returns non-truthy', async () => {
+      (globalThis as any).DsmBridge.getAppStateString = jest.fn(() => 'false');
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockReturnValue({ genesisHash: new Uint8Array(32) });
+
+      expect(await svc.hasIdentity()).toBe(false);
+    });
+  });
+
+  describe('getIdentityInfo', () => {
+    it('throws when bridge is not ready', async () => {
+      delete (globalThis as any).DsmBridge;
+      await expect(svc.getIdentityInfo()).rejects.toThrow('DSM bridge not ready');
+    });
+
+    it('returns identity info from headers', async () => {
+      const deviceId = new Uint8Array(32).fill(0x01);
+      const chainTip = new Uint8Array(32).fill(0x02);
+      const genesisHash = new Uint8Array(32).fill(0x03);
+
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockReturnValue({ deviceId, chainTip, genesisHash });
+
+      const info = await svc.getIdentityInfo();
+
+      expect(info.deviceId).toEqual(deviceId);
+      expect(info.chainTip).toEqual(chainTip);
+      expect(info.genesisHash).toEqual(genesisHash);
+      expect(info.networkId).toBe('dsm-local');
+      expect(typeof info.locale).toBe('string');
+    });
+
+    it('returns defaults when headers are missing', async () => {
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockReturnValue({});
+
+      const info = await svc.getIdentityInfo();
+
+      expect(info.deviceId).toEqual(new Uint8Array(32));
+      expect(info.chainTip).toEqual(new Uint8Array(32));
+      expect(info.genesisHash).toBeUndefined();
+    });
+
+    it('returns default info when transport throws', async () => {
+      mockQueryTransportHeadersV3.mockRejectedValue(new Error('transport fail'));
+
+      const info = await svc.getIdentityInfo();
+
+      expect(info.deviceId).toEqual(new Uint8Array(32));
+      expect(info.chainTip).toEqual(new Uint8Array(32));
+      expect(info.genesisHash).toBeUndefined();
+      expect(info.networkId).toBe('dsm-local');
+    });
+
+    it('returns default info when fromBinary throws', async () => {
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1, 2, 3]));
+      mockFromBinary.mockImplementation(() => { throw new Error('bad proto'); });
+
+      const info = await svc.getIdentityInfo();
+
+      expect(info.deviceId).toEqual(new Uint8Array(32));
+      expect(info.genesisHash).toBeUndefined();
+    });
+
+    it('ignores genesisHash with wrong length', async () => {
+      mockQueryTransportHeadersV3.mockResolvedValue(new Uint8Array([1]));
+      mockFromBinary.mockReturnValue({
+        deviceId: new Uint8Array(32),
+        chainTip: new Uint8Array(32),
+        genesisHash: new Uint8Array(16),
+      });
+
+      const info = await svc.getIdentityInfo();
+
+      expect(info.genesisHash).toBeUndefined();
+    });
+  });
+});

--- a/dsm_client/frontend/src/services/__tests__/telemetry.test.ts
+++ b/dsm_client/frontend/src/services/__tests__/telemetry.test.ts
@@ -1,0 +1,152 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+const mockCallBin = jest.fn();
+const mockGetPreference = jest.fn();
+const mockGetDiagnosticsLogStrict = jest.fn();
+
+jest.mock('../../dsm/WebViewBridge', () => ({
+  callBin: (...args: any[]) => mockCallBin(...args),
+  getPreference: (...args: any[]) => mockGetPreference(...args),
+  getDiagnosticsLogStrict: (...args: any[]) => mockGetDiagnosticsLogStrict(...args),
+}));
+
+// Lazily mock proto only when the fallback path is reached
+const mockPbToBinary = jest.fn(() => new Uint8Array([99]));
+jest.mock('../../proto/dsm_app_pb', () => ({
+  BridgeRpcRequest: jest.fn().mockImplementation(() => ({
+    toBinary: mockPbToBinary,
+  })),
+  BytesPayload: jest.fn().mockImplementation((args: any) => args),
+}));
+
+import { sendDiagnostics, hasUserConsentFromPrefs, exportDiagnosticsReport, DIAGNOSTICS_LOG_METHOD } from '../telemetry';
+
+beforeEach(() => {
+  mockCallBin.mockReset();
+  mockGetPreference.mockReset();
+  mockGetDiagnosticsLogStrict.mockReset();
+  mockPbToBinary.mockClear();
+  delete (window as any).DsmBridge;
+  delete (window as any).dsmBridge;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('DIAGNOSTICS_LOG_METHOD', () => {
+  it('exports the correct method name', () => {
+    expect(DIAGNOSTICS_LOG_METHOD).toBe('diagnosticsLog');
+  });
+});
+
+describe('sendDiagnostics', () => {
+  it('returns immediately when consent is false', async () => {
+    await sendDiagnostics('test payload', false);
+    expect(mockCallBin).not.toHaveBeenCalled();
+  });
+
+  it('returns immediately when consent defaults (no second arg)', async () => {
+    await sendDiagnostics('test payload');
+    expect(mockCallBin).not.toHaveBeenCalled();
+  });
+
+  it('sends via callBin when available and consent is true', async () => {
+    mockCallBin.mockResolvedValue(undefined);
+    await sendDiagnostics('diagnostic data', true);
+
+    expect(mockCallBin).toHaveBeenCalledTimes(1);
+    expect(mockCallBin.mock.calls[0][0]).toBe(DIAGNOSTICS_LOG_METHOD);
+    const sentBytes = mockCallBin.mock.calls[0][1];
+    expect(new TextDecoder().decode(sentBytes)).toBe('diagnostic data');
+  });
+
+  it('falls back to DsmBridge.__callBin when callBin is unavailable', async () => {
+    // Make callBin throw to trigger fallback
+    mockCallBin.mockImplementation(() => { throw new Error('not available'); });
+
+    const mockBridgeCallBin = jest.fn().mockResolvedValue(undefined);
+    (window as any).DsmBridge = { __callBin: mockBridgeCallBin };
+
+    await sendDiagnostics('data', true);
+
+    expect(mockBridgeCallBin).toHaveBeenCalled();
+  });
+
+  it('falls back to postMessage when __callBin is unavailable', async () => {
+    mockCallBin.mockImplementation(() => { throw new Error('not available'); });
+
+    const mockPostMessage = jest.fn();
+    (window as any).DsmBridge = { postMessage: mockPostMessage };
+
+    await sendDiagnostics('data', true);
+
+    expect(mockPostMessage).toHaveBeenCalled();
+  });
+
+  it('silently swallows all errors', async () => {
+    mockCallBin.mockImplementation(() => { throw new Error('fail'); });
+    (window as any).DsmBridge = {
+      __callBin: () => { throw new Error('also fail'); },
+    };
+
+    // Should not throw
+    await sendDiagnostics('data', true);
+  });
+
+  it('encodes null payload as empty string bytes', async () => {
+    mockCallBin.mockResolvedValue(undefined);
+    await sendDiagnostics(null, true);
+
+    const bytesArg = mockCallBin.mock.calls[0][1] as Uint8Array;
+    expect(new TextDecoder().decode(bytesArg)).toBe('');
+  });
+});
+
+describe('hasUserConsentFromPrefs', () => {
+  it('returns true when preference is "1"', async () => {
+    mockGetPreference.mockResolvedValue('1');
+    expect(await hasUserConsentFromPrefs()).toBe(true);
+  });
+
+  it('returns true when preference is "true"', async () => {
+    mockGetPreference.mockResolvedValue('true');
+    expect(await hasUserConsentFromPrefs()).toBe(true);
+  });
+
+  it('returns false when preference is "0"', async () => {
+    mockGetPreference.mockResolvedValue('0');
+    expect(await hasUserConsentFromPrefs()).toBe(false);
+  });
+
+  it('returns false when preference is null', async () => {
+    mockGetPreference.mockResolvedValue(null);
+    expect(await hasUserConsentFromPrefs()).toBe(false);
+  });
+
+  it('returns false on error', async () => {
+    mockGetPreference.mockRejectedValue(new Error('bridge error'));
+    expect(await hasUserConsentFromPrefs()).toBe(false);
+  });
+});
+
+describe('exportDiagnosticsReport', () => {
+  it('returns bytes from getDiagnosticsLogStrict', async () => {
+    const logBytes = new Uint8Array([10, 20, 30]);
+    mockGetDiagnosticsLogStrict.mockReturnValue(logBytes);
+
+    const result = await exportDiagnosticsReport();
+
+    expect(result).toEqual(logBytes);
+  });
+
+  it('returns empty array when getDiagnosticsLogStrict is unavailable', async () => {
+    // Dynamic import will return the mock, but getDiagnosticsLogStrict throws
+    mockGetDiagnosticsLogStrict.mockImplementation(() => { throw new Error('not available'); });
+
+    const result = await exportDiagnosticsReport();
+
+    expect(result).toEqual(new Uint8Array(0));
+  });
+});

--- a/dsm_client/frontend/src/services/__tests__/tokenService.test.ts
+++ b/dsm_client/frontend/src/services/__tests__/tokenService.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+
+jest.mock('../../dsm/index', () => ({
+  dsmClient: {
+    getAllBalances: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/tokenMeta', () => ({
+  getTokenDecimals: jest.fn((id: string) => {
+    if (!id) return 0;
+    const u = id.trim().toUpperCase();
+    if (u === 'DBTC' || u === 'BTC') return 8;
+    return 0;
+  }),
+}));
+
+import { getTokenBalance, getTokenMetadata, listTokens, createToken, transferToken } from '../tokenService';
+import { dsmClient } from '../../dsm/index';
+
+const mockGetAllBalances = dsmClient.getAllBalances as jest.Mock;
+
+describe('getTokenBalance', () => {
+  it('returns zero balance when no matching token found', async () => {
+    mockGetAllBalances.mockResolvedValue([]);
+    const result = await getTokenBalance('ERA');
+    expect(result.tokenId).toBe('ERA');
+    expect(result.balance).toBe(0);
+    expect(result.symbol).toBe('ERA');
+    expect(result.decimals).toBe(0);
+  });
+
+  it('returns balance from ledger data', async () => {
+    mockGetAllBalances.mockResolvedValue([
+      { tokenId: 'ERA', balance: '500', symbol: 'ERA' },
+    ]);
+    const result = await getTokenBalance('ERA');
+    expect(result.balance).toBe(500);
+    expect(result.symbol).toBe('ERA');
+  });
+
+  it('normalizes "era" to match "ERA" case-insensitively', async () => {
+    mockGetAllBalances.mockResolvedValue([
+      { tokenId: 'ERA', balance: '42', symbol: 'ERA' },
+    ]);
+    const result = await getTokenBalance('era');
+    expect(result.balance).toBe(42);
+  });
+
+  it('normalizes " era " with whitespace', async () => {
+    mockGetAllBalances.mockResolvedValue([
+      { tokenId: 'ERA', balance: '7', symbol: 'ERA' },
+    ]);
+    const result = await getTokenBalance(' era ');
+    expect(result.balance).toBe(7);
+  });
+
+  it('clamps balance exceeding MAX_SAFE_INTEGER', async () => {
+    const huge = (BigInt(Number.MAX_SAFE_INTEGER) + 1000n).toString();
+    mockGetAllBalances.mockResolvedValue([
+      { tokenId: 'ERA', balance: huge },
+    ]);
+    const result = await getTokenBalance('ERA');
+    expect(result.balance).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('clamps negative balance below -MAX_SAFE_INTEGER', async () => {
+    const negHuge = (-(BigInt(Number.MAX_SAFE_INTEGER) + 1000n)).toString();
+    mockGetAllBalances.mockResolvedValue([
+      { tokenId: 'ERA', balance: negHuge },
+    ]);
+    const result = await getTokenBalance('ERA');
+    expect(result.balance).toBe(-Number.MAX_SAFE_INTEGER);
+  });
+
+  it('returns correct decimals for dBTC token', async () => {
+    mockGetAllBalances.mockResolvedValue([
+      { tokenId: 'dBTC', balance: '100000000' },
+    ]);
+    const result = await getTokenBalance('dBTC');
+    expect(result.decimals).toBe(8);
+  });
+});
+
+describe('getTokenMetadata', () => {
+  it('returns ERA metadata', async () => {
+    mockGetAllBalances.mockResolvedValue([]);
+    const meta = await getTokenMetadata('ERA');
+    expect(meta.tokenId).toBe('ERA');
+    expect(meta.name).toBe('ERA Token');
+    expect(meta.symbol).toBe('ERA');
+    expect(meta.decimals).toBe(0);
+  });
+
+  it('returns generic metadata for non-ERA token', async () => {
+    mockGetAllBalances.mockResolvedValue([]);
+    const meta = await getTokenMetadata('CUSTOM');
+    expect(meta.tokenId).toBe('CUSTOM');
+    expect(meta.name).toBe('CUSTOM');
+    expect(meta.symbol).toBe('CUSTOM');
+  });
+});
+
+describe('listTokens', () => {
+  it('returns empty list when no balances', async () => {
+    mockGetAllBalances.mockResolvedValue([]);
+    const tokens = await listTokens();
+    expect(tokens).toEqual([]);
+  });
+
+  it('deduplicates tokens by id', async () => {
+    mockGetAllBalances.mockResolvedValue([
+      { tokenId: 'ERA', balance: '10', symbol: 'ERA' },
+      { tokenId: 'ERA', balance: '20', symbol: 'ERA' },
+      { tokenId: 'dBTC', balance: '5', symbol: 'dBTC' },
+    ]);
+    const tokens = await listTokens();
+    expect(tokens).toHaveLength(2);
+    expect(tokens.map((t) => t.tokenId)).toContain('ERA');
+    expect(tokens.map((t) => t.tokenId)).toContain('dBTC');
+  });
+
+  it('uses presentNameFor and presentSymbolFor', async () => {
+    mockGetAllBalances.mockResolvedValue([
+      { tokenId: 'ERA', balance: '1' },
+    ]);
+    const tokens = await listTokens();
+    expect(tokens[0].name).toBe('ERA Token');
+    expect(tokens[0].symbol).toBe('ERA');
+  });
+});
+
+describe('createToken / transferToken', () => {
+  it('createToken throws strict error', async () => {
+    await expect(createToken()).rejects.toThrow(/STRICT/);
+  });
+
+  it('transferToken throws strict error', async () => {
+    await expect(transferToken()).rejects.toThrow(/STRICT/);
+  });
+});

--- a/dsm_client/frontend/src/services/bilateral/__tests__/bilateralEventService.test.ts
+++ b/dsm_client/frontend/src/services/bilateral/__tests__/bilateralEventService.test.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+import { encodeBase32Crockford, decodeBase32Crockford } from '../../../utils/textId';
+
+const mockFromBinary = jest.fn();
+const mockToBinary = jest.fn();
+
+jest.mock('../../../proto/dsm_app_pb', () => ({
+  BilateralEventType: {
+    BILATERAL_EVENT_PREPARE_RECEIVED: 0,
+    BILATERAL_EVENT_ACCEPT_SENT: 1,
+    BILATERAL_EVENT_COMMIT_RECEIVED: 2,
+    BILATERAL_EVENT_TRANSFER_COMPLETE: 3,
+    BILATERAL_EVENT_REJECTED: 4,
+    BILATERAL_EVENT_FAILED: 5,
+  },
+  BilateralEventNotification: Object.assign(
+    jest.fn().mockImplementation((data: Record<string, unknown>) => ({
+      ...data,
+      toBinary: mockToBinary,
+    })),
+    { fromBinary: mockFromBinary },
+  ),
+}));
+
+jest.mock('../../../dsm/index', () => ({
+  acceptOfflineTransfer: jest.fn().mockResolvedValue({ success: true }),
+  rejectOfflineTransfer: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+import {
+  BilateralEventType,
+  decodeBilateralEvent,
+  encodeBilateralEventNotification,
+  acceptIncomingTransfer,
+  rejectIncomingTransfer,
+  BilateralTransferEvent,
+} from '../bilateralEventService';
+import { acceptOfflineTransfer, rejectOfflineTransfer } from '../../../dsm/index';
+
+describe('BilateralEventType', () => {
+  it('exports expected event type constants', () => {
+    expect(BilateralEventType.PREPARE_RECEIVED).toBe(0);
+    expect(BilateralEventType.ACCEPT_SENT).toBe(1);
+    expect(BilateralEventType.COMMIT_RECEIVED).toBe(2);
+    expect(BilateralEventType.TRANSFER_COMPLETE).toBe(3);
+    expect(BilateralEventType.REJECTED).toBe(4);
+    expect(BilateralEventType.FAILED).toBe(5);
+  });
+});
+
+describe('decodeBilateralEvent', () => {
+  beforeEach(() => {
+    mockFromBinary.mockReset();
+  });
+
+  it('decodes a valid notification with Uint8Array fields', () => {
+    const devId = new Uint8Array(32).fill(0xaa);
+    const commitHash = new Uint8Array(32).fill(0xbb);
+    const txHash = new Uint8Array(32).fill(0xcc);
+
+    mockFromBinary.mockReturnValue({
+      eventType: 3,
+      counterpartyDeviceId: devId,
+      commitmentHash: commitHash,
+      transactionHash: txHash,
+      amount: 100n,
+      tokenId: 'ERA',
+      status: 'complete',
+      message: 'Transfer done',
+      senderBleAddress: 'AA:BB:CC:DD:EE:FF',
+    });
+
+    const result = decodeBilateralEvent(new Uint8Array([1, 2, 3]));
+    expect(result).not.toBeNull();
+    expect(result!.eventType).toBe(3);
+    expect(result!.counterpartyDeviceId).toBe(encodeBase32Crockford(devId));
+    expect(result!.commitmentHash).toBe(encodeBase32Crockford(commitHash));
+    expect(result!.transactionHash).toBe(encodeBase32Crockford(txHash));
+    expect(result!.amount).toBe(100n);
+    expect(result!.tokenId).toBe('ERA');
+    expect(result!.status).toBe('complete');
+    expect(result!.message).toBe('Transfer done');
+    expect(result!.senderBleAddress).toBe('AA:BB:CC:DD:EE:FF');
+  });
+
+  it('returns empty base32 strings for null/empty byte fields', () => {
+    mockFromBinary.mockReturnValue({
+      eventType: 0,
+      counterpartyDeviceId: null,
+      commitmentHash: new Uint8Array(0),
+      transactionHash: undefined,
+      amount: 0n,
+      tokenId: '',
+      status: 'pending',
+      message: '',
+      senderBleAddress: '',
+    });
+
+    const result = decodeBilateralEvent(new Uint8Array([0]));
+    expect(result).not.toBeNull();
+    expect(result!.counterpartyDeviceId).toBe('');
+    expect(result!.commitmentHash).toBe('');
+    expect(result!.transactionHash).toBe('');
+  });
+
+  it('returns null on protobuf decode failure', () => {
+    mockFromBinary.mockImplementation(() => {
+      throw new Error('bad proto');
+    });
+    expect(decodeBilateralEvent(new Uint8Array([0xff]))).toBeNull();
+  });
+});
+
+describe('encodeBilateralEventNotification', () => {
+  beforeEach(() => {
+    mockToBinary.mockReset();
+  });
+
+  it('constructs a notification and calls toBinary', () => {
+    const expected = new Uint8Array([10, 20, 30]);
+    mockToBinary.mockReturnValue(expected);
+
+    const result = encodeBilateralEventNotification({
+      eventType: BilateralEventType.ACCEPT_SENT,
+      status: 'ok',
+      message: 'accepted',
+      amount: 42n,
+      tokenId: 'ERA',
+    });
+
+    expect(result).toBe(expected);
+    expect(mockToBinary).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults empty status and message', () => {
+    mockToBinary.mockReturnValue(new Uint8Array(0));
+    encodeBilateralEventNotification({ eventType: BilateralEventType.FAILED });
+    expect(mockToBinary).toHaveBeenCalled();
+  });
+});
+
+describe('acceptIncomingTransfer', () => {
+  it('decodes base32 hashes and calls acceptOfflineTransfer', async () => {
+    const commitBytes = new Uint8Array(32).fill(0x11);
+    const devBytes = new Uint8Array(32).fill(0x22);
+    const event: BilateralTransferEvent = {
+      eventType: BilateralEventType.PREPARE_RECEIVED,
+      counterpartyDeviceId: encodeBase32Crockford(devBytes),
+      commitmentHash: encodeBase32Crockford(commitBytes),
+      status: 'pending',
+      message: '',
+    };
+
+    const result = await acceptIncomingTransfer(event);
+    expect(result).toEqual({ success: true });
+    expect(acceptOfflineTransfer).toHaveBeenCalledWith({
+      commitmentHash: expect.any(Uint8Array),
+      counterpartyDeviceId: expect.any(Uint8Array),
+    });
+  });
+
+  it('throws when commitmentHash does not decode to 32 bytes', async () => {
+    const event: BilateralTransferEvent = {
+      eventType: BilateralEventType.PREPARE_RECEIVED,
+      counterpartyDeviceId: encodeBase32Crockford(new Uint8Array(32).fill(0x33)),
+      commitmentHash: encodeBase32Crockford(new Uint8Array(5)),
+      status: '',
+      message: '',
+    };
+    await expect(acceptIncomingTransfer(event)).rejects.toThrow(/commitmentHash must decode to 32 bytes/);
+  });
+});
+
+describe('rejectIncomingTransfer', () => {
+  it('decodes base32 hashes and calls rejectOfflineTransfer', async () => {
+    const commitBytes = new Uint8Array(32).fill(0x44);
+    const devBytes = new Uint8Array(32).fill(0x55);
+    const event: BilateralTransferEvent = {
+      eventType: BilateralEventType.PREPARE_RECEIVED,
+      counterpartyDeviceId: encodeBase32Crockford(devBytes),
+      commitmentHash: encodeBase32Crockford(commitBytes),
+      status: 'pending',
+      message: '',
+    };
+
+    await rejectIncomingTransfer(event, 'user declined');
+    expect(rejectOfflineTransfer).toHaveBeenCalledWith({
+      commitmentHash: expect.any(Uint8Array),
+      counterpartyDeviceId: expect.any(Uint8Array),
+      reason: 'user declined',
+    });
+  });
+
+  it('throws when counterpartyDeviceId does not decode to 32 bytes', async () => {
+    const event: BilateralTransferEvent = {
+      eventType: BilateralEventType.PREPARE_RECEIVED,
+      counterpartyDeviceId: encodeBase32Crockford(new Uint8Array(10)),
+      commitmentHash: encodeBase32Crockford(new Uint8Array(32).fill(0x66)),
+      status: '',
+      message: '',
+    };
+    await expect(rejectIncomingTransfer(event)).rejects.toThrow(/counterpartyDeviceId must decode to 32 bytes/);
+  });
+});

--- a/dsm_client/frontend/src/services/policy/__tests__/policyDisplayService.test.ts
+++ b/dsm_client/frontend/src/services/policy/__tests__/policyDisplayService.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+import { mapPoliciesToDisplayEntries, PolicyRecord } from '../policyDisplayService';
+import { shortId, prettyAnchor } from '../../../utils/anchorDisplay';
+
+function make32(seed: number): Uint8Array {
+  const b = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) b[i] = (seed + i) & 0xff;
+  return b;
+}
+
+describe('mapPoliciesToDisplayEntries', () => {
+  it('maps a single policy with all metadata', () => {
+    const hash = make32(0x10);
+    const policies: PolicyRecord[] = [
+      {
+        alias: 'My Token',
+        ticker: 'MTK',
+        policy_hash: hash,
+        metadata: { ticker: 'MTK', alias: 'My Token', decimals: 8, maxSupply: '21000000' },
+      },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].label).toBe('MTK');
+    expect(entries[0].shortId).toBe(shortId(hash));
+    expect(entries[0].prettyAnchor).toBe(prettyAnchor(hash));
+    expect(entries[0].ticker).toBe('MTK');
+    expect(entries[0].alias).toBe('My Token');
+    expect(entries[0].decimals).toBe(8);
+    expect(entries[0].maxSupply).toBe('21000000');
+  });
+
+  it('falls back to alias/name for label when no metadata ticker', () => {
+    const hash = make32(0x20);
+    const policies: PolicyRecord[] = [
+      { alias: 'FallbackAlias', policy_hash: hash },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].label).toBe('FallbackAlias');
+  });
+
+  it('uses shortId as label when no identifier fields at all', () => {
+    const hash = make32(0x30);
+    const policies: PolicyRecord[] = [{ policy_hash: hash }];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].label).toBe(shortId(hash));
+  });
+
+  it('skips policies without any 32-byte anchor', () => {
+    const policies: PolicyRecord[] = [
+      { alias: 'NoBytesPolicy', policy_hash: null },
+      { alias: 'ShortBytes', policy_hash: new Uint8Array(16) },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(0);
+  });
+
+  it('extracts from policy_hash with nested .v field', () => {
+    const hash = make32(0x40);
+    const policies: PolicyRecord[] = [
+      { alias: 'Nested', policy_hash: { v: hash } },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].shortId).toBe(shortId(hash));
+  });
+
+  it('extracts from policy_hash with nested .value field', () => {
+    const hash = make32(0x50);
+    const policies: PolicyRecord[] = [
+      { alias: 'NestedVal', policy_hash: { value: hash } },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].shortId).toBe(shortId(hash));
+  });
+
+  it('falls back to policyHash when policy_hash is absent', () => {
+    const hash = make32(0x60);
+    const policies: PolicyRecord[] = [
+      { alias: 'AltHash', policyHash: hash },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].shortId).toBe(shortId(hash));
+  });
+
+  it('falls back to policy_commit when hashes are absent', () => {
+    const commit = make32(0x70);
+    const policies: PolicyRecord[] = [
+      { alias: 'Commit', policy_commit: commit },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].shortId).toBe(shortId(commit));
+  });
+
+  it('falls back to policyCommit when all others are absent', () => {
+    const commit = make32(0x80);
+    const policies: PolicyRecord[] = [
+      { alias: 'PCom', policyCommit: commit },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].shortId).toBe(shortId(commit));
+  });
+
+  it('handles an empty array', () => {
+    expect(mapPoliciesToDisplayEntries([])).toEqual([]);
+  });
+
+  it('handles null/undefined input', () => {
+    expect(mapPoliciesToDisplayEntries(null)).toEqual([]);
+    expect(mapPoliciesToDisplayEntries(undefined)).toEqual([]);
+  });
+
+  it('coerces { policies: [...] } wrapper objects', () => {
+    const hash = make32(0x90);
+    const wrapper = {
+      policies: [{ alias: 'Wrapped', policy_hash: hash }],
+    };
+    const entries = mapPoliciesToDisplayEntries(wrapper);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].label).toBe('Wrapped');
+  });
+
+  it('maps multiple policies preserving order', () => {
+    const h1 = make32(0xa0);
+    const h2 = make32(0xb0);
+    const policies: PolicyRecord[] = [
+      { alias: 'First', policy_hash: h1 },
+      { alias: 'Second', policy_hash: h2 },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].label).toBe('First');
+    expect(entries[1].label).toBe('Second');
+  });
+
+  it('prefers metadata.ticker over alias for label', () => {
+    const hash = make32(0xc0);
+    const policies: PolicyRecord[] = [
+      {
+        alias: 'AliasName',
+        policy_hash: hash,
+        metadata: { ticker: 'TKR' },
+      },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries[0].label).toBe('TKR');
+  });
+
+  it('uses policyId as id fallback in label chain', () => {
+    const hash = make32(0xd0);
+    const policies: PolicyRecord[] = [
+      { policyId: 'pol-123', policy_hash: hash },
+    ];
+    const entries = mapPoliciesToDisplayEntries(policies);
+    expect(entries[0].label).toBe('pol-123');
+  });
+});

--- a/dsm_client/frontend/src/services/qr/__tests__/contactQrService.test.ts
+++ b/dsm_client/frontend/src/services/qr/__tests__/contactQrService.test.ts
@@ -1,0 +1,237 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+const mockToBinary = jest.fn(() => new Uint8Array([1, 2, 3, 4]));
+const mockFromBinary = jest.fn();
+const mockContactQrV3 = jest.fn().mockImplementation(() => ({
+  toBinary: mockToBinary,
+}));
+
+jest.mock('../../../proto/dsm_app_pb', () => ({
+  ContactQrV3: Object.assign(mockContactQrV3, {
+    fromBinary: (...args: any[]) => mockFromBinary(...args),
+  }),
+}));
+
+const mockDecodeBase32 = jest.fn();
+const mockEncodeBase32 = jest.fn();
+jest.mock('../../../utils/textId', () => ({
+  decodeBase32Crockford: (...args: any[]) => mockDecodeBase32(...args),
+  encodeBase32Crockford: (...args: any[]) => mockEncodeBase32(...args),
+}));
+
+import {
+  encodeContactQrV3Payload,
+  decodeContactQrV3Payload,
+  decodeQrPayloadBase32ToText,
+} from '../contactQrService';
+
+beforeEach(() => {
+  mockToBinary.mockClear();
+  mockFromBinary.mockClear();
+  mockContactQrV3.mockClear();
+  mockDecodeBase32.mockClear();
+  mockEncodeBase32.mockClear();
+  delete (window as any).__QR_DEBUG__;
+});
+
+describe('encodeContactQrV3Payload', () => {
+  it('encodes valid 32-byte genesis hash and device id', async () => {
+    const genesisHash = new Uint8Array(32).fill(0xAA);
+    const deviceId = new Uint8Array(32).fill(0xBB);
+
+    const result = await encodeContactQrV3Payload({ genesisHash, deviceId });
+
+    expect(mockContactQrV3).toHaveBeenCalledWith(expect.objectContaining({
+      network: 'dsm-local',
+      storageNodes: [],
+    }));
+    expect(result).toEqual(new Uint8Array([1, 2, 3, 4]));
+  });
+
+  it('passes signing public key when provided', async () => {
+    const genesisHash = new Uint8Array(32).fill(0xAA);
+    const deviceId = new Uint8Array(32).fill(0xBB);
+    const signingPublicKey = new Uint8Array(64).fill(0xCC);
+
+    await encodeContactQrV3Payload({ genesisHash, deviceId, signingPublicKey });
+
+    const ctorArg = mockContactQrV3.mock.calls[0][0];
+    expect(ctorArg.signingPublicKey).toBeTruthy();
+    expect(ctorArg.signingPublicKey.length).toBe(64);
+  });
+
+  it('passes empty signing key when not provided', async () => {
+    const genesisHash = new Uint8Array(32).fill(0xAA);
+    const deviceId = new Uint8Array(32).fill(0xBB);
+
+    await encodeContactQrV3Payload({ genesisHash, deviceId });
+
+    const ctorArg = mockContactQrV3.mock.calls[0][0];
+    expect(ctorArg.signingPublicKey.length).toBe(0);
+  });
+
+  it('uses custom network when provided', async () => {
+    const genesisHash = new Uint8Array(32).fill(0xAA);
+    const deviceId = new Uint8Array(32).fill(0xBB);
+
+    await encodeContactQrV3Payload({ genesisHash, deviceId, network: 'testnet' });
+
+    const ctorArg = mockContactQrV3.mock.calls[0][0];
+    expect(ctorArg.network).toBe('testnet');
+  });
+
+  it('trims preferredAlias', async () => {
+    const genesisHash = new Uint8Array(32).fill(0xAA);
+    const deviceId = new Uint8Array(32).fill(0xBB);
+
+    await encodeContactQrV3Payload({ genesisHash, deviceId, preferredAlias: '  Alice  ' });
+
+    const ctorArg = mockContactQrV3.mock.calls[0][0];
+    expect(ctorArg.preferredAlias).toBe('Alice');
+  });
+
+  it('rejects genesis hash that is not 32 bytes', async () => {
+    const genesisHash = new Uint8Array(16);
+    const deviceId = new Uint8Array(32);
+
+    await expect(encodeContactQrV3Payload({ genesisHash, deviceId }))
+      .rejects.toThrow('genesis_hash must be 32 bytes');
+  });
+
+  it('rejects device id that is not 32 bytes', async () => {
+    const genesisHash = new Uint8Array(32);
+    const deviceId = new Uint8Array(16);
+
+    await expect(encodeContactQrV3Payload({ genesisHash, deviceId }))
+      .rejects.toThrow('device_id must be exactly 32 bytes');
+  });
+
+  it('rejects payload that exceeds max size', async () => {
+    const genesisHash = new Uint8Array(32).fill(0xAA);
+    const deviceId = new Uint8Array(32).fill(0xBB);
+    mockToBinary.mockReturnValueOnce(new Uint8Array(1000));
+
+    await expect(encodeContactQrV3Payload({ genesisHash, deviceId }))
+      .rejects.toThrow('exceeds safe limit');
+  });
+});
+
+describe('decodeContactQrV3Payload', () => {
+  it('decodes dsm:contact/v3: URI format', () => {
+    const fakeBytes = new Uint8Array([10, 20, 30]);
+    mockDecodeBase32.mockReturnValue(fakeBytes);
+    const fakeContact = {
+      deviceId: new Uint8Array(32).fill(1),
+      genesisHash: new Uint8Array(32).fill(2),
+      network: 'mainnet',
+      signingPublicKey: new Uint8Array(64).fill(3),
+      toBinary: () => new Uint8Array([99]),
+    };
+    mockFromBinary.mockReturnValue(fakeContact);
+    mockEncodeBase32.mockReturnValue('ENCODED_SPK');
+
+    const result = decodeContactQrV3Payload('dsm:contact/v3:ABCDEF');
+
+    expect(mockDecodeBase32).toHaveBeenCalledWith('ABCDEF');
+    expect(result).not.toBeNull();
+    expect(result!.contact.deviceId).toEqual(fakeContact.deviceId);
+    expect(result!.contact.genesisHash).toEqual(fakeContact.genesisHash);
+    expect(result!.contact.network).toBe('mainnet');
+    expect(result!.contact.signingPublicKeyB32).toBe('ENCODED_SPK');
+    expect(result!.contact.signingPublicKeyLength).toBe(64);
+  });
+
+  it('decodes raw base32 payload', () => {
+    mockDecodeBase32.mockReturnValue(new Uint8Array([10]));
+    mockFromBinary.mockReturnValue({
+      deviceId: new Uint8Array(32).fill(1),
+      genesisHash: new Uint8Array(32).fill(2),
+      network: '',
+      signingPublicKey: new Uint8Array(0),
+      toBinary: () => new Uint8Array([99]),
+    });
+
+    const result = decodeContactQrV3Payload('RAW_B32_PAYLOAD');
+
+    expect(mockDecodeBase32).toHaveBeenCalledWith('RAW_B32_PAYLOAD');
+    expect(result).not.toBeNull();
+    expect(result!.contact.signingPublicKeyB32).toBeUndefined();
+    expect(result!.contact.signingPublicKeyLength).toBe(0);
+  });
+
+  it('returns null for empty device id', () => {
+    mockDecodeBase32.mockReturnValue(new Uint8Array([10]));
+    mockFromBinary.mockReturnValue({
+      deviceId: new Uint8Array(0),
+      genesisHash: new Uint8Array(32).fill(2),
+      toBinary: () => new Uint8Array(0),
+    });
+
+    expect(decodeContactQrV3Payload('test')).toBeNull();
+  });
+
+  it('returns null for empty genesis hash', () => {
+    mockDecodeBase32.mockReturnValue(new Uint8Array([10]));
+    mockFromBinary.mockReturnValue({
+      deviceId: new Uint8Array(32).fill(1),
+      genesisHash: new Uint8Array(0),
+      toBinary: () => new Uint8Array(0),
+    });
+
+    expect(decodeContactQrV3Payload('test')).toBeNull();
+  });
+
+  it('returns null on decode error', () => {
+    mockDecodeBase32.mockImplementation(() => { throw new Error('bad base32'); });
+
+    expect(decodeContactQrV3Payload('invalid')).toBeNull();
+  });
+
+  it('returns null on protobuf parse error', () => {
+    mockDecodeBase32.mockReturnValue(new Uint8Array([10]));
+    mockFromBinary.mockImplementation(() => { throw new Error('bad proto'); });
+
+    expect(decodeContactQrV3Payload('test')).toBeNull();
+  });
+
+  it('treats empty network as undefined', () => {
+    mockDecodeBase32.mockReturnValue(new Uint8Array([10]));
+    mockFromBinary.mockReturnValue({
+      deviceId: new Uint8Array(32).fill(1),
+      genesisHash: new Uint8Array(32).fill(2),
+      network: '',
+      signingPublicKey: new Uint8Array(0),
+      toBinary: () => new Uint8Array([99]),
+    });
+
+    const result = decodeContactQrV3Payload('test');
+    expect(result!.contact.network).toBeUndefined();
+  });
+});
+
+describe('decodeQrPayloadBase32ToText', () => {
+  it('decodes base32 to text', () => {
+    const textBytes = new TextEncoder().encode('hello world');
+    mockDecodeBase32.mockReturnValue(textBytes);
+
+    const result = decodeQrPayloadBase32ToText('SOME_B32');
+
+    expect(result).toBe('hello world');
+  });
+
+  it('returns null on error', () => {
+    mockDecodeBase32.mockImplementation(() => { throw new Error('bad'); });
+
+    expect(decodeQrPayloadBase32ToText('invalid')).toBeNull();
+  });
+
+  it('handles empty string input', () => {
+    mockDecodeBase32.mockReturnValue(new Uint8Array(0));
+
+    const result = decodeQrPayloadBase32ToText('');
+
+    expect(result).toBe('');
+    expect(mockDecodeBase32).toHaveBeenCalledWith('');
+  });
+});

--- a/dsm_client/frontend/src/stores/__tests__/contactsStore.test.ts
+++ b/dsm_client/frontend/src/stores/__tests__/contactsStore.test.ts
@@ -1,0 +1,439 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook } from '@testing-library/react';
+
+jest.mock('../../services/dsmClient', () => ({
+  dsmClient: {
+    getContacts: jest.fn(),
+    addContact: jest.fn(),
+    updateContactStrict: jest.fn(),
+    deleteContactStrict: jest.fn(),
+  },
+}));
+
+jest.mock('../../contexts/contacts/utils', () => ({
+  parseBinary32: jest.fn((input: any) => (input instanceof Uint8Array ? input : new Uint8Array(32))),
+  parseBinary64: jest.fn((input: any) => (input instanceof Uint8Array ? input : new Uint8Array(64))),
+  bytesToDisplay: jest.fn((u8: Uint8Array) => Array.from(u8).map(b => b.toString(16).padStart(2, '0')).join('')),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  default: { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() },
+  __esModule: true,
+}));
+
+// requestAnimationFrame polyfill for awaitWithFrameBudget
+let rafCallbacks: Array<() => void> = [];
+(globalThis as any).requestAnimationFrame = (cb: () => void) => {
+  rafCallbacks.push(cb);
+  return rafCallbacks.length;
+};
+(globalThis as any).cancelAnimationFrame = jest.fn();
+
+function flushRaf(frames = 1) {
+  for (let i = 0; i < frames; i++) {
+    const batch = rafCallbacks.slice();
+    rafCallbacks = [];
+    batch.forEach(cb => cb());
+  }
+}
+
+function freshModule() {
+  jest.resetModules();
+  jest.doMock('../../services/dsmClient', () => ({
+    dsmClient: {
+      getContacts: jest.fn(),
+      addContact: jest.fn(),
+      updateContactStrict: jest.fn(),
+      deleteContactStrict: jest.fn(),
+    },
+  }));
+  jest.doMock('../../contexts/contacts/utils', () => ({
+    parseBinary32: jest.fn((input: any) => (input instanceof Uint8Array ? input : new Uint8Array(32))),
+    parseBinary64: jest.fn((input: any) => (input instanceof Uint8Array ? input : new Uint8Array(64))),
+    bytesToDisplay: jest.fn((u8: Uint8Array) => Array.from(u8).map(b => b.toString(16).padStart(2, '0')).join('')),
+  }));
+  jest.doMock('../../utils/logger', () => ({
+    default: { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() },
+    __esModule: true,
+  }));
+  const mod = require('../contactsStore');
+  const client = require('../../services/dsmClient').dsmClient;
+  return { ...mod, client };
+}
+
+function makeContact(overrides: Record<string, any> = {}) {
+  return {
+    alias: 'Alice',
+    genesisHash: 'abcd1234',
+    deviceId: 'dev001',
+    signingPublicKey: 'key123',
+    genesisVerifiedOnline: true,
+    ...overrides,
+  };
+}
+
+describe('ContactsStore', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    rafCallbacks = [];
+  });
+
+  describe('initial state', () => {
+    it('has correct defaults', () => {
+      const { contactsStore } = freshModule();
+      const s = contactsStore.getSnapshot();
+      expect(s).toEqual({ contacts: [], isLoading: false, error: null });
+    });
+  });
+
+  describe('subscribe / unsubscribe', () => {
+    it('notifies listeners and supports unsubscribe', () => {
+      const { contactsStore } = freshModule();
+      const listener = jest.fn();
+      const unsub = contactsStore.subscribe(listener);
+      contactsStore.setError('test');
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      unsub();
+      contactsStore.setError('ignored');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setError / clearContacts', () => {
+    it('sets and clears error', () => {
+      const { contactsStore } = freshModule();
+      contactsStore.setError('bad');
+      expect(contactsStore.getSnapshot().error).toBe('bad');
+      contactsStore.setError(null);
+      expect(contactsStore.getSnapshot().error).toBeNull();
+    });
+
+    it('clears contacts array', () => {
+      const { contactsStore } = freshModule();
+      contactsStore.clearContacts();
+      expect(contactsStore.getSnapshot().contacts).toEqual([]);
+    });
+  });
+
+  describe('refreshContacts()', () => {
+    it('fetches contacts and maps them', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({
+        contacts: [makeContact()],
+      });
+
+      await contactsStore.refreshContacts();
+      const s = contactsStore.getSnapshot();
+      expect(s.contacts).toHaveLength(1);
+      expect(s.contacts[0].alias).toBe('Alice');
+      expect(s.isLoading).toBe(false);
+    });
+
+    it('handles empty contacts', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({ contacts: [] });
+
+      await contactsStore.refreshContacts();
+      expect(contactsStore.getSnapshot().contacts).toEqual([]);
+    });
+
+    it('handles missing contacts field', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({});
+
+      await contactsStore.refreshContacts();
+      expect(contactsStore.getSnapshot().contacts).toEqual([]);
+    });
+
+    it('preserves existing bleAddress if new data lacks it', async () => {
+      const { contactsStore, client } = freshModule();
+      const contactWithBle = makeContact({ bleAddress: 'AA:BB:CC' });
+      client.getContacts.mockResolvedValue({ contacts: [contactWithBle] });
+      await contactsStore.refreshContacts();
+
+      // Second refresh — contact without bleAddress
+      const contactNoBle = makeContact({ bleAddress: undefined });
+      client.getContacts.mockResolvedValue({ contacts: [contactNoBle] });
+      await contactsStore.refreshContacts();
+
+      expect(contactsStore.getSnapshot().contacts[0].bleAddress).toBe('AA:BB:CC');
+    });
+
+    it('sets error on failure', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockRejectedValue(new Error('fetch fail'));
+
+      await contactsStore.refreshContacts();
+      expect(contactsStore.getSnapshot().error).toBe('fetch fail');
+    });
+
+    it('uses default message for non-Error throw', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockRejectedValue('bad');
+
+      await contactsStore.refreshContacts();
+      expect(contactsStore.getSnapshot().error).toBe('Failed to refresh contacts');
+    });
+
+    it('sets isLoading true only on first load', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({ contacts: [] });
+
+      const listener = jest.fn();
+      contactsStore.subscribe(listener);
+
+      await contactsStore.refreshContacts();
+      // First call: isLoading was set to true
+      const loadingEmits = listener.mock.calls.filter(() => true);
+      expect(loadingEmits.length).toBeGreaterThan(0);
+
+      listener.mockClear();
+      await contactsStore.refreshContacts();
+      // Second call should not set isLoading to true again (hasLoadedOnce is true)
+      // But it should still emit for error: null and contacts
+    });
+  });
+
+  describe('stale-refresh protection (sequence number)', () => {
+    it('ignores results from outdated refresh calls', async () => {
+      const { contactsStore, client } = freshModule();
+      let resolve1!: (v: any) => void;
+      let resolve2!: (v: any) => void;
+
+      client.getContacts
+        .mockReturnValueOnce(new Promise(r => { resolve1 = r; }))
+        .mockReturnValueOnce(new Promise(r => { resolve2 = r; }));
+
+      const p1 = contactsStore.refreshContacts();
+      const p2 = contactsStore.refreshContacts();
+
+      // Resolve second before first — second should win
+      resolve2({ contacts: [makeContact({ alias: 'Bob' })] });
+      await p2;
+
+      resolve1({ contacts: [makeContact({ alias: 'Stale' })] });
+      await p1;
+
+      const contacts = contactsStore.getSnapshot().contacts;
+      // The first call was stale (seq was outdated), so Bob should be the result
+      expect(contacts[0].alias).toBe('Bob');
+    });
+  });
+
+  describe('scheduleRefreshContacts()', () => {
+    it('deduplicates rapid calls via queueMicrotask', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({ contacts: [] });
+
+      contactsStore.scheduleRefreshContacts('a');
+      contactsStore.scheduleRefreshContacts('b');
+
+      // Flush microtask queue
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Only one actual refresh should have been triggered
+      expect(client.getContacts).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleBleMapped / handleBleUpdated', () => {
+    it('both schedule a refresh', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({ contacts: [] });
+
+      contactsStore.handleBleMapped({ address: 'AA' });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(client.getContacts).toHaveBeenCalledTimes(1);
+
+      // Allow the pending flag to reset
+      await new Promise(r => setTimeout(r, 0));
+
+      contactsStore.handleBleUpdated({ bleAddress: 'BB' });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(client.getContacts).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('addContact()', () => {
+    it('adds contact and refreshes', async () => {
+      const { contactsStore, client } = freshModule();
+      client.addContact.mockResolvedValue({ accepted: true });
+      client.getContacts.mockResolvedValue({ contacts: [makeContact()] });
+
+      const result = await contactsStore.addContact('Alice', new Uint8Array(32), new Uint8Array(32), new Uint8Array(64));
+      expect(result).toBe(true);
+      expect(client.addContact).toHaveBeenCalled();
+    });
+
+    it('returns false when add is not accepted', async () => {
+      const { contactsStore, client } = freshModule();
+      client.addContact.mockResolvedValue({ accepted: false, error: 'dup' });
+
+      const result = await contactsStore.addContact('A', new Uint8Array(32), new Uint8Array(32), new Uint8Array(64));
+      expect(result).toBe(false);
+      expect(contactsStore.getSnapshot().error).toBe('dup');
+    });
+
+    it('returns false when deviceId is empty', async () => {
+      const { contactsStore } = freshModule();
+      const result = await contactsStore.addContact('A', new Uint8Array(32), '', new Uint8Array(64));
+      expect(result).toBe(false);
+      expect(contactsStore.getSnapshot().error).toContain('device_id required');
+    });
+
+    it('returns false when signingPublicKey is empty', async () => {
+      const { contactsStore } = freshModule();
+      const result = await contactsStore.addContact('A', new Uint8Array(32), new Uint8Array(32), '');
+      expect(result).toBe(false);
+      expect(contactsStore.getSnapshot().error).toContain('signingPublicKey required');
+    });
+
+    it('sets isLoading false on completion', async () => {
+      const { contactsStore, client } = freshModule();
+      client.addContact.mockRejectedValue(new Error('net'));
+
+      await contactsStore.addContact('A', new Uint8Array(32), new Uint8Array(32), new Uint8Array(64));
+      expect(contactsStore.getSnapshot().isLoading).toBe(false);
+    });
+  });
+
+  describe('updateContact()', () => {
+    it('returns true on success', async () => {
+      const { contactsStore, client } = freshModule();
+      client.updateContactStrict = jest.fn().mockResolvedValue({ success: true });
+      client.getContacts.mockResolvedValue({ contacts: [] });
+
+      const result = await contactsStore.updateContact('id1', { alias: 'Bob' });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when not available', async () => {
+      const { contactsStore, client } = freshModule();
+      delete client.updateContactStrict;
+
+      const result = await contactsStore.updateContact('id1', { alias: 'Bob' });
+      expect(result).toBe(false);
+      expect(contactsStore.getSnapshot().error).toContain('not available');
+    });
+
+    it('returns false on failure result', async () => {
+      const { contactsStore, client } = freshModule();
+      client.updateContactStrict = jest.fn().mockResolvedValue({ success: false, message: 'denied' });
+
+      const result = await contactsStore.updateContact('id1', {});
+      expect(result).toBe(false);
+      expect(contactsStore.getSnapshot().error).toBe('denied');
+    });
+  });
+
+  describe('deleteContact()', () => {
+    it('returns true on success', async () => {
+      const { contactsStore, client } = freshModule();
+      client.deleteContactStrict = jest.fn().mockResolvedValue({ success: true });
+      client.getContacts.mockResolvedValue({ contacts: [] });
+
+      const result = await contactsStore.deleteContact('id1');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when not available', async () => {
+      const { contactsStore, client } = freshModule();
+      delete client.deleteContactStrict;
+
+      const result = await contactsStore.deleteContact('id1');
+      expect(result).toBe(false);
+      expect(contactsStore.getSnapshot().error).toContain('not available');
+    });
+
+    it('returns false on failure result', async () => {
+      const { contactsStore, client } = freshModule();
+      client.deleteContactStrict = jest.fn().mockResolvedValue({ success: false, message: 'nope' });
+
+      const result = await contactsStore.deleteContact('id1');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getContactByGenesisHash()', () => {
+    it('finds contact by genesis hash (case-insensitive)', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({ contacts: [makeContact({ genesisHash: 'ABCD' })] });
+      await contactsStore.refreshContacts();
+
+      const contact = contactsStore.getContactByGenesisHash('abcd');
+      expect(contact).not.toBeNull();
+      expect(contact?.alias).toBe('Alice');
+    });
+
+    it('returns null when not found', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({ contacts: [] });
+      await contactsStore.refreshContacts();
+
+      expect(contactsStore.getContactByGenesisHash('nonexistent')).toBeNull();
+    });
+  });
+
+  describe('getContactByAlias()', () => {
+    it('finds contact by alias (case-insensitive)', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({ contacts: [makeContact()] });
+      await contactsStore.refreshContacts();
+
+      const contact = contactsStore.getContactByAlias('alice');
+      expect(contact).not.toBeNull();
+    });
+
+    it('returns null when not found', () => {
+      const { contactsStore } = freshModule();
+      expect(contactsStore.getContactByAlias('nobody')).toBeNull();
+    });
+  });
+
+  describe('contact mapping edge cases', () => {
+    it('handles Uint8Array genesisHash', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({
+        contacts: [makeContact({ genesisHash: new Uint8Array([0, 1, 2]) })],
+      });
+      await contactsStore.refreshContacts();
+      expect(contactsStore.getSnapshot().contacts[0].genesisHash).toBeDefined();
+    });
+
+    it('handles missing alias', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({
+        contacts: [makeContact({ alias: undefined })],
+      });
+      await contactsStore.refreshContacts();
+      expect(contactsStore.getSnapshot().contacts[0].alias).toBe('Unknown');
+    });
+
+    it('sets isVerified from genesisVerifiedOnline', async () => {
+      const { contactsStore, client } = freshModule();
+      client.getContacts.mockResolvedValue({
+        contacts: [makeContact({ genesisVerifiedOnline: false })],
+      });
+      await contactsStore.refreshContacts();
+      expect(contactsStore.getSnapshot().contacts[0].isVerified).toBe(false);
+    });
+  });
+});
+
+// Hook tests use static imports (same React instance as @testing-library/react)
+import { useContactsStore } from '../contactsStore';
+
+describe('useContactsStore hook', () => {
+  it('returns the full snapshot', () => {
+    const { result } = renderHook(() => useContactsStore());
+    expect(result.current).toHaveProperty('contacts');
+    expect(result.current).toHaveProperty('isLoading');
+    expect(result.current).toHaveProperty('error');
+  });
+});

--- a/dsm_client/frontend/src/stores/__tests__/storageStore.test.ts
+++ b/dsm_client/frontend/src/stores/__tests__/storageStore.test.ts
@@ -1,0 +1,377 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook } from '@testing-library/react';
+
+const mockStorageNodeService = {
+  init: jest.fn().mockResolvedValue(undefined),
+  getNodesConfig: jest.fn().mockReturnValue({ nodes: [], retryPolicy: { maxRetries: 3, backoffMs: 1000 } }),
+  checkAllNodesHealth: jest.fn().mockResolvedValue([]),
+  addNode: jest.fn(),
+  removeNode: jest.fn(),
+  collectDiagnostics: jest.fn(),
+  exportDiagnostics: jest.fn().mockReturnValue(new Uint8Array(0)),
+};
+
+const mockDsmClient = {
+  getStorageStatus: jest.fn(),
+  createBackup: jest.fn(),
+  listLocalDlvs: jest.fn(),
+  checkDlvPresence: jest.fn(),
+};
+
+jest.mock('../../services/dsmClient', () => ({
+  dsmClient: mockDsmClient,
+}));
+
+jest.mock('../../services/storageNodeService', () => ({
+  storageNodeService: mockStorageNodeService,
+}));
+
+jest.mock('../../config/featureFlags', () => ({
+  isFeatureEnabled: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('../../types/storage', () => ({
+  asDisplayOnlyNumber: (n: number) => n,
+}));
+
+import { isFeatureEnabled } from '../../config/featureFlags';
+
+function freshModule() {
+  jest.resetModules();
+  jest.doMock('../../services/dsmClient', () => ({ dsmClient: mockDsmClient }));
+  jest.doMock('../../services/storageNodeService', () => ({ storageNodeService: mockStorageNodeService }));
+  jest.doMock('../../config/featureFlags', () => ({ isFeatureEnabled: jest.fn().mockResolvedValue(false) }));
+  jest.doMock('../../types/storage', () => ({ asDisplayOnlyNumber: (n: number) => n }));
+  const mod = require('../storageStore');
+  const flags = require('../../config/featureFlags');
+  return { ...mod, flags };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStorageNodeService.getNodesConfig.mockReturnValue({ nodes: [], retryPolicy: { maxRetries: 3, backoffMs: 1000 } });
+});
+
+describe('StorageStore', () => {
+  describe('initial state', () => {
+    it('has correct defaults', () => {
+      const { storageStore } = freshModule();
+      const s = storageStore.getSnapshot();
+      expect(s.storageInfo).toBeNull();
+      expect(s.overviewLoading).toBe(true);
+      expect(s.overviewError).toBeNull();
+      expect(s.dlvs).toEqual([]);
+      expect(s.presence).toEqual({});
+      expect(s.dlvLoading).toBe(true);
+      expect(s.showObjectsTab).toBe(false);
+      expect(s.nodeHealth).toEqual([]);
+      expect(s.nodeHealthLoading).toBe(true);
+      expect(s.nodeHealthRefreshing).toBe(false);
+      expect(s.diagnostics).toBeNull();
+      expect(s.diagnosticsCollecting).toBe(false);
+    });
+  });
+
+  describe('subscribe / emit', () => {
+    it('notifies listeners and unsubscribes cleanly', () => {
+      const { storageStore } = freshModule();
+      const listener = jest.fn();
+      const unsub = storageStore.subscribe(listener);
+
+      storageStore.clearDiagnostics();
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      unsub();
+      storageStore.clearDiagnostics();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('initialize()', () => {
+    it('calls storageNodeService.init and reads feature flag', async () => {
+      const { storageStore, flags } = freshModule();
+      flags.isFeatureEnabled.mockResolvedValue(true);
+
+      await storageStore.initialize();
+
+      expect(mockStorageNodeService.init).toHaveBeenCalled();
+      expect(flags.isFeatureEnabled).toHaveBeenCalledWith('storageObjectBrowser');
+      expect(storageStore.getSnapshot().showObjectsTab).toBe(true);
+    });
+
+    it('deduplicates concurrent initialize calls', async () => {
+      const { storageStore } = freshModule();
+      const p1 = storageStore.initialize();
+      const p2 = storageStore.initialize();
+      await Promise.all([p1, p2]);
+      expect(mockStorageNodeService.init).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows re-initialize after first completes', async () => {
+      const { storageStore } = freshModule();
+      await storageStore.initialize();
+      await storageStore.initialize();
+      expect(mockStorageNodeService.init).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('refreshOverview()', () => {
+    it('stores status when getStorageStatus returns data', async () => {
+      const { storageStore } = freshModule();
+      const status = { totalNodes: 3, connectedNodes: 2, lastSync: 123, dataSize: '1GB', backupStatus: 'ok' };
+      mockDsmClient.getStorageStatus.mockResolvedValue(status);
+
+      await storageStore.refreshOverview();
+      const s = storageStore.getSnapshot();
+      expect(s.storageInfo).toEqual(expect.objectContaining({ totalNodes: 3, connectedNodes: 2 }));
+      expect(s.overviewLoading).toBe(false);
+      expect(s.overviewError).toBeNull();
+    });
+
+    it('sets error when getStorageStatus is not a function', async () => {
+      const { storageStore } = freshModule();
+      delete mockDsmClient.getStorageStatus;
+
+      await storageStore.refreshOverview();
+      const s = storageStore.getSnapshot();
+      expect(s.overviewError).toBe('Storage status is not available in this build.');
+      expect(s.storageInfo).toBeNull();
+      expect(s.overviewLoading).toBe(false);
+
+      // Restore for other tests
+      mockDsmClient.getStorageStatus = jest.fn();
+    });
+
+    it('sets error when getStorageStatus returns null', async () => {
+      const { storageStore } = freshModule();
+      mockDsmClient.getStorageStatus.mockResolvedValue(null);
+
+      await storageStore.refreshOverview();
+      expect(storageStore.getSnapshot().overviewError).toBe('No storage data returned from backend.');
+    });
+
+    it('sets error on exception', async () => {
+      const { storageStore } = freshModule();
+      mockDsmClient.getStorageStatus.mockRejectedValue(new Error('network'));
+
+      await storageStore.refreshOverview();
+      expect(storageStore.getSnapshot().overviewError).toBe('Failed to load storage info.');
+    });
+  });
+
+  describe('refreshDlvsAndPresence()', () => {
+    it('loads DLVs and checks presence', async () => {
+      const { storageStore } = freshModule();
+      const dlv = { cptaAnchorHex: '0xabc' };
+      mockDsmClient.listLocalDlvs.mockResolvedValue([dlv]);
+      mockDsmClient.checkDlvPresence.mockResolvedValue({ anchor: '0xabc', observed: 2 });
+
+      await storageStore.refreshDlvsAndPresence();
+      const s = storageStore.getSnapshot();
+      expect(s.dlvs).toEqual([dlv]);
+      expect(s.presence['0xabc']).toEqual({ anchor: '0xabc', observed: 2 });
+      expect(s.dlvLoading).toBe(false);
+    });
+
+    it('handles empty DLV list', async () => {
+      const { storageStore } = freshModule();
+      mockDsmClient.listLocalDlvs.mockResolvedValue([]);
+
+      await storageStore.refreshDlvsAndPresence();
+      expect(storageStore.getSnapshot().dlvs).toEqual([]);
+    });
+
+    it('skips presence entries without anchor', async () => {
+      const { storageStore } = freshModule();
+      mockDsmClient.listLocalDlvs.mockResolvedValue([{ cptaAnchorHex: '0x1' }]);
+      mockDsmClient.checkDlvPresence.mockResolvedValue({ observed: 1 }); // no anchor
+
+      await storageStore.refreshDlvsAndPresence();
+      expect(storageStore.getSnapshot().presence).toEqual({});
+    });
+
+    it('handles listLocalDlvs returning non-array', async () => {
+      const { storageStore } = freshModule();
+      mockDsmClient.listLocalDlvs.mockResolvedValue(null);
+
+      await storageStore.refreshDlvsAndPresence();
+      expect(storageStore.getSnapshot().dlvs).toEqual([]);
+    });
+
+    it('handles error gracefully', async () => {
+      const { storageStore } = freshModule();
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockDsmClient.listLocalDlvs.mockRejectedValue(new Error('fail'));
+
+      await storageStore.refreshDlvsAndPresence();
+      expect(storageStore.getSnapshot().dlvLoading).toBe(false);
+    });
+  });
+
+  describe('refreshNodeHealth()', () => {
+    it('fetches node health metrics', async () => {
+      const { storageStore } = freshModule();
+      const health = [{ url: 'http://n1', status: 'healthy' }];
+      mockStorageNodeService.checkAllNodesHealth.mockResolvedValue(health);
+
+      await storageStore.refreshNodeHealth();
+      const s = storageStore.getSnapshot();
+      expect(s.nodeHealth).toEqual(health);
+      expect(s.nodeHealthLoading).toBe(false);
+      expect(s.nodeHealthRefreshing).toBe(false);
+    });
+
+    it('sets nodeHealthRefreshing=true when isRefresh=true', async () => {
+      const { storageStore } = freshModule();
+      const listener = jest.fn();
+      storageStore.subscribe(listener);
+      mockStorageNodeService.checkAllNodesHealth.mockResolvedValue([]);
+
+      await storageStore.refreshNodeHealth(true);
+      // First emit sets nodeHealthRefreshing to true
+      const firstCall = listener.mock.calls[0];
+      expect(storageStore.getSnapshot().nodeHealthRefreshing).toBe(false); // final
+    });
+
+    it('handles health check failure', async () => {
+      const { storageStore } = freshModule();
+      mockStorageNodeService.checkAllNodesHealth.mockRejectedValue(new Error('fail'));
+
+      await storageStore.refreshNodeHealth();
+      expect(storageStore.getSnapshot().nodeHealthLoading).toBe(false);
+    });
+  });
+
+  describe('addNode()', () => {
+    it('returns success and refreshes health', async () => {
+      const { storageStore } = freshModule();
+      mockStorageNodeService.addNode.mockResolvedValue({ success: true, assignedUrl: 'http://new' });
+      mockStorageNodeService.checkAllNodesHealth.mockResolvedValue([]);
+
+      const result = await storageStore.addNode();
+      expect(result).toEqual({ success: true, assignedUrl: 'http://new' });
+      expect(mockStorageNodeService.checkAllNodesHealth).toHaveBeenCalled();
+    });
+
+    it('returns error on failure', async () => {
+      const { storageStore } = freshModule();
+      mockStorageNodeService.addNode.mockResolvedValue({ success: false, error: 'limit' });
+
+      const result = await storageStore.addNode();
+      expect(result).toEqual({ success: false, error: 'limit' });
+    });
+  });
+
+  describe('removeNode()', () => {
+    it('returns success and refreshes health', async () => {
+      const { storageStore } = freshModule();
+      mockStorageNodeService.removeNode.mockResolvedValue({ success: true });
+      mockStorageNodeService.checkAllNodesHealth.mockResolvedValue([]);
+
+      const result = await storageStore.removeNode('http://n1');
+      expect(result).toEqual({ success: true });
+      expect(mockStorageNodeService.checkAllNodesHealth).toHaveBeenCalled();
+    });
+
+    it('returns error on failure', async () => {
+      const { storageStore } = freshModule();
+      mockStorageNodeService.removeNode.mockResolvedValue({ success: false, error: 'not found' });
+
+      const result = await storageStore.removeNode('http://n1');
+      expect(result).toEqual({ success: false, error: 'not found' });
+    });
+  });
+
+  describe('collectDiagnostics()', () => {
+    it('collects and stores diagnostics', async () => {
+      const { storageStore } = freshModule();
+      const bundle = { timestamp: 1, data: 'diag' };
+      mockStorageNodeService.collectDiagnostics.mockResolvedValue(bundle);
+
+      await storageStore.collectDiagnostics();
+      expect(storageStore.getSnapshot().diagnostics).toEqual(bundle);
+      expect(storageStore.getSnapshot().diagnosticsCollecting).toBe(false);
+    });
+
+    it('handles failure gracefully', async () => {
+      const { storageStore } = freshModule();
+      mockStorageNodeService.collectDiagnostics.mockRejectedValue(new Error('fail'));
+
+      await storageStore.collectDiagnostics();
+      expect(storageStore.getSnapshot().diagnosticsCollecting).toBe(false);
+    });
+  });
+
+  describe('clearDiagnostics()', () => {
+    it('sets diagnostics to null', async () => {
+      const { storageStore } = freshModule();
+      mockStorageNodeService.collectDiagnostics.mockResolvedValue({ data: 'x' });
+      await storageStore.collectDiagnostics();
+      storageStore.clearDiagnostics();
+      expect(storageStore.getSnapshot().diagnostics).toBeNull();
+    });
+  });
+
+  describe('exportDiagnostics()', () => {
+    it('delegates to storageNodeService', () => {
+      const { storageStore } = freshModule();
+      const bundle = { data: 'x' } as any;
+      storageStore.exportDiagnostics(bundle);
+      expect(mockStorageNodeService.exportDiagnostics).toHaveBeenCalledWith(bundle);
+    });
+  });
+
+  describe('createBackup()', () => {
+    it('returns success when backup succeeds', async () => {
+      const { storageStore } = freshModule();
+      mockDsmClient.createBackup = jest.fn().mockResolvedValue({ success: true });
+
+      const result = await storageStore.createBackup('pw');
+      expect(result).toEqual({ success: true });
+    });
+
+    it('sets error when backup not available', async () => {
+      const { storageStore } = freshModule();
+      delete mockDsmClient.createBackup;
+
+      const result = await storageStore.createBackup();
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not available');
+      expect(storageStore.getSnapshot().overviewError).toContain('not available');
+
+      mockDsmClient.createBackup = jest.fn();
+    });
+
+    it('sets error when backup returns failure', async () => {
+      const { storageStore } = freshModule();
+      mockDsmClient.createBackup = jest.fn().mockResolvedValue({ success: false, error: 'no space' });
+
+      const result = await storageStore.createBackup();
+      expect(result.success).toBe(false);
+      expect(storageStore.getSnapshot().overviewError).toBe('no space');
+    });
+
+    it('handles exception during backup', async () => {
+      const { storageStore } = freshModule();
+      mockDsmClient.createBackup = jest.fn().mockRejectedValue(new Error('boom'));
+
+      const result = await storageStore.createBackup();
+      expect(result).toEqual({ success: false, error: 'Failed to create backup.' });
+    });
+  });
+});
+
+// Hook tests use static imports (same React instance as @testing-library/react)
+import { useStorageStore } from '../storageStore';
+
+describe('useStorageStore hook', () => {
+  it('returns the full snapshot', () => {
+    const { result } = renderHook(() => useStorageStore());
+    expect(result.current).toHaveProperty('storageInfo');
+    expect(result.current).toHaveProperty('overviewLoading');
+    expect(result.current).toHaveProperty('dlvs');
+    expect(result.current).toHaveProperty('nodeHealth');
+  });
+});

--- a/dsm_client/frontend/src/stores/__tests__/walletStore.test.ts
+++ b/dsm_client/frontend/src/stores/__tests__/walletStore.test.ts
@@ -1,0 +1,355 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+
+jest.mock('../../services/dsmClient', () => ({
+  dsmClient: {
+    getIdentity: jest.fn(),
+    getAllBalances: jest.fn(),
+    getWalletHistory: jest.fn(),
+  },
+}));
+
+jest.mock('../../bridge/bridgeEvents', () => ({
+  bridgeEvents: {
+    emit: jest.fn(),
+  },
+}));
+
+import { dsmClient } from '../../services/dsmClient';
+import { bridgeEvents } from '../../bridge/bridgeEvents';
+
+const mockedClient = dsmClient as jest.Mocked<typeof dsmClient>;
+const mockedBridgeEvents = bridgeEvents as jest.Mocked<typeof bridgeEvents>;
+
+// Fresh store for each test — avoids cross-test contamination of singleton state
+function freshModule() {
+  jest.resetModules();
+  jest.doMock('../../services/dsmClient', () => ({
+    dsmClient: {
+      getIdentity: jest.fn(),
+      getAllBalances: jest.fn(),
+      getWalletHistory: jest.fn(),
+    },
+  }));
+  jest.doMock('../../bridge/bridgeEvents', () => ({
+    bridgeEvents: { emit: jest.fn() },
+  }));
+  const mod = require('../walletStore');
+  const client = require('../../services/dsmClient').dsmClient;
+  const events = require('../../bridge/bridgeEvents').bridgeEvents;
+  return { ...mod, client, events };
+}
+
+describe('WalletStore', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('has correct defaults', () => {
+      const { walletStore } = freshModule();
+      const state = walletStore.getSnapshot();
+      expect(state).toEqual({
+        genesisHash: null,
+        deviceId: null,
+        balances: [],
+        transactions: [],
+        isInitialized: false,
+        isLoading: false,
+        error: null,
+      });
+    });
+  });
+
+  describe('subscribe / emit', () => {
+    it('notifies listeners on state change', () => {
+      const { walletStore } = freshModule();
+      const listener = jest.fn();
+      walletStore.subscribe(listener);
+      walletStore.setError('boom');
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(walletStore.getSnapshot().error).toBe('boom');
+    });
+
+    it('unsubscribes correctly', () => {
+      const { walletStore } = freshModule();
+      const listener = jest.fn();
+      const unsub = walletStore.subscribe(listener);
+      unsub();
+      walletStore.setError('ignored');
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('initialize()', () => {
+    it('sets identity and isInitialized when both genesisHash and deviceId present', async () => {
+      const { walletStore, client } = freshModule();
+      client.getIdentity.mockResolvedValue({ genesisHash: 'abc', deviceId: 'dev1' });
+      client.getAllBalances.mockResolvedValue([]);
+      client.getWalletHistory.mockResolvedValue({ transactions: [] });
+
+      await walletStore.initialize();
+      const s = walletStore.getSnapshot();
+
+      expect(s.genesisHash).toBe('abc');
+      expect(s.deviceId).toBe('dev1');
+      expect(s.isInitialized).toBe(true);
+      expect(s.isLoading).toBe(false);
+      expect(s.error).toBeNull();
+    });
+
+    it('sets isInitialized false when genesisHash is missing', async () => {
+      const { walletStore, client } = freshModule();
+      client.getIdentity.mockResolvedValue({ genesisHash: null, deviceId: 'dev1' });
+
+      await walletStore.initialize();
+      expect(walletStore.getSnapshot().isInitialized).toBe(false);
+    });
+
+    it('sets isInitialized false when deviceId is missing', async () => {
+      const { walletStore, client } = freshModule();
+      client.getIdentity.mockResolvedValue({ genesisHash: 'abc', deviceId: null });
+
+      await walletStore.initialize();
+      expect(walletStore.getSnapshot().isInitialized).toBe(false);
+    });
+
+    it('stores error message on failure', async () => {
+      const { walletStore, client } = freshModule();
+      client.getIdentity.mockRejectedValue(new Error('network down'));
+
+      await walletStore.initialize();
+      const s = walletStore.getSnapshot();
+      expect(s.error).toBe('network down');
+      expect(s.isLoading).toBe(false);
+    });
+
+    it('falls back to default error message for non-Error throws', async () => {
+      const { walletStore, client } = freshModule();
+      client.getIdentity.mockRejectedValue('oops');
+
+      await walletStore.initialize();
+      expect(walletStore.getSnapshot().error).toBe('Failed to initialize wallet');
+    });
+
+    it('does not call refreshAll when not initialized', async () => {
+      const { walletStore, client } = freshModule();
+      client.getIdentity.mockResolvedValue({ genesisHash: null, deviceId: null });
+      await walletStore.initialize();
+      expect(client.getAllBalances).not.toHaveBeenCalled();
+      expect(client.getWalletHistory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('refreshBalances()', () => {
+    it('fetches and stores balances', async () => {
+      const { walletStore, client } = freshModule();
+      const balances = [{ tokenId: 'DSM', balance: 100n, tokenName: 'DSM', decimals: 0, symbol: 'DSM' }];
+      client.getAllBalances.mockResolvedValue(balances);
+
+      await walletStore.refreshBalances();
+      const s = walletStore.getSnapshot();
+      expect(s.balances).toEqual(balances);
+      expect(s.isLoading).toBe(false);
+      expect(s.error).toBeNull();
+    });
+
+    it('filters out BTC_CHAIN entries', async () => {
+      const { walletStore, client } = freshModule();
+      client.getAllBalances.mockResolvedValue([
+        { tokenId: 'BTC_CHAIN', balance: 10n },
+        { tokenId: 'DSM', balance: 50n },
+      ]);
+
+      await walletStore.refreshBalances();
+      const ids = walletStore.getSnapshot().balances.map((b: any) => b.tokenId);
+      expect(ids).toEqual(['DSM']);
+    });
+
+    it('reports partial failure when ERA fetch rejects', async () => {
+      const { walletStore, client } = freshModule();
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      client.getAllBalances.mockRejectedValue(new Error('ERA down'));
+
+      await walletStore.refreshBalances();
+      const s = walletStore.getSnapshot();
+      expect(s.error).toBe('Failed to refresh ERA balances');
+      expect(s.isLoading).toBe(false);
+    });
+
+    it('emits wallet.creditReceived when balance increases after first observation', async () => {
+      const { walletStore, client, events } = freshModule();
+      client.getAllBalances.mockResolvedValue([{ tokenId: 'DSM', balance: 100n }]);
+      await walletStore.refreshBalances(); // first call → sets hasObservedBalances
+
+      client.getAllBalances.mockResolvedValue([{ tokenId: 'DSM', balance: 200n }]);
+      await walletStore.refreshBalances();
+
+      expect(events.emit).toHaveBeenCalledWith('wallet.creditReceived', expect.objectContaining({
+        tokenId: 'DSM',
+        amount: '100',
+        creditCount: 1,
+      }));
+    });
+
+    it('does not emit creditReceived on first observation', async () => {
+      const { walletStore, client, events } = freshModule();
+      client.getAllBalances.mockResolvedValue([{ tokenId: 'DSM', balance: 100n }]);
+      await walletStore.refreshBalances();
+      expect(events.emit).not.toHaveBeenCalled();
+    });
+
+    it('does not emit creditReceived when balance decreases', async () => {
+      const { walletStore, client, events } = freshModule();
+      client.getAllBalances.mockResolvedValue([{ tokenId: 'DSM', balance: 200n }]);
+      await walletStore.refreshBalances();
+
+      client.getAllBalances.mockResolvedValue([{ tokenId: 'DSM', balance: 100n }]);
+      await walletStore.refreshBalances();
+      expect(events.emit).not.toHaveBeenCalled();
+    });
+
+    it('handles error in refreshBalances gracefully', async () => {
+      const { walletStore, client } = freshModule();
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      client.getAllBalances.mockImplementation(() => { throw new Error('crash'); });
+
+      await walletStore.refreshBalances();
+      const s = walletStore.getSnapshot();
+      expect(s.error).toBe('crash');
+      expect(s.isLoading).toBe(false);
+    });
+  });
+
+  describe('refreshTransactions()', () => {
+    it('fetches and stores transactions', async () => {
+      const { walletStore, client } = freshModule();
+      const txns = [{ txId: 'tx1', type: 'online', amount: 10n, recipient: 'r', status: 'confirmed' }];
+      client.getWalletHistory.mockResolvedValue({ transactions: txns });
+
+      await walletStore.refreshTransactions();
+      expect(walletStore.getSnapshot().transactions).toEqual(txns);
+      expect(walletStore.getSnapshot().isLoading).toBe(false);
+    });
+
+    it('stores empty array when history has no transactions field', async () => {
+      const { walletStore, client } = freshModule();
+      client.getWalletHistory.mockResolvedValue({});
+
+      await walletStore.refreshTransactions();
+      expect(walletStore.getSnapshot().transactions).toEqual([]);
+    });
+
+    it('sets error on failure', async () => {
+      const { walletStore, client } = freshModule();
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      client.getWalletHistory.mockRejectedValue(new Error('tx fail'));
+
+      await walletStore.refreshTransactions();
+      expect(walletStore.getSnapshot().error).toBe('tx fail');
+    });
+  });
+
+  describe('refreshAll()', () => {
+    it('calls both refreshBalances and refreshTransactions', async () => {
+      const { walletStore, client } = freshModule();
+      client.getAllBalances.mockResolvedValue([]);
+      client.getWalletHistory.mockResolvedValue({ transactions: [] });
+
+      await walletStore.refreshAll();
+      expect(client.getAllBalances).toHaveBeenCalled();
+      expect(client.getWalletHistory).toHaveBeenCalled();
+    });
+  });
+
+  describe('concurrent loading tracking', () => {
+    it('keeps isLoading true while any concurrent operation is still running', async () => {
+      const { walletStore, client } = freshModule();
+      let resolveBalances!: (v: any) => void;
+      let resolveTx!: (v: any) => void;
+      client.getAllBalances.mockReturnValue(new Promise(r => { resolveBalances = r; }));
+      client.getWalletHistory.mockReturnValue(new Promise(r => { resolveTx = r; }));
+
+      const allPromise = walletStore.refreshAll();
+      expect(walletStore.getSnapshot().isLoading).toBe(true);
+
+      resolveBalances([]);
+      // Wait for microtask queue to settle
+      await new Promise(r => setTimeout(r, 0));
+      // Transactions still pending → isLoading should be true
+      expect(walletStore.getSnapshot().isLoading).toBe(true);
+
+      resolveTx({ transactions: [] });
+      await allPromise;
+      expect(walletStore.getSnapshot().isLoading).toBe(false);
+    });
+  });
+
+  describe('setError()', () => {
+    it('updates error field', () => {
+      const { walletStore } = freshModule();
+      walletStore.setError('test error');
+      expect(walletStore.getSnapshot().error).toBe('test error');
+    });
+
+    it('clears error with null', () => {
+      const { walletStore } = freshModule();
+      walletStore.setError('x');
+      walletStore.setError(null);
+      expect(walletStore.getSnapshot().error).toBeNull();
+    });
+  });
+});
+
+// Hook tests use static imports (same React instance as @testing-library/react)
+import {
+  useWalletStore,
+  useWalletBalances,
+  useWalletTransactions,
+  useWalletIdentity,
+  useWalletInitialized,
+  useWalletLoading,
+  useWalletError,
+} from '../walletStore';
+
+describe('wallet store hooks', () => {
+  it('useWalletStore returns full snapshot', () => {
+    const { result } = renderHook(() => useWalletStore());
+    expect(result.current).toHaveProperty('genesisHash');
+    expect(result.current).toHaveProperty('balances');
+    expect(result.current).toHaveProperty('transactions');
+    expect(result.current).toHaveProperty('isInitialized');
+  });
+
+  it('useWalletBalances returns balances array', () => {
+    const { result } = renderHook(() => useWalletBalances());
+    expect(Array.isArray(result.current)).toBe(true);
+  });
+
+  it('useWalletTransactions returns transactions array', () => {
+    const { result } = renderHook(() => useWalletTransactions());
+    expect(Array.isArray(result.current)).toBe(true);
+  });
+
+  it('useWalletIdentity returns cached identity object', () => {
+    const { result } = renderHook(() => useWalletIdentity());
+    expect(result.current).toEqual({ genesisHash: null, deviceId: null });
+  });
+
+  it('useWalletInitialized returns boolean', () => {
+    const { result } = renderHook(() => useWalletInitialized());
+    expect(result.current).toBe(false);
+  });
+
+  it('useWalletLoading returns boolean', () => {
+    const { result } = renderHook(() => useWalletLoading());
+    expect(result.current).toBe(false);
+  });
+
+  it('useWalletError returns null initially', () => {
+    const { result } = renderHook(() => useWalletError());
+    expect(result.current).toBeNull();
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/audio.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/audio.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+import { SFX_FILE_MAP, type SfxKey } from '../audio';
+
+describe('audio SFX_FILE_MAP', () => {
+  const keys = Object.keys(SFX_FILE_MAP) as SfxKey[];
+
+  it('maps every SfxKey to a non-empty filename where defined', () => {
+    for (const k of keys) {
+      const name = SFX_FILE_MAP[k];
+      expect(name).toBeTruthy();
+      expect(name!.length).toBeGreaterThan(0);
+      expect(name).toMatch(/\.(mp3|ogg|wav)$/i);
+    }
+  });
+
+  it('covers all logical dpad and button keys', () => {
+    expect(SFX_FILE_MAP['dpad-up']).toBe('dpad_up.mp3');
+    expect(SFX_FILE_MAP['button-a']).toBe('button_a.mp3');
+    expect(SFX_FILE_MAP.start).toBe('start.mp3');
+    expect(SFX_FILE_MAP.select).toBe('select.mp3');
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/deterministicSafety.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/deterministicSafety.test.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+// eslint-env jest
+declare const describe: any;
+declare const test: any;
+declare const expect: any;
+declare const beforeEach: any;
+declare const afterEach: any;
+
+import { parseDeterministicSafety, emitDeterministicSafetyIfPresent } from '../deterministicSafety';
+import { bridgeEvents } from '../../bridge/bridgeEvents';
+
+describe('parseDeterministicSafety', () => {
+  test('returns null for null/undefined/empty', () => {
+    expect(parseDeterministicSafety(null)).toBeNull();
+    expect(parseDeterministicSafety(undefined)).toBeNull();
+    expect(parseDeterministicSafety('')).toBeNull();
+  });
+
+  test('returns null for non-matching messages', () => {
+    expect(parseDeterministicSafety('some random error')).toBeNull();
+    expect(parseDeterministicSafety('Deterministic safety')).toBeNull();
+    expect(parseDeterministicSafety('Deterministic safety rejection')).toBeNull();
+  });
+
+  test('parses a valid deterministic safety rejection message', () => {
+    const msg = 'Deterministic safety rejection [OVERFLOW]: value exceeds maximum';
+    const result = parseDeterministicSafety(msg);
+    expect(result).toEqual({
+      classification: 'OVERFLOW',
+      message: 'value exceeds maximum',
+    });
+  });
+
+  test('is case-insensitive', () => {
+    const msg = 'deterministic safety rejection [Replay]: duplicate nonce detected';
+    const result = parseDeterministicSafety(msg);
+    expect(result).toEqual({
+      classification: 'Replay',
+      message: 'duplicate nonce detected',
+    });
+  });
+
+  test('handles empty classification gracefully', () => {
+    const msg = 'Deterministic safety rejection []: some detail';
+    const result = parseDeterministicSafety(msg);
+    expect(result).toBeNull();
+  });
+
+  test('handles empty detail', () => {
+    const msg = 'Deterministic safety rejection [CRITICAL]:';
+    const result = parseDeterministicSafety(msg);
+    expect(result).toEqual({
+      classification: 'CRITICAL',
+      message: '',
+    });
+  });
+
+  test('trims classification and detail', () => {
+    const msg = 'Deterministic safety rejection [ BOUNDS ]:  out of range  ';
+    const result = parseDeterministicSafety(msg);
+    expect(result).toEqual({
+      classification: 'BOUNDS',
+      message: 'out of range',
+    });
+  });
+});
+
+describe('emitDeterministicSafetyIfPresent', () => {
+  let emitSpy: any;
+
+  beforeEach(() => {
+    emitSpy = jest.spyOn(bridgeEvents, 'emit').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    emitSpy.mockRestore();
+  });
+
+  test('returns false and does not emit for non-matching messages', () => {
+    expect(emitDeterministicSafetyIfPresent('random error')).toBe(false);
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  test('returns false for null/undefined', () => {
+    expect(emitDeterministicSafetyIfPresent(null)).toBe(false);
+    expect(emitDeterministicSafetyIfPresent(undefined)).toBe(false);
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  test('returns true and emits for valid safety rejection', () => {
+    const msg = 'Deterministic safety rejection [DOUBLE_SPEND]: already spent';
+    expect(emitDeterministicSafetyIfPresent(msg)).toBe(true);
+    expect(emitSpy).toHaveBeenCalledWith('dsm.deterministicSafety', {
+      classification: 'DOUBLE_SPEND',
+      message: 'already spent',
+    });
+  });
+
+  test('returns true even if emit throws', () => {
+    emitSpy.mockImplementation(() => { throw new Error('fail'); });
+    const msg = 'Deterministic safety rejection [ERROR]: something broke';
+    expect(emitDeterministicSafetyIfPresent(msg)).toBe(true);
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/deviceTesting.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/deviceTesting.test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+// eslint-env jest
+declare const describe: any;
+declare const test: any;
+declare const expect: any;
+declare const beforeEach: any;
+declare const afterEach: any;
+
+import { isAndroidWebView, hasDsmBridge, testBridgeConnectivity } from '../deviceTesting';
+
+describe('isAndroidWebView', () => {
+  const originalUA = navigator.userAgent;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUA,
+      configurable: true,
+    });
+  });
+
+  test('returns false when userAgent does not contain Android', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X)',
+      configurable: true,
+    });
+    expect(isAndroidWebView()).toBe(false);
+  });
+
+  test('returns true when userAgent contains Android', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36',
+      configurable: true,
+    });
+    expect(isAndroidWebView()).toBe(true);
+  });
+});
+
+describe('hasDsmBridge', () => {
+  afterEach(() => {
+    delete (window as any).DsmBridge;
+  });
+
+  test('returns false when DsmBridge is not on window', () => {
+    delete (window as any).DsmBridge;
+    expect(hasDsmBridge()).toBe(false);
+  });
+
+  test('returns true when DsmBridge is present', () => {
+    (window as any).DsmBridge = { hasIdentityDirect: () => true };
+    expect(hasDsmBridge()).toBe(true);
+  });
+});
+
+describe('testBridgeConnectivity', () => {
+  afterEach(() => {
+    delete (window as any).DsmBridge;
+  });
+
+  test('resolves false when no DsmBridge', async () => {
+    delete (window as any).DsmBridge;
+    await expect(testBridgeConnectivity()).resolves.toBe(false);
+  });
+
+  test('resolves true when bridge has hasIdentityDirect returning boolean', async () => {
+    (window as any).DsmBridge = {
+      hasIdentityDirect: () => false,
+    };
+    await expect(testBridgeConnectivity()).resolves.toBe(true);
+  });
+
+  test('resolves false when bridge lacks hasIdentityDirect', async () => {
+    (window as any).DsmBridge = {};
+    await expect(testBridgeConnectivity()).resolves.toBe(false);
+  });
+
+  test('resolves false when hasIdentityDirect returns non-boolean', async () => {
+    (window as any).DsmBridge = {
+      hasIdentityDirect: () => 'yes',
+    };
+    await expect(testBridgeConnectivity()).resolves.toBe(false);
+  });
+
+  test('resolves false when bridge throws', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    (window as any).DsmBridge = {
+      hasIdentityDirect: () => { throw new Error('broken'); },
+    };
+    await expect(testBridgeConnectivity()).resolves.toBe(false);
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/displayId.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/displayId.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+// eslint-env jest
+declare const describe: any;
+declare const test: any;
+declare const expect: any;
+
+import { displayIdentifier, shortId } from '../displayId';
+
+describe('displayIdentifier', () => {
+  test('returns a Base32 Crockford string for 32 bytes', () => {
+    const id = new Uint8Array(32).fill(0);
+    const result = displayIdentifier(id);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    expect(/^[0-9A-HJKMNP-TV-Z]+$/.test(result)).toBe(true);
+  });
+
+  test('produces different output for different inputs', () => {
+    const a = new Uint8Array(32).fill(0);
+    const b = new Uint8Array(32).fill(1);
+    expect(displayIdentifier(a)).not.toBe(displayIdentifier(b));
+  });
+
+  test('throws for non-Uint8Array', () => {
+    expect(() => displayIdentifier('hello' as any)).toThrow('must be a Uint8Array');
+    expect(() => displayIdentifier(null as any)).toThrow('must be a Uint8Array');
+    expect(() => displayIdentifier(undefined as any)).toThrow('must be a Uint8Array');
+    expect(() => displayIdentifier(42 as any)).toThrow('must be a Uint8Array');
+  });
+
+  test('throws for wrong byte length', () => {
+    expect(() => displayIdentifier(new Uint8Array(31))).toThrow('exactly 32 bytes');
+    expect(() => displayIdentifier(new Uint8Array(33))).toThrow('exactly 32 bytes');
+    expect(() => displayIdentifier(new Uint8Array(0))).toThrow('exactly 32 bytes');
+  });
+
+  test('is deterministic', () => {
+    const id = new Uint8Array(32).map((_, i) => (i * 13) & 0xff);
+    expect(displayIdentifier(id)).toBe(displayIdentifier(id));
+  });
+});
+
+describe('shortId', () => {
+  test('returns first 8 characters of the full identifier', () => {
+    const id = new Uint8Array(32).map((_, i) => (i * 7) & 0xff);
+    const full = displayIdentifier(id);
+    const short = shortId(id);
+    expect(short).toBe(full.substring(0, 8));
+    expect(short.length).toBe(8);
+  });
+
+  test('throws for invalid input (delegates to displayIdentifier)', () => {
+    expect(() => shortId(null as any)).toThrow();
+    expect(() => shortId(new Uint8Array(16))).toThrow();
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/githubIssue.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/githubIssue.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+// eslint-env jest
+declare const describe: any;
+declare const test: any;
+declare const expect: any;
+
+import {
+  DSM_RELEASE_REPO,
+  DSM_RELEASE_REPO_URL,
+  BETA_BUG_TEMPLATE,
+  BETA_FEATURE_TEMPLATE,
+  BETA_FEEDBACK_TEMPLATE,
+  buildGitHubIssueUrl,
+} from '../githubIssue';
+
+describe('exported constants', () => {
+  test('DSM_RELEASE_REPO is a valid org/repo string', () => {
+    expect(DSM_RELEASE_REPO).toBe('deterministicstatemachine/dsm');
+  });
+
+  test('DSM_RELEASE_REPO_URL points to GitHub', () => {
+    expect(DSM_RELEASE_REPO_URL).toBe('https://github.com/deterministicstatemachine/dsm');
+  });
+
+  test('template constants are .yml filenames', () => {
+    expect(BETA_BUG_TEMPLATE).toBe('bug-report-beta.yml');
+    expect(BETA_FEATURE_TEMPLATE).toBe('feature-request-beta.yml');
+    expect(BETA_FEEDBACK_TEMPLATE).toBe('general-feedback-beta.yml');
+  });
+});
+
+describe('buildGitHubIssueUrl', () => {
+  const BASE = 'https://github.com/deterministicstatemachine/dsm/issues/new';
+
+  test('returns plain new-issue URL when called with no arguments', () => {
+    expect(buildGitHubIssueUrl()).toBe(BASE);
+  });
+
+  test('returns plain new-issue URL for empty object', () => {
+    expect(buildGitHubIssueUrl({})).toBe(BASE);
+  });
+
+  test('returns plain URL when all fields are empty/whitespace', () => {
+    expect(buildGitHubIssueUrl({ title: '', body: '  ', template: undefined })).toBe(BASE);
+  });
+
+  test('includes template param', () => {
+    const url = buildGitHubIssueUrl({ template: BETA_BUG_TEMPLATE });
+    expect(url).toContain('template=bug-report-beta.yml');
+    expect(url.startsWith(BASE + '?')).toBe(true);
+  });
+
+  test('includes title param', () => {
+    const url = buildGitHubIssueUrl({ title: 'Test bug' });
+    expect(url).toContain('title=Test+bug');
+  });
+
+  test('includes body param', () => {
+    const url = buildGitHubIssueUrl({ body: 'Steps to reproduce' });
+    expect(url).toContain('body=Steps+to+reproduce');
+  });
+
+  test('includes all params together', () => {
+    const url = buildGitHubIssueUrl({
+      title: 'Bug title',
+      body: 'Bug body',
+      template: BETA_FEATURE_TEMPLATE,
+    });
+    expect(url).toContain('template=feature-request-beta.yml');
+    expect(url).toContain('title=Bug+title');
+    expect(url).toContain('body=Bug+body');
+  });
+
+  test('trims title whitespace', () => {
+    const url = buildGitHubIssueUrl({ title: '  spaced  ' });
+    expect(url).toContain('title=spaced');
+  });
+
+  test('truncates body to 6000 characters', () => {
+    const longBody = 'x'.repeat(7000);
+    const url = buildGitHubIssueUrl({ body: longBody });
+    const params = new URLSearchParams(url.split('?')[1]);
+    expect(params.get('body')!.length).toBe(6000);
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/safeJsonStringify.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/safeJsonStringify.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+import { safeJsonStringify } from '../safeJsonStringify';
+
+describe('safeJsonStringify', () => {
+  it('matches JSON.stringify for plain objects', () => {
+    expect(safeJsonStringify({ a: 1, b: 'x' })).toBe(JSON.stringify({ a: 1, b: 'x' }));
+  });
+
+  it('serializes bigint as decimal string', () => {
+    expect(safeJsonStringify({ n: 42n })).toBe('{"n":"42"}');
+  });
+
+  it('handles nested bigint', () => {
+    expect(safeJsonStringify({ inner: { v: 9007199254740993n } })).toBe(
+      '{"inner":{"v":"9007199254740993"}}',
+    );
+  });
+
+  it('handles bigint in arrays', () => {
+    expect(safeJsonStringify([1n, 2n])).toBe('["1","2"]');
+  });
+
+  it('preserves null and undefined omission behavior of JSON.stringify', () => {
+    expect(safeJsonStringify({ x: null })).toBe('{"x":null}');
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/textId.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/textId.test.ts
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+// eslint-env jest
+declare const describe: any;
+declare const test: any;
+declare const expect: any;
+declare const it: any;
+
+import {
+  normalizeBase32Crockford,
+  encodeBase32Crockford,
+  decodeBase32Crockford,
+  encodeBase32Crockford32,
+  decodeBase32Crockford32,
+  bytesToBase32CrockfordPrefix,
+} from '../textId';
+
+describe('normalizeBase32Crockford', () => {
+  test('uppercases input', () => {
+    expect(normalizeBase32Crockford('abc')).toBe('ABC');
+  });
+
+  test('strips spaces and hyphens', () => {
+    expect(normalizeBase32Crockford('AB CD-EF')).toBe('ABCDEF');
+    expect(normalizeBase32Crockford('  A-B-C  ')).toBe('ABC');
+  });
+
+  test('replaces O with 0', () => {
+    expect(normalizeBase32Crockford('O')).toBe('0');
+    expect(normalizeBase32Crockford('oOo')).toBe('000');
+  });
+
+  test('replaces I and L with 1', () => {
+    expect(normalizeBase32Crockford('I')).toBe('1');
+    expect(normalizeBase32Crockford('L')).toBe('1');
+    expect(normalizeBase32Crockford('iLl')).toBe('111');
+  });
+
+  test('returns empty string for empty/falsy input', () => {
+    expect(normalizeBase32Crockford('')).toBe('');
+  });
+
+  test('handles mixed normalizations', () => {
+    expect(normalizeBase32Crockford('a-b O I L')).toBe('AB011');
+  });
+});
+
+describe('encodeBase32Crockford', () => {
+  test('returns empty string for empty array', () => {
+    expect(encodeBase32Crockford(new Uint8Array([]))).toBe('');
+  });
+
+  test('returns empty string for null/undefined', () => {
+    expect(encodeBase32Crockford(null as any)).toBe('');
+    expect(encodeBase32Crockford(undefined as any)).toBe('');
+  });
+
+  test('encodes single byte', () => {
+    const result = encodeBase32Crockford(new Uint8Array([0]));
+    expect(result).toBe('00');
+  });
+
+  test('encodes known byte sequences', () => {
+    const bytes = new Uint8Array([0xff]);
+    const encoded = encodeBase32Crockford(bytes);
+    expect(encoded).toBe('ZW');
+
+    const hello = new TextEncoder().encode('Hello');
+    const helloEncoded = encodeBase32Crockford(hello);
+    expect(typeof helloEncoded).toBe('string');
+    expect(helloEncoded.length).toBeGreaterThan(0);
+    expect(/^[0-9A-Z]+$/.test(helloEncoded)).toBe(true);
+  });
+
+  test('output contains only Crockford alphabet characters', () => {
+    const bytes = new Uint8Array(16).map((_, i) => i * 17);
+    const encoded = encodeBase32Crockford(bytes);
+    expect(/^[0-9A-HJKMNP-TV-Z]+$/.test(encoded)).toBe(true);
+  });
+});
+
+describe('decodeBase32Crockford', () => {
+  test('returns empty array for empty string', () => {
+    const result = decodeBase32Crockford('');
+    expect(result).toEqual(new Uint8Array(0));
+  });
+
+  test('roundtrips with encode', () => {
+    const original = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const encoded = encodeBase32Crockford(original);
+    const decoded = decodeBase32Crockford(encoded);
+    expect(decoded).toEqual(original);
+  });
+
+  test('handles normalization during decode (O->0, I/L->1)', () => {
+    const encoded = encodeBase32Crockford(new Uint8Array([0]));
+    const withSubstitutions = encoded.replace(/0/g, 'O');
+    const decoded = decodeBase32Crockford(withSubstitutions);
+    expect(decoded).toEqual(new Uint8Array([0]));
+  });
+
+  test('handles spaces and hyphens', () => {
+    const original = new Uint8Array([10, 20, 30]);
+    const encoded = encodeBase32Crockford(original);
+    const withSpaces = encoded.slice(0, 2) + ' ' + encoded.slice(2);
+    const decoded = decodeBase32Crockford(withSpaces);
+    expect(decoded).toEqual(original);
+  });
+
+  test('throws on invalid characters', () => {
+    expect(() => decodeBase32Crockford('U')).toThrow(/Invalid Base32 Crockford character/);
+  });
+
+  test('roundtrips 32-byte array', () => {
+    const bytes = new Uint8Array(32).map((_, i) => i);
+    const encoded = encodeBase32Crockford(bytes);
+    const decoded = decodeBase32Crockford(encoded);
+    expect(decoded).toEqual(bytes);
+  });
+});
+
+describe('encodeBase32Crockford32', () => {
+  test('encodes exactly 32 bytes', () => {
+    const bytes = new Uint8Array(32).fill(0xab);
+    const result = encodeBase32Crockford32(bytes);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test('throws for non-32-byte input', () => {
+    expect(() => encodeBase32Crockford32(new Uint8Array(31))).toThrow('exactly 32 bytes');
+    expect(() => encodeBase32Crockford32(new Uint8Array(33))).toThrow('exactly 32 bytes');
+    expect(() => encodeBase32Crockford32(new Uint8Array(0))).toThrow('exactly 32 bytes');
+  });
+
+  test('throws for non-Uint8Array', () => {
+    expect(() => encodeBase32Crockford32('hello' as any)).toThrow('exactly 32 bytes');
+    expect(() => encodeBase32Crockford32(null as any)).toThrow('exactly 32 bytes');
+  });
+});
+
+describe('decodeBase32Crockford32', () => {
+  test('roundtrips with encodeBase32Crockford32', () => {
+    const original = new Uint8Array(32).map((_, i) => (i * 7) & 0xff);
+    const encoded = encodeBase32Crockford32(original);
+    const decoded = decodeBase32Crockford32(encoded);
+    expect(decoded).toEqual(original);
+  });
+
+  test('throws if decoded result is not 32 bytes', () => {
+    const short = encodeBase32Crockford(new Uint8Array([1, 2, 3]));
+    expect(() => decodeBase32Crockford32(short)).toThrow('exactly 32 bytes');
+  });
+});
+
+describe('bytesToBase32CrockfordPrefix', () => {
+  test('returns empty for non-Uint8Array', () => {
+    expect(bytesToBase32CrockfordPrefix(null as any, 4)).toBe('');
+    expect(bytesToBase32CrockfordPrefix('hello' as any, 4)).toBe('');
+  });
+
+  test('returns empty for zero maxBytes', () => {
+    expect(bytesToBase32CrockfordPrefix(new Uint8Array([1, 2, 3]), 0)).toBe('');
+  });
+
+  test('returns empty for negative maxBytes', () => {
+    expect(bytesToBase32CrockfordPrefix(new Uint8Array([1, 2, 3]), -1)).toBe('');
+  });
+
+  test('returns prefix of encoded bytes', () => {
+    const bytes = new Uint8Array(64).map((_, i) => i);
+    const result = bytesToBase32CrockfordPrefix(bytes, 4);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThanOrEqual(40);
+  });
+
+  test('clamps maxBytes to array length', () => {
+    const bytes = new Uint8Array([0xaa, 0xbb]);
+    const full = bytesToBase32CrockfordPrefix(bytes, 100);
+    const clamped = bytesToBase32CrockfordPrefix(bytes, 2);
+    expect(full).toBe(clamped);
+  });
+
+  test('output is capped at 40 characters', () => {
+    const bytes = new Uint8Array(128).fill(0xff);
+    const result = bytesToBase32CrockfordPrefix(bytes, 128);
+    expect(result.length).toBeLessThanOrEqual(40);
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/theme.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/theme.test.ts
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+// eslint-env jest
+declare const describe: any;
+declare const test: any;
+declare const expect: any;
+declare const beforeEach: any;
+
+import { palettes, applyTheme, getAvailableThemes, ThemeName } from '../theme';
+
+describe('palettes', () => {
+  test('every theme listed in getAvailableThemes has a palette entry', () => {
+    for (const name of getAvailableThemes()) {
+      expect(palettes[name]).toBeDefined();
+    }
+  });
+
+  test('every palette has required CSS variable keys', () => {
+    const requiredKeys = ['--bg', '--bg-secondary', '--text', '--text-dark', '--border'];
+    for (const [name, vars] of Object.entries(palettes)) {
+      for (const key of requiredKeys) {
+        expect(vars[key]).toBeDefined();
+      }
+    }
+  });
+
+  test('all palette colour values look like CSS colours', () => {
+    const colorRegex = /^#[0-9a-fA-F]{3,8}$/;
+    const rgbRegex = /^\d{1,3},\d{1,3},\d{1,3}$/;
+    for (const [, vars] of Object.entries(palettes)) {
+      for (const [key, value] of Object.entries(vars)) {
+        expect(colorRegex.test(value) || rgbRegex.test(value)).toBe(true);
+      }
+    }
+  });
+});
+
+describe('getAvailableThemes', () => {
+  test('returns an array of theme names', () => {
+    const themes = getAvailableThemes();
+    expect(Array.isArray(themes)).toBe(true);
+    expect(themes.length).toBeGreaterThan(0);
+  });
+
+  test('includes stateboy as the first theme', () => {
+    expect(getAvailableThemes()[0]).toBe('stateboy');
+  });
+
+  test('includes all known themes', () => {
+    const themes = getAvailableThemes();
+    expect(themes).toContain('stateboy');
+    expect(themes).toContain('pocket');
+    expect(themes).toContain('light');
+    expect(themes).toContain('inverted');
+    expect(themes).toContain('crimson');
+  });
+
+  test('has no duplicates', () => {
+    const themes = getAvailableThemes();
+    expect(new Set(themes).size).toBe(themes.length);
+  });
+});
+
+describe('applyTheme', () => {
+  beforeEach(() => {
+    document.documentElement.style.cssText = '';
+    document.body.innerHTML = '';
+  });
+
+  test('sets CSS variables on document.documentElement', () => {
+    applyTheme('stateboy');
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--bg')).toBe('#9bbc0f');
+    expect(root.style.getPropertyValue('--text')).toBe('#0f380f');
+  });
+
+  test('sets --nav-lit-color to the theme --bg value', () => {
+    applyTheme('berry');
+    expect(document.documentElement.style.getPropertyValue('--nav-lit-color')).toBe('#e8a2bf');
+  });
+
+  test('applies a different theme with different values', () => {
+    applyTheme('inverted');
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--bg')).toBe('#252525');
+    expect(root.style.getPropertyValue('--text')).toBe('#bec4b5');
+  });
+
+  test('sets data-theme on .stateboy element if present', () => {
+    const shell = document.createElement('div');
+    shell.className = 'stateboy';
+    document.body.appendChild(shell);
+
+    applyTheme('grape');
+    expect(shell.getAttribute('data-theme')).toBe('grape');
+  });
+
+  test('sets data-theme on #dsm-app-root if present', () => {
+    const appRoot = document.createElement('div');
+    appRoot.id = 'dsm-app-root';
+    document.body.appendChild(appRoot);
+
+    applyTheme('teal');
+    expect(appRoot.getAttribute('data-theme')).toBe('teal');
+  });
+
+  test('falls back to stateboy for invalid theme name', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    applyTheme('nonexistent' as ThemeName);
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--bg')).toBe('#9bbc0f');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/time.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/time.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+// eslint-env jest
+declare const describe: any;
+declare const test: any;
+declare const expect: any;
+
+import { formatTimeAgo, formatDateTime } from '../time';
+
+describe('formatTimeAgo', () => {
+  const nowSec = () => Math.floor(Date.now() / 1000);
+
+  test('returns empty string for 0', () => {
+    expect(formatTimeAgo(0)).toBe('');
+  });
+
+  test('returns empty string for negative values', () => {
+    expect(formatTimeAgo(-1)).toBe('');
+    expect(formatTimeAgo(-9999)).toBe('');
+  });
+
+  test('returns empty string for NaN/falsy', () => {
+    expect(formatTimeAgo(NaN)).toBe('');
+    expect(formatTimeAgo(undefined as any)).toBe('');
+    expect(formatTimeAgo(null as any)).toBe('');
+  });
+
+  test('returns "Just now" for timestamps within the last 60 seconds', () => {
+    expect(formatTimeAgo(nowSec())).toBe('Just now');
+    expect(formatTimeAgo(nowSec() - 30)).toBe('Just now');
+    expect(formatTimeAgo(nowSec() - 59)).toBe('Just now');
+  });
+
+  test('returns minutes ago for timestamps within the last hour', () => {
+    const result = formatTimeAgo(nowSec() - 120);
+    expect(result).toBe('2m ago');
+
+    const result2 = formatTimeAgo(nowSec() - 3540);
+    expect(result2).toBe('59m ago');
+  });
+
+  test('returns hours ago for timestamps within the last day', () => {
+    const result = formatTimeAgo(nowSec() - 7200);
+    expect(result).toBe('2h ago');
+  });
+
+  test('returns "Yesterday" for timestamps 24-48h ago', () => {
+    expect(formatTimeAgo(nowSec() - 86400)).toBe('Yesterday');
+    expect(formatTimeAgo(nowSec() - 100000)).toBe('Yesterday');
+  });
+
+  test('returns a formatted date for older timestamps', () => {
+    const threeDaysAgo = nowSec() - 3 * 86400;
+    const result = formatTimeAgo(threeDaysAgo);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).not.toBe('Yesterday');
+    expect(result).not.toContain('ago');
+  });
+});
+
+describe('formatDateTime', () => {
+  test('returns "Unknown" for 0', () => {
+    expect(formatDateTime(0)).toBe('Unknown');
+  });
+
+  test('returns "Unknown" for negative values', () => {
+    expect(formatDateTime(-1)).toBe('Unknown');
+  });
+
+  test('returns "Unknown" for falsy values', () => {
+    expect(formatDateTime(NaN)).toBe('Unknown');
+    expect(formatDateTime(undefined as any)).toBe('Unknown');
+    expect(formatDateTime(null as any)).toBe('Unknown');
+  });
+
+  test('returns a formatted date/time string for valid timestamps', () => {
+    const ts = Math.floor(new Date('2024-06-15T12:30:00Z').getTime() / 1000);
+    const result = formatDateTime(ts);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('2024');
+    expect(result).toContain('15');
+  });
+});

--- a/dsm_client/frontend/src/utils/__tests__/tokenMeta.test.ts
+++ b/dsm_client/frontend/src/utils/__tests__/tokenMeta.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// SPDX-License-Identifier: Apache-2.0
+// eslint-env jest
+declare const describe: any;
+declare const test: any;
+declare const expect: any;
+declare const it: any;
+
+import { getTokenDecimals, formatTokenAmount, formatSignedTokenAmount } from '../tokenMeta';
+
+describe('getTokenDecimals', () => {
+  test('returns 8 for dBTC (case-insensitive)', () => {
+    expect(getTokenDecimals('DBTC')).toBe(8);
+    expect(getTokenDecimals('dbtc')).toBe(8);
+    expect(getTokenDecimals('Dbtc')).toBe(8);
+  });
+
+  test('returns 8 for BTC', () => {
+    expect(getTokenDecimals('BTC')).toBe(8);
+    expect(getTokenDecimals('btc')).toBe(8);
+  });
+
+  test('returns 0 for unknown tokens', () => {
+    expect(getTokenDecimals('ERA')).toBe(0);
+    expect(getTokenDecimals('UNKNOWN')).toBe(0);
+    expect(getTokenDecimals('foo')).toBe(0);
+  });
+
+  test('returns 0 for undefined/empty input', () => {
+    expect(getTokenDecimals(undefined)).toBe(0);
+    expect(getTokenDecimals('')).toBe(0);
+  });
+
+  test('trims whitespace from token id', () => {
+    expect(getTokenDecimals('  DBTC  ')).toBe(8);
+    expect(getTokenDecimals(' btc ')).toBe(8);
+  });
+});
+
+describe('formatTokenAmount', () => {
+  test('formats whole-unit tokens (0 decimals)', () => {
+    expect(formatTokenAmount(0n, 'ERA')).toBe('0');
+    expect(formatTokenAmount(1n, 'ERA')).toBe('1');
+    expect(formatTokenAmount(123456n, 'ERA')).toBe('123456');
+  });
+
+  test('formats dBTC with 8 decimals', () => {
+    expect(formatTokenAmount(100000000n, 'DBTC')).toBe('1.0');
+    expect(formatTokenAmount(0n, 'DBTC')).toBe('0.0');
+    expect(formatTokenAmount(1n, 'DBTC')).toBe('0.00000001');
+    expect(formatTokenAmount(50000000n, 'DBTC')).toBe('0.5');
+    expect(formatTokenAmount(123456789n, 'DBTC')).toBe('1.23456789');
+  });
+
+  test('strips trailing zeros but keeps at least one decimal digit', () => {
+    expect(formatTokenAmount(100000000n, 'BTC')).toBe('1.0');
+    expect(formatTokenAmount(110000000n, 'BTC')).toBe('1.1');
+    expect(formatTokenAmount(100100000n, 'BTC')).toBe('1.001');
+  });
+
+  test('handles large values without precision loss', () => {
+    const tenBtc = 1000000000n;
+    expect(formatTokenAmount(tenBtc, 'BTC')).toBe('10.0');
+
+    const huge = 2100000000000000n;
+    expect(formatTokenAmount(huge, 'BTC')).toBe('21000000.0');
+  });
+});
+
+describe('formatSignedTokenAmount', () => {
+  test('positive amounts have no prefix', () => {
+    expect(formatSignedTokenAmount(100000000n, 'DBTC')).toBe('1.0');
+    expect(formatSignedTokenAmount(1n, 'ERA')).toBe('1');
+  });
+
+  test('negative amounts have minus prefix', () => {
+    expect(formatSignedTokenAmount(-100000000n, 'DBTC')).toBe('-1.0');
+    expect(formatSignedTokenAmount(-1n, 'ERA')).toBe('-1');
+    expect(formatSignedTokenAmount(-50000000n, 'BTC')).toBe('-0.5');
+  });
+
+  test('zero has no prefix', () => {
+    expect(formatSignedTokenAmount(0n, 'DBTC')).toBe('0.0');
+    expect(formatSignedTokenAmount(0n, 'ERA')).toBe('0');
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds broad frontend unit coverage across wallet-facing flows, React hooks, DSM service wrappers, stores, and utility helpers.

## What Changed

- adds wallet screen helper coverage
- adds contacts-context and domain-mapper tests
- adds DSM API/service coverage for contacts, wallet, storage, policies, events, identity, DLV, and resolution flows
- adds hook coverage for navigation, bridge events, diagnostics, genesis flow, keyboard bindings, session bridge, wallet refresh, wallet sync, and theme assets
- adds service coverage for headers, identity, telemetry, token, bilateral events, policy display, and contact QR flows
- adds store coverage for contacts, storage, and wallet stores
- adds utility coverage for audio, deterministic safety, device testing, IDs, GitHub issue formatting, JSON safety, theme, time, and token metadata

## Why

The frontend has a broad surface area with a lot of application logic living in hooks, stores, and service wrappers. This PR raises unit-level confidence in those paths and reduces reliance on manual verification for common wallet and UI state flows.

## Reviewer Focus

- hook tests with mocked environment behavior
- store tests validating state transitions and side effects
- service-layer tests wrapping DSM functionality
- utility tests that encode assumptions used across the UI

## Validation

- branch adds 43 frontend test files
- changes are test-focused
- coverage growth is concentrated in hooks, stores, services, and wallet logic