### PR TITLE
test(dsm): expand core unit coverage

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/common/canonical_encoding.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/canonical_encoding.rs
@@ -146,7 +146,6 @@ mod tests {
         let data = [42u8; 32];
         cbor::encode_bstr_32(&mut buf, &data);
 
-        // Should start with 0x58 (bstr, 1-byte length) + 0x20 (32) + 32 bytes of data
         assert_eq!(buf.len(), 34);
         assert_eq!(buf[0], 0x58);
         assert_eq!(buf[1], 32);
@@ -159,9 +158,143 @@ mod tests {
         let data = b"hello";
         length_prefix::encode_u32_prefix(&mut buf, data).unwrap();
 
-        // Should have 4-byte length prefix + data
         assert_eq!(buf.len(), 9);
         assert_eq!(u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]), 5);
         assert_eq!(&buf[4..], data);
+    }
+
+    #[test]
+    fn test_cbor_bstr_variable_empty() {
+        let mut buf = Vec::new();
+        cbor::encode_bstr_variable(&mut buf, &[]).unwrap();
+        assert_eq!(buf, vec![0x40]); // major type 2, length 0 inline
+    }
+
+    #[test]
+    fn test_cbor_bstr_variable_small() {
+        let mut buf = Vec::new();
+        let data = [0xAB; 5];
+        cbor::encode_bstr_variable(&mut buf, &data).unwrap();
+
+        assert_eq!(buf[0], 0x40 | 5); // major type 2, length 5 inline
+        assert_eq!(&buf[1..], &data[..]);
+    }
+
+    #[test]
+    fn test_cbor_bstr_variable_one_byte_length() {
+        let data = vec![0xFF; 100];
+        let mut buf = Vec::new();
+        cbor::encode_bstr_variable(&mut buf, &data).unwrap();
+
+        assert_eq!(buf[0], 0x58); // 1-byte length
+        assert_eq!(buf[1], 100);
+        assert_eq!(&buf[2..], &data[..]);
+    }
+
+    #[test]
+    fn test_cbor_bstr_variable_two_byte_length() {
+        let data = vec![0x01; 300];
+        let mut buf = Vec::new();
+        cbor::encode_bstr_variable(&mut buf, &data).unwrap();
+
+        assert_eq!(buf[0], 0x59); // 2-byte length
+        let len = u16::from_be_bytes([buf[1], buf[2]]);
+        assert_eq!(len, 300);
+        assert_eq!(buf.len(), 3 + 300);
+    }
+
+    #[test]
+    fn test_cbor_array_header_inline() {
+        let mut buf = Vec::new();
+        cbor::encode_array_header(&mut buf, 3).unwrap();
+        assert_eq!(buf, vec![0x80 | 3]);
+    }
+
+    #[test]
+    fn test_cbor_array_header_one_byte_length() {
+        let mut buf = Vec::new();
+        cbor::encode_array_header(&mut buf, 200).unwrap();
+        assert_eq!(buf[0], 0x98);
+        assert_eq!(buf[1], 200);
+    }
+
+    #[test]
+    fn test_cbor_array_header_two_byte_length() {
+        let mut buf = Vec::new();
+        cbor::encode_array_header(&mut buf, 1000).unwrap();
+        assert_eq!(buf[0], 0x99);
+        let len = u16::from_be_bytes([buf[1], buf[2]]);
+        assert_eq!(len, 1000);
+    }
+
+    #[test]
+    fn test_length_prefix_u32_empty_data() {
+        let mut buf = Vec::new();
+        length_prefix::encode_u32_prefix(&mut buf, &[]).unwrap();
+        assert_eq!(buf.len(), 4);
+        assert_eq!(u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]), 0);
+    }
+
+    #[test]
+    fn test_length_prefix_variable_small() {
+        let mut buf = Vec::new();
+        let data = b"abc";
+        length_prefix::encode_variable_prefix(&mut buf, data).unwrap();
+
+        assert_eq!(buf[0], 3u8); // 1-byte length
+        assert_eq!(&buf[1..], data.as_slice());
+    }
+
+    #[test]
+    fn test_length_prefix_variable_medium() {
+        let data = vec![0x42; 300];
+        let mut buf = Vec::new();
+        length_prefix::encode_variable_prefix(&mut buf, &data).unwrap();
+
+        let len = u16::from_be_bytes([buf[0], buf[1]]);
+        assert_eq!(len, 300);
+        assert_eq!(&buf[2..], &data[..]);
+    }
+
+    #[test]
+    fn test_domain_separated_hash_deterministic() {
+        let h1 = domain_separated_hash("DSM/test-tag", b"payload");
+        let h2 = domain_separated_hash("DSM/test-tag", b"payload");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_domain_separated_hash_different_tags_differ() {
+        let h1 = domain_separated_hash("DSM/tag-a", b"payload");
+        let h2 = domain_separated_hash("DSM/tag-b", b"payload");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_domain_separated_hash_different_data_differ() {
+        let h1 = domain_separated_hash("DSM/tag", b"data-1");
+        let h2 = domain_separated_hash("DSM/tag", b"data-2");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_cbor_bstr_variable_boundary_23_bytes() {
+        let data = vec![0x01; 23];
+        let mut buf = Vec::new();
+        cbor::encode_bstr_variable(&mut buf, &data).unwrap();
+
+        assert_eq!(buf[0], 0x40 | 23); // still inline
+        assert_eq!(buf.len(), 1 + 23);
+    }
+
+    #[test]
+    fn test_cbor_bstr_variable_boundary_24_bytes() {
+        let data = vec![0x01; 24];
+        let mut buf = Vec::new();
+        cbor::encode_bstr_variable(&mut buf, &data).unwrap();
+
+        assert_eq!(buf[0], 0x58); // switches to 1-byte length
+        assert_eq!(buf[1], 24);
+        assert_eq!(buf.len(), 2 + 24);
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/common/domain_tags.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/domain_tags.rs
@@ -16,3 +16,85 @@ pub fn tagged_bytes(tag: &str, body: &[u8]) -> Vec<u8> {
     out.extend_from_slice(body);
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn all_tags_are_nul_terminated() {
+        let tags = [
+            TAG_RECEIPT_COMMIT,
+            TAG_SMT_NODE,
+            TAG_SMT_LEAF,
+            TAG_DBRW,
+            TAG_DEV_MERKLE,
+            TAG_DEV_LEAF,
+            TAG_DEV_EMPTY,
+        ];
+        for tag in &tags {
+            assert!(tag.ends_with('\0'), "Tag {tag:?} must be NUL-terminated");
+            assert!(tag.len() > 1, "Tag must contain more than just NUL");
+        }
+    }
+
+    #[test]
+    fn all_tags_are_unique() {
+        let tags = [
+            TAG_RECEIPT_COMMIT,
+            TAG_SMT_NODE,
+            TAG_SMT_LEAF,
+            TAG_DBRW,
+            TAG_DEV_MERKLE,
+            TAG_DEV_LEAF,
+            TAG_DEV_EMPTY,
+        ];
+        let set: HashSet<&str> = tags.iter().copied().collect();
+        assert_eq!(set.len(), tags.len(), "All domain tags must be unique");
+    }
+
+    #[test]
+    fn all_tags_start_with_dsm_prefix() {
+        let tags = [
+            TAG_RECEIPT_COMMIT,
+            TAG_SMT_NODE,
+            TAG_SMT_LEAF,
+            TAG_DBRW,
+            TAG_DEV_MERKLE,
+            TAG_DEV_LEAF,
+            TAG_DEV_EMPTY,
+        ];
+        for tag in &tags {
+            assert!(tag.starts_with("DSM/"), "Tag {tag:?} must start with DSM/");
+        }
+    }
+
+    #[test]
+    fn tagged_bytes_concatenates_tag_and_body() {
+        let result = tagged_bytes("DSM/test\0", b"hello");
+        assert_eq!(&result[..9], b"DSM/test\0");
+        assert_eq!(&result[9..], b"hello");
+        assert_eq!(result.len(), 9 + 5);
+    }
+
+    #[test]
+    fn tagged_bytes_with_empty_body() {
+        let result = tagged_bytes(TAG_DBRW, b"");
+        assert_eq!(result, TAG_DBRW.as_bytes());
+    }
+
+    #[test]
+    fn tagged_bytes_different_tags_produce_different_output() {
+        let a = tagged_bytes(TAG_SMT_NODE, b"data");
+        let b = tagged_bytes(TAG_SMT_LEAF, b"data");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn tagged_bytes_different_bodies_produce_different_output() {
+        let a = tagged_bytes(TAG_DBRW, b"alpha");
+        let b = tagged_bytes(TAG_DBRW, b"beta");
+        assert_ne!(a, b);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/chain_tip_store.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/chain_tip_store.rs
@@ -58,3 +58,114 @@ impl ChainTipStore for NoopChainTipStore {
 pub fn noop_chain_tip_store() -> Arc<dyn ChainTipStore> {
     Arc::new(NoopChainTipStore)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[test]
+    fn noop_get_always_returns_none() {
+        let store = NoopChainTipStore;
+        let id = [0xABu8; 32];
+        assert!(store.get_contact_chain_tip(&id).is_none());
+        assert!(store.get_contact_chain_tip(&[0u8; 32]).is_none());
+    }
+
+    #[test]
+    fn noop_set_always_succeeds() {
+        let store = NoopChainTipStore;
+        let id = [1u8; 32];
+        let parent = [2u8; 32];
+        let tip = [3u8; 32];
+        assert_eq!(store.set_contact_chain_tip(&id, parent, tip).unwrap(), true);
+    }
+
+    #[test]
+    fn noop_helper_returns_arc() {
+        let store = noop_chain_tip_store();
+        assert!(store.get_contact_chain_tip(&[0u8; 32]).is_none());
+        assert!(store
+            .set_contact_chain_tip(&[0u8; 32], [0u8; 32], [1u8; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn debug_impl_for_dyn_chain_tip_store() {
+        let store: Arc<dyn ChainTipStore> = noop_chain_tip_store();
+        let dbg = format!("{:?}", store);
+        assert!(dbg.contains("ChainTipStore(..)"));
+    }
+
+    struct InMemoryChainTipStore {
+        tips: Mutex<HashMap<[u8; 32], [u8; 32]>>,
+    }
+
+    impl InMemoryChainTipStore {
+        fn new() -> Self {
+            Self {
+                tips: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl ChainTipStore for InMemoryChainTipStore {
+        fn get_contact_chain_tip(&self, device_id: &[u8; 32]) -> Option<[u8; 32]> {
+            self.tips.lock().unwrap().get(device_id).copied()
+        }
+
+        fn set_contact_chain_tip(
+            &self,
+            device_id: &[u8; 32],
+            expected_parent_tip: [u8; 32],
+            new_tip: [u8; 32],
+        ) -> Result<bool, DsmError> {
+            let mut tips = self.tips.lock().unwrap();
+            let current = tips.get(device_id).copied().unwrap_or([0u8; 32]);
+            if current != expected_parent_tip {
+                return Ok(false);
+            }
+            tips.insert(*device_id, new_tip);
+            Ok(true)
+        }
+    }
+
+    #[test]
+    fn in_memory_store_set_then_get() {
+        let store = InMemoryChainTipStore::new();
+        let id = [42u8; 32];
+        let tip = [99u8; 32];
+        assert!(store.get_contact_chain_tip(&id).is_none());
+        assert!(store.set_contact_chain_tip(&id, [0u8; 32], tip).unwrap());
+        assert_eq!(store.get_contact_chain_tip(&id), Some(tip));
+    }
+
+    #[test]
+    fn in_memory_store_cas_rejects_wrong_parent() {
+        let store = InMemoryChainTipStore::new();
+        let id = [1u8; 32];
+        let tip1 = [10u8; 32];
+        let tip2 = [20u8; 32];
+        store.set_contact_chain_tip(&id, [0u8; 32], tip1).unwrap();
+
+        let wrong_parent = [0xFFu8; 32];
+        let applied = store
+            .set_contact_chain_tip(&id, wrong_parent, tip2)
+            .unwrap();
+        assert!(!applied, "CAS should reject wrong parent");
+        assert_eq!(store.get_contact_chain_tip(&id), Some(tip1));
+    }
+
+    #[test]
+    fn in_memory_store_cas_accepts_correct_parent() {
+        let store = InMemoryChainTipStore::new();
+        let id = [5u8; 32];
+        let tip1 = [10u8; 32];
+        let tip2 = [20u8; 32];
+        store.set_contact_chain_tip(&id, [0u8; 32], tip1).unwrap();
+        let applied = store.set_contact_chain_tip(&id, tip1, tip2).unwrap();
+        assert!(applied);
+        assert_eq!(store.get_contact_chain_tip(&id), Some(tip2));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/chain_tip_store.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/chain_tip_store.rs
@@ -79,7 +79,7 @@ mod tests {
         let id = [1u8; 32];
         let parent = [2u8; 32];
         let tip = [3u8; 32];
-        assert_eq!(store.set_contact_chain_tip(&id, parent, tip).unwrap(), true);
+        assert!(store.set_contact_chain_tip(&id, parent, tip).unwrap());
     }
 
     #[test]

--- a/dsm_client/deterministic_state_machine/dsm/src/core/error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/error.rs
@@ -446,3 +446,578 @@ impl<T> From<std::sync::PoisonError<T>> for DsmCoreError {
 }
 
 // No From<serde_json::Error> in core (JSON-free)
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error as StdError;
+    use std::io;
+
+    // ── Helper: a trivial error type for testing source chains ──
+
+    #[derive(Debug)]
+    struct TestSourceError(String);
+    impl std::fmt::Display for TestSourceError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+    impl StdError for TestSourceError {}
+
+    // ── Constructor tests ──
+
+    #[test]
+    fn crypto_with_source() {
+        let src = TestSourceError("bad nonce".into());
+        let e = DsmCoreError::crypto("lattice op failed", Some(src));
+        assert!(matches!(e, DsmCoreError::Crypto { .. }));
+        let msg = e.to_string();
+        assert!(msg.contains("lattice op failed"));
+        assert!(msg.contains("bad nonce"));
+    }
+
+    #[test]
+    fn crypto_without_source() {
+        let e = DsmCoreError::crypto("no source", Option::<TestSourceError>::None);
+        assert!(matches!(e, DsmCoreError::Crypto { source: None, .. }));
+        assert!(!e.to_string().contains("caused by"));
+    }
+
+    #[test]
+    fn storage_with_source() {
+        let src = TestSourceError("disk full".into());
+        let e = DsmCoreError::storage("write failed", Some(src));
+        assert!(matches!(e, DsmCoreError::Storage { .. }));
+        assert!(e.to_string().contains("write failed"));
+        assert!(e.to_string().contains("disk full"));
+    }
+
+    #[test]
+    fn storage_without_source() {
+        let e = DsmCoreError::storage("no source", Option::<TestSourceError>::None);
+        assert!(matches!(e, DsmCoreError::Storage { source: None, .. }));
+    }
+
+    #[test]
+    fn network_with_source() {
+        let src = TestSourceError("dns fail".into());
+        let e = DsmCoreError::network("lookup", Some(src));
+        assert!(matches!(e, DsmCoreError::Network { .. }));
+        assert!(e.to_string().contains("lookup"));
+    }
+
+    #[test]
+    fn network_without_source() {
+        let e = DsmCoreError::network("timeout", Option::<TestSourceError>::None);
+        if let DsmCoreError::Network {
+            entity, details, ..
+        } = &e
+        {
+            assert!(entity.is_empty());
+            assert!(details.is_none());
+        } else {
+            panic!("expected Network");
+        }
+    }
+
+    #[test]
+    fn state_machine_constructor() {
+        let e = DsmCoreError::state_machine("bad transition");
+        assert!(matches!(e, DsmCoreError::StateMachine(ref m) if m == "bad transition"));
+    }
+
+    #[test]
+    fn not_found_with_details() {
+        let e = DsmCoreError::not_found("Token", Some("id=42"));
+        if let DsmCoreError::NotFound {
+            entity,
+            details,
+            context,
+            source,
+        } = &e
+        {
+            assert_eq!(entity, "Token");
+            assert_eq!(details.as_deref(), Some("id=42"));
+            assert_eq!(context, "Entity not found");
+            assert!(source.is_none());
+        } else {
+            panic!("expected NotFound");
+        }
+    }
+
+    #[test]
+    fn not_found_without_details() {
+        let e = DsmCoreError::not_found("Wallet", Option::<String>::None);
+        if let DsmCoreError::NotFound { details, .. } = &e {
+            assert!(details.is_none());
+        } else {
+            panic!("expected NotFound");
+        }
+    }
+
+    #[test]
+    fn internal_constructor() {
+        let src = TestSourceError("oops".into());
+        let e = DsmCoreError::internal("unexpected", Some(src));
+        assert!(matches!(e, DsmCoreError::Internal { .. }));
+        assert!(e.to_string().contains("unexpected"));
+    }
+
+    #[test]
+    fn validation_constructor() {
+        let e = DsmCoreError::validation("bad input", Option::<TestSourceError>::None);
+        assert!(matches!(e, DsmCoreError::Validation { source: None, .. }));
+    }
+
+    #[test]
+    fn serialization_constructor() {
+        let e = DsmCoreError::serialization("decode failed", Option::<TestSourceError>::None);
+        if let DsmCoreError::Serialization {
+            context,
+            entity,
+            details,
+            ..
+        } = &e
+        {
+            assert_eq!(context, "decode failed");
+            assert_eq!(entity, "Data");
+            assert!(details.is_none());
+        } else {
+            panic!("expected Serialization");
+        }
+    }
+
+    #[test]
+    fn lock_error_constructor() {
+        let e = DsmCoreError::lock_error();
+        assert!(matches!(e, DsmCoreError::LockError));
+    }
+
+    // ── Display for every variant ──
+
+    #[test]
+    fn display_crypto() {
+        let e = DsmCoreError::crypto("aes fail", Option::<TestSourceError>::None);
+        assert!(e.to_string().starts_with("Cryptographic error:"));
+    }
+
+    #[test]
+    fn display_invalid_public_key() {
+        let e = DsmCoreError::InvalidPublicKey;
+        assert_eq!(e.to_string(), "Invalid public key");
+    }
+
+    #[test]
+    fn display_invalid_secret_key() {
+        let e = DsmCoreError::InvalidSecretKey;
+        assert_eq!(e.to_string(), "Invalid secret key");
+    }
+
+    #[test]
+    fn display_storage() {
+        let e = DsmCoreError::storage("corrupted", Option::<TestSourceError>::None);
+        assert!(e.to_string().starts_with("Storage error:"));
+    }
+
+    #[test]
+    fn display_network() {
+        let e = DsmCoreError::network("refused", Option::<TestSourceError>::None);
+        assert!(e.to_string().starts_with("Network error:"));
+    }
+
+    #[test]
+    fn display_state_machine() {
+        let e = DsmCoreError::state_machine("stuck");
+        assert_eq!(e.to_string(), "State machine error: stuck");
+    }
+
+    #[test]
+    fn display_not_found() {
+        let e = DsmCoreError::not_found("Peer", Some("abc"));
+        let msg = e.to_string();
+        assert!(msg.contains("Peer not found"));
+        assert!(msg.contains("abc"));
+        assert!(msg.contains("Entity not found"));
+    }
+
+    #[test]
+    fn display_not_found_without_details() {
+        let e = DsmCoreError::not_found("Peer", Option::<String>::None);
+        let msg = e.to_string();
+        assert!(msg.contains("Peer not found"));
+        assert!(!msg.contains(':'));
+    }
+
+    #[test]
+    fn display_internal() {
+        let e = DsmCoreError::internal("bug", Option::<TestSourceError>::None);
+        assert!(e.to_string().starts_with("Internal error:"));
+    }
+
+    #[test]
+    fn display_lock_error() {
+        let e = DsmCoreError::LockError;
+        assert_eq!(e.to_string(), "Failed to acquire lock");
+    }
+
+    #[test]
+    fn display_catchall_variants() {
+        let catchall_variants: Vec<DsmCoreError> = vec![
+            DsmCoreError::Integrity {
+                context: "x".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidKeyLength,
+            DsmCoreError::Validation {
+                context: "x".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidParameter("x".into()),
+            DsmCoreError::Serialization {
+                context: "x".into(),
+                source: None,
+                entity: "x".into(),
+                details: None,
+            },
+            DsmCoreError::Verification("x".into()),
+            DsmCoreError::State("x".into()),
+            DsmCoreError::Merkle("x".into()),
+            DsmCoreError::HashChain("x".into()),
+            DsmCoreError::Transaction("x".into()),
+            DsmCoreError::PreCommitment("x".into()),
+            DsmCoreError::Genesis("x".into()),
+            DsmCoreError::DeviceHierarchy("x".into()),
+            DsmCoreError::ForwardCommitment("x".into()),
+            DsmCoreError::Relationship("x".into()),
+            DsmCoreError::ExternalCommitment("x".into()),
+            DsmCoreError::Identity("x".into()),
+            DsmCoreError::Communication {
+                context: "x".into(),
+                source: None,
+            },
+            DsmCoreError::NotInitialized {
+                context: "x".into(),
+                source: None,
+            },
+            DsmCoreError::Transport {
+                context: "x".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidCiphertext,
+            DsmCoreError::Generic {
+                message: "x".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidIndex,
+            DsmCoreError::InvalidOperation("x".into()),
+            DsmCoreError::SystemError("x".into()),
+            DsmCoreError::TokenError {
+                context: "x".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidToken {
+                context: "x".into(),
+                source: None,
+            },
+            DsmCoreError::Unauthorized {
+                context: "x".into(),
+                source: None,
+            },
+            DsmCoreError::InsufficientBalance {
+                token_id: "t".into(),
+                available: 10,
+                requested: 20,
+            },
+            DsmCoreError::FeatureNotAvailable {
+                feature: "x".into(),
+                details: None,
+            },
+            DsmCoreError::PolicyViolation {
+                token_id: "t".into(),
+                message: "x".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidState("x".into()),
+            DsmCoreError::TimeError("x".into()),
+            DsmCoreError::Blockchain {
+                context: "x".into(),
+                source: None,
+            },
+        ];
+        for v in catchall_variants {
+            assert_eq!(v.to_string(), "DSM core error");
+        }
+    }
+
+    // ── is_recoverable for every variant ──
+
+    #[test]
+    fn recoverable_variants() {
+        let recoverable = vec![
+            DsmCoreError::Network {
+                context: "".into(),
+                source: None,
+                entity: "".into(),
+                details: None,
+            },
+            DsmCoreError::Storage {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::Transport {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::Communication {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::TimeError("".into()),
+            DsmCoreError::LockError,
+            DsmCoreError::NotInitialized {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::Blockchain {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::SystemError("".into()),
+        ];
+        for v in &recoverable {
+            assert!(v.is_recoverable(), "{v:?} should be recoverable");
+        }
+    }
+
+    #[test]
+    fn non_recoverable_variants() {
+        let non_recoverable = vec![
+            DsmCoreError::Crypto {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::Integrity {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidPublicKey,
+            DsmCoreError::InvalidSecretKey,
+            DsmCoreError::InvalidKeyLength,
+            DsmCoreError::StateMachine("".into()),
+            DsmCoreError::NotFound {
+                entity: "".into(),
+                details: None,
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::Internal {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::Validation {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidParameter("".into()),
+            DsmCoreError::Serialization {
+                context: "".into(),
+                source: None,
+                entity: "".into(),
+                details: None,
+            },
+            DsmCoreError::Verification("".into()),
+            DsmCoreError::State("".into()),
+            DsmCoreError::Merkle("".into()),
+            DsmCoreError::HashChain("".into()),
+            DsmCoreError::Transaction("".into()),
+            DsmCoreError::PreCommitment("".into()),
+            DsmCoreError::Genesis("".into()),
+            DsmCoreError::DeviceHierarchy("".into()),
+            DsmCoreError::ForwardCommitment("".into()),
+            DsmCoreError::Relationship("".into()),
+            DsmCoreError::ExternalCommitment("".into()),
+            DsmCoreError::Identity("".into()),
+            DsmCoreError::InvalidCiphertext,
+            DsmCoreError::Generic {
+                message: "".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidIndex,
+            DsmCoreError::InvalidOperation("".into()),
+            DsmCoreError::TokenError {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidToken {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::Unauthorized {
+                context: "".into(),
+                source: None,
+            },
+            DsmCoreError::InsufficientBalance {
+                token_id: "".into(),
+                available: 0,
+                requested: 0,
+            },
+            DsmCoreError::FeatureNotAvailable {
+                feature: "".into(),
+                details: None,
+            },
+            DsmCoreError::PolicyViolation {
+                token_id: "".into(),
+                message: "".into(),
+                source: None,
+            },
+            DsmCoreError::InvalidState("".into()),
+        ];
+        for v in &non_recoverable {
+            assert!(!v.is_recoverable(), "{v:?} should NOT be recoverable");
+        }
+    }
+
+    // ── Error::source ──
+
+    #[test]
+    fn source_crypto_with_source() {
+        let e = DsmCoreError::crypto("ctx", Some(TestSourceError("inner".into())));
+        assert!(e.source().is_some());
+        assert!(e.source().unwrap().to_string().contains("inner"));
+    }
+
+    #[test]
+    fn source_crypto_without_source() {
+        let e = DsmCoreError::crypto("ctx", Option::<TestSourceError>::None);
+        assert!(e.source().is_none());
+    }
+
+    #[test]
+    fn source_storage() {
+        let e = DsmCoreError::storage("ctx", Some(TestSourceError("s".into())));
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn source_network() {
+        let e = DsmCoreError::network("ctx", Some(TestSourceError("n".into())));
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn source_internal() {
+        let e = DsmCoreError::internal("ctx", Some(TestSourceError("i".into())));
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn source_validation() {
+        let e = DsmCoreError::validation("ctx", Some(TestSourceError("v".into())));
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn source_serialization() {
+        let e = DsmCoreError::serialization("ctx", Some(TestSourceError("ser".into())));
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn source_generic() {
+        let e = DsmCoreError::Generic {
+            message: "g".into(),
+            source: Some(Box::new(TestSourceError("gen".into()))),
+        };
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn source_returns_none_for_other_variants() {
+        let e = DsmCoreError::InvalidPublicKey;
+        assert!(e.source().is_none());
+        let e2 = DsmCoreError::StateMachine("x".into());
+        assert!(e2.source().is_none());
+    }
+
+    // ── From<std::io::Error> ──
+
+    #[test]
+    fn from_io_not_found() {
+        let io_err = io::Error::new(io::ErrorKind::NotFound, "gone");
+        let e: DsmCoreError = io_err.into();
+        assert!(matches!(e, DsmCoreError::NotFound { .. }));
+    }
+
+    #[test]
+    fn from_io_permission_denied() {
+        let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "nope");
+        let e: DsmCoreError = io_err.into();
+        assert!(matches!(e, DsmCoreError::Storage { .. }));
+    }
+
+    #[test]
+    fn from_io_connection_refused() {
+        let io_err = io::Error::new(io::ErrorKind::ConnectionRefused, "refused");
+        let e: DsmCoreError = io_err.into();
+        assert!(matches!(e, DsmCoreError::Network { .. }));
+    }
+
+    #[test]
+    fn from_io_connection_reset() {
+        let io_err = io::Error::new(io::ErrorKind::ConnectionReset, "reset");
+        let e: DsmCoreError = io_err.into();
+        assert!(matches!(e, DsmCoreError::Network { .. }));
+    }
+
+    #[test]
+    fn from_io_timed_out() {
+        let io_err = io::Error::new(io::ErrorKind::TimedOut, "slow");
+        let e: DsmCoreError = io_err.into();
+        assert!(matches!(e, DsmCoreError::Network { .. }));
+    }
+
+    #[test]
+    fn from_io_other_becomes_generic() {
+        let io_err = io::Error::new(io::ErrorKind::Other, "misc");
+        let e: DsmCoreError = io_err.into();
+        assert!(matches!(e, DsmCoreError::Generic { .. }));
+        assert!(e.to_string().contains("DSM core error"));
+    }
+
+    // ── From<PoisonError> ──
+
+    #[test]
+    fn from_poison_error() {
+        let lock = std::sync::Mutex::new(42);
+        // Poison the mutex by panicking inside a lock
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = lock.lock().unwrap();
+            panic!("poison");
+        }));
+        let err = lock.lock().unwrap_err();
+        let e: DsmCoreError = err.into();
+        assert!(matches!(e, DsmCoreError::LockError));
+    }
+
+    // ── Debug is implemented ──
+
+    #[test]
+    fn debug_format_works() {
+        let e = DsmCoreError::crypto("dbg test", Option::<TestSourceError>::None);
+        let dbg = format!("{:?}", e);
+        assert!(dbg.contains("Crypto"));
+        assert!(dbg.contains("dbg test"));
+    }
+
+    // ── Send + Sync ──
+
+    #[test]
+    fn error_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        // DsmCoreError is Debug and has Send+Sync sources, so this should compile.
+        // We can't assert the trait for DsmCoreError directly because dyn Error
+        // is not Sync unless explicitly boxed as such. But the constructors do.
+        let e = DsmCoreError::crypto("t", Option::<TestSourceError>::None);
+        let _ = format!("{e}");
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/error.rs
@@ -978,7 +978,7 @@ mod tests {
 
     #[test]
     fn from_io_other_becomes_generic() {
-        let io_err = io::Error::new(io::ErrorKind::Other, "misc");
+        let io_err = io::Error::other("misc");
         let e: DsmCoreError = io_err.into();
         assert!(matches!(e, DsmCoreError::Generic { .. }));
         assert!(e.to_string().contains("DSM core error"));
@@ -1013,11 +1013,10 @@ mod tests {
 
     #[test]
     fn error_is_send_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
-        // DsmCoreError is Debug and has Send+Sync sources, so this should compile.
-        // We can't assert the trait for DsmCoreError directly because dyn Error
-        // is not Sync unless explicitly boxed as such. But the constructors do.
+        // DsmCoreError is Debug and has Send+Sync sources, so boxing it behind a
+        // `dyn Error + Send + Sync` should compile.
         let e = DsmCoreError::crypto("t", Option::<TestSourceError>::None);
-        let _ = format!("{e}");
+        let boxed: Box<dyn std::error::Error + Send + Sync> = Box::new(e);
+        let _ = format!("{boxed}");
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/core/security/bilateral_control.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/security/bilateral_control.rs
@@ -589,3 +589,518 @@ impl BilateralControlResistance {
         Ok(false)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::operations::Operation;
+    use crate::types::state_types::{DeviceInfo, State, StateParams};
+    use crate::types::token_types::Balance;
+
+    // ── Mock storage ────────────────────────────────────────────────
+    struct MockStorage {
+        historical: Vec<State>,
+        published: Vec<State>,
+        reports: std::sync::Mutex<Vec<Vec<u8>>>,
+    }
+
+    impl MockStorage {
+        fn empty() -> Self {
+            Self {
+                historical: vec![],
+                published: vec![],
+                reports: std::sync::Mutex::new(vec![]),
+            }
+        }
+
+        #[allow(dead_code)]
+        fn with_published(states: Vec<State>) -> Self {
+            Self {
+                historical: vec![],
+                published: states,
+                reports: std::sync::Mutex::new(vec![]),
+            }
+        }
+    }
+
+    impl DecentralizedStorage for MockStorage {
+        fn store_suspicious_activity_report(&self, report: &[u8]) -> Result<(), DsmError> {
+            self.reports.lock().unwrap().push(report.to_vec());
+            Ok(())
+        }
+
+        fn get_historical_states(&self, _device_id: &[u8; 32]) -> Result<Vec<State>, DsmError> {
+            Ok(self.historical.clone())
+        }
+
+        fn get_published_states(&self, _device_id: &[u8; 32]) -> Result<Vec<State>, DsmError> {
+            Ok(self.published.clone())
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    fn dev_info() -> DeviceInfo {
+        DeviceInfo::new([0x11; 32], vec![0x22; 64])
+    }
+
+    fn make_state(n: u64) -> State {
+        State::new(StateParams::new(
+            n,
+            vec![0xAA; 16],
+            Operation::Noop,
+            dev_info(),
+        ))
+    }
+
+    fn make_chained_states(start: u64, count: u64) -> Vec<State> {
+        let mut states = Vec::new();
+        for i in 0..count {
+            let mut s = make_state(start + i);
+            if i > 0 {
+                s.prev_state_hash = states.last().map(|p: &State| p.hash).unwrap_or([0u8; 32]);
+            }
+            let h = s.compute_hash().unwrap_or([0u8; 32]);
+            s.hash = h;
+            states.push(s);
+        }
+        states
+    }
+
+    fn make_identity_anchor(id: &str) -> IdentityAnchor {
+        IdentityAnchor::new(
+            id.to_string(),
+            vec![0x01; 32],
+            vec![0x02; 64],
+            vec![0x03; 16],
+        )
+    }
+
+    // ── AlertSeverity ───────────────────────────────────────────────
+
+    #[test]
+    fn alert_severity_equality() {
+        assert_eq!(AlertSeverity::Low, AlertSeverity::Low);
+        assert_ne!(AlertSeverity::Low, AlertSeverity::High);
+        assert_ne!(AlertSeverity::Medium, AlertSeverity::Critical);
+    }
+
+    #[test]
+    fn alert_severity_clone() {
+        let s = AlertSeverity::Critical;
+        let c = s;
+        assert_eq!(c, AlertSeverity::Critical);
+    }
+
+    // ── Alert ───────────────────────────────────────────────────────
+
+    #[test]
+    fn alert_construction() {
+        let a = Alert {
+            alert_type: "TestAlert".into(),
+            description: "test desc".into(),
+            severity: AlertSeverity::High,
+        };
+        assert_eq!(a.alert_type, "TestAlert");
+        assert_eq!(a.severity, AlertSeverity::High);
+    }
+
+    // ── RelationshipStatePair ───────────────────────────────────────
+
+    #[test]
+    fn relationship_state_pair_contains_state() {
+        let mut s1 = make_state(1);
+        s1.hash = s1.compute_hash().unwrap();
+        let pair = RelationshipStatePair {
+            entity_id: [0x01; 32],
+            counterparty_id: [0x02; 32],
+            states: vec![s1.clone()],
+        };
+        assert!(pair.contains_state(&s1));
+
+        let s2 = make_state(2);
+        assert!(!pair.contains_state(&s2));
+    }
+
+    // ── calculate_attack_probability ────────────────────────────────
+
+    #[test]
+    fn attack_probability_zero_network() {
+        let p = BilateralControlResistance::calculate_attack_probability(256, 5, 0);
+        assert!(p > 0.0, "zero network should yield >= 1.0 for network_term");
+    }
+
+    #[test]
+    fn attack_probability_high_security_param() {
+        let p = BilateralControlResistance::calculate_attack_probability(1024, 1, 1000);
+        assert!(p < 0.001, "high security param should make crypto_term 0");
+    }
+
+    #[test]
+    fn attack_probability_large_network_small_relationships() {
+        let p = BilateralControlResistance::calculate_attack_probability(256, 1, 1_000_000);
+        assert!(p < 1e-6);
+    }
+
+    #[test]
+    fn attack_probability_monotonic_with_relationships() {
+        let p1 = BilateralControlResistance::calculate_attack_probability(256, 1, 1000);
+        let p2 = BilateralControlResistance::calculate_attack_probability(256, 10, 1000);
+        assert!(p2 > p1);
+    }
+
+    #[test]
+    fn attack_probability_monotonic_with_security_param() {
+        let p1 = BilateralControlResistance::calculate_attack_probability(128, 5, 1000);
+        let p2 = BilateralControlResistance::calculate_attack_probability(256, 5, 1000);
+        assert!(p1 >= p2);
+    }
+
+    // ── verify_genesis_threshold ────────────────────────────────────
+
+    #[tokio::test]
+    async fn genesis_threshold_below_minimum_fails() {
+        let identity = make_identity_anchor("alice");
+        let signers = vec![make_identity_anchor("bob"), make_identity_anchor("carol")];
+        let storage = MockStorage::empty();
+        let result =
+            BilateralControlResistance::verify_genesis_threshold(&identity, &signers, 2, &storage)
+                .await
+                .unwrap();
+        assert!(!result, "threshold < 3 should fail");
+    }
+
+    #[tokio::test]
+    async fn genesis_threshold_not_enough_signers() {
+        let identity = make_identity_anchor("alice");
+        let signers = vec![make_identity_anchor("bob"), make_identity_anchor("carol")];
+        let storage = MockStorage::empty();
+        let result =
+            BilateralControlResistance::verify_genesis_threshold(&identity, &signers, 3, &storage)
+                .await
+                .unwrap();
+        assert!(!result, "signers.len() < threshold should fail");
+    }
+
+    #[tokio::test]
+    async fn genesis_threshold_self_signing_fails() {
+        let identity = make_identity_anchor("alice");
+        let signers = vec![
+            make_identity_anchor("alice"),
+            make_identity_anchor("bob"),
+            make_identity_anchor("carol"),
+        ];
+        let storage = MockStorage::empty();
+        let result =
+            BilateralControlResistance::verify_genesis_threshold(&identity, &signers, 3, &storage)
+                .await
+                .unwrap();
+        assert!(!result, "self-signing should fail");
+    }
+
+    #[tokio::test]
+    async fn genesis_threshold_valid() {
+        let identity = make_identity_anchor("alice");
+        let signers = vec![
+            make_identity_anchor("bob"),
+            make_identity_anchor("carol"),
+            make_identity_anchor("dave"),
+        ];
+        let storage = MockStorage::empty();
+        let result =
+            BilateralControlResistance::verify_genesis_threshold(&identity, &signers, 3, &storage)
+                .await
+                .unwrap();
+        assert!(result);
+    }
+
+    // ── verify_temporal_consistency ──────────────────────────────────
+
+    #[tokio::test]
+    async fn temporal_consistency_valid_chain() {
+        let states = make_chained_states(0, 5);
+        let storage = MockStorage::empty();
+        let ok = BilateralControlResistance::verify_temporal_consistency(&states, &storage)
+            .await
+            .unwrap();
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn temporal_consistency_empty() {
+        let storage = MockStorage::empty();
+        let ok = BilateralControlResistance::verify_temporal_consistency(&[], &storage)
+            .await
+            .unwrap();
+        assert!(ok, "empty state list is trivially consistent");
+    }
+
+    #[tokio::test]
+    async fn temporal_consistency_single_state() {
+        let states = make_chained_states(0, 1);
+        let storage = MockStorage::empty();
+        let ok = BilateralControlResistance::verify_temporal_consistency(&states, &storage)
+            .await
+            .unwrap();
+        assert!(ok, "single state is trivially consistent");
+    }
+
+    #[tokio::test]
+    async fn temporal_consistency_non_sequential_fails() {
+        let mut states = make_chained_states(0, 3);
+        states[2].state_number = 5; // skip 3,4
+        let storage = MockStorage::empty();
+        let ok = BilateralControlResistance::verify_temporal_consistency(&states, &storage)
+            .await
+            .unwrap();
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn temporal_consistency_broken_hash_chain_fails() {
+        let mut states = make_chained_states(0, 3);
+        states[2].prev_state_hash = [0xFF; 32]; // corrupt
+        let storage = MockStorage::empty();
+        let ok = BilateralControlResistance::verify_temporal_consistency(&states, &storage)
+            .await
+            .unwrap();
+        assert!(!ok);
+    }
+
+    // ── detect_temporal_manipulation ────────────────────────────────
+
+    #[test]
+    fn temporal_manipulation_single_state() {
+        let states = make_chained_states(0, 1);
+        assert!(!BilateralControlResistance::detect_temporal_manipulation(&states).unwrap());
+    }
+
+    #[test]
+    fn temporal_manipulation_non_monotonic() {
+        let mut s1 = make_state(5);
+        s1.hash = s1.compute_hash().unwrap();
+        let mut s2 = make_state(3);
+        s2.hash = s2.compute_hash().unwrap();
+        assert!(BilateralControlResistance::detect_temporal_manipulation(&[s1, s2]).unwrap());
+    }
+
+    #[test]
+    fn temporal_manipulation_equal_state_numbers() {
+        let mut s1 = make_state(5);
+        s1.hash = s1.compute_hash().unwrap();
+        let mut s2 = make_state(5);
+        s2.hash = s2.compute_hash().unwrap();
+        assert!(BilateralControlResistance::detect_temporal_manipulation(&[s1, s2]).unwrap());
+    }
+
+    #[test]
+    fn temporal_manipulation_regular_intervals_long_sequence() {
+        let mut states = Vec::new();
+        for i in 0..10 {
+            let mut s = make_state(i * 3);
+            s.hash = s.compute_hash().unwrap();
+            states.push(s);
+        }
+        assert!(
+            BilateralControlResistance::detect_temporal_manipulation(&states).unwrap(),
+            "8+ states with identical gaps is suspicious"
+        );
+    }
+
+    #[test]
+    fn temporal_manipulation_large_jump() {
+        let mut s1 = make_state(1);
+        s1.hash = s1.compute_hash().unwrap();
+        let mut s2 = make_state(200);
+        s2.hash = s2.compute_hash().unwrap();
+        assert!(BilateralControlResistance::detect_temporal_manipulation(&[s1, s2]).unwrap());
+    }
+
+    #[test]
+    fn temporal_manipulation_valid_short_sequence() {
+        let mut states = Vec::new();
+        for i in 0..5 {
+            let mut s = make_state(i);
+            s.hash = s.compute_hash().unwrap();
+            states.push(s);
+        }
+        assert!(
+            !BilateralControlResistance::detect_temporal_manipulation(&states).unwrap(),
+            "short consecutive sequence should not flag (below 8-state threshold for regularity)"
+        );
+    }
+
+    // ── detect_anomalous_balance_changes ─────────────────────────────
+
+    #[test]
+    fn anomalous_balance_no_states() {
+        let result = BilateralControlResistance::detect_anomalous_balance_changes(&[]).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn anomalous_balance_no_token_balances() {
+        let states = make_chained_states(0, 3);
+        let result = BilateralControlResistance::detect_anomalous_balance_changes(&states).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn anomalous_balance_generic_op_large_delta() {
+        let mut s1 = make_state(0);
+        s1.token_balances
+            .insert("tok".into(), Balance::from_state(100, [0; 32], 0));
+        s1.hash = s1.compute_hash().unwrap();
+
+        let mut s2 = make_state(1);
+        s2.token_balances
+            .insert("tok".into(), Balance::from_state(300, [0; 32], 1));
+        s2.prev_state_hash = s1.hash;
+        s2.hash = s2.compute_hash().unwrap();
+
+        let result =
+            BilateralControlResistance::detect_anomalous_balance_changes(&[s1, s2]).unwrap();
+        assert!(
+            !result.is_empty(),
+            "delta (200) > prev balance (100) should be anomalous"
+        );
+    }
+
+    // ── build_compact_report ────────────────────────────────────────
+
+    #[test]
+    fn compact_report_starts_with_prefix() {
+        let states = make_chained_states(0, 2);
+        let alerts = vec![Alert {
+            alert_type: "Test".into(),
+            description: "desc".into(),
+            severity: AlertSeverity::Low,
+        }];
+        let report = BilateralControlResistance::build_compact_report(&states, &alerts);
+        assert!(report.starts_with(BilateralControlResistance::report_prefix()));
+    }
+
+    #[test]
+    fn compact_report_empty_alerts() {
+        let states = make_chained_states(0, 1);
+        let report = BilateralControlResistance::build_compact_report(&states, &[]);
+        assert!(report.starts_with(BilateralControlResistance::report_prefix()));
+        let prefix_len = BilateralControlResistance::report_prefix().len();
+        let alert_count =
+            u32::from_le_bytes(report[prefix_len..prefix_len + 4].try_into().unwrap());
+        assert_eq!(alert_count, 0);
+    }
+
+    #[test]
+    fn compact_report_deterministic() {
+        let states = make_chained_states(0, 2);
+        let alerts = vec![Alert {
+            alert_type: "A".into(),
+            description: "d".into(),
+            severity: AlertSeverity::Medium,
+        }];
+        let r1 = BilateralControlResistance::build_compact_report(&states, &alerts);
+        let r2 = BilateralControlResistance::build_compact_report(&states, &alerts);
+        assert_eq!(r1, r2);
+    }
+
+    // ── detect_suspicious_patterns (integration) ────────────────────
+
+    #[tokio::test]
+    async fn suspicious_patterns_clean_short_sequence() {
+        let states = make_chained_states(0, 3);
+        let storage = MockStorage::empty();
+        let alerts = BilateralControlResistance::detect_suspicious_patterns(&states, &storage)
+            .await
+            .unwrap();
+        assert!(
+            alerts.is_empty(),
+            "short clean sequence should produce no alerts"
+        );
+    }
+
+    #[tokio::test]
+    async fn suspicious_patterns_rapid_transactions() {
+        let states = make_chained_states(0, 12);
+        let storage = MockStorage::empty();
+        let alerts = BilateralControlResistance::detect_suspicious_patterns(&states, &storage)
+            .await
+            .unwrap();
+        let has_rapid = alerts.iter().any(|a| a.alert_type == "RapidTransactions");
+        assert!(
+            has_rapid,
+            "12 consecutive states should trigger rapid transaction alert"
+        );
+    }
+
+    // ── has_cycle_from ──────────────────────────────────────────────
+
+    #[test]
+    fn has_cycle_no_edges() {
+        let graph: HashMap<[u8; 32], Vec<[u8; 32]>> = HashMap::new();
+        assert!(!BilateralControlResistance::has_cycle_from(&graph, [0; 32]));
+    }
+
+    #[test]
+    fn has_cycle_self_loop() {
+        let node = [0x01; 32];
+        let mut graph = HashMap::new();
+        graph.insert(node, vec![node]);
+        assert!(BilateralControlResistance::has_cycle_from(&graph, node));
+    }
+
+    #[test]
+    fn has_cycle_triangle() {
+        let a = [0x01; 32];
+        let b = [0x02; 32];
+        let c = [0x03; 32];
+        let mut graph = HashMap::new();
+        graph.insert(a, vec![b]);
+        graph.insert(b, vec![c]);
+        graph.insert(c, vec![a]);
+        assert!(BilateralControlResistance::has_cycle_from(&graph, a));
+    }
+
+    #[test]
+    fn has_cycle_linear_chain_no_cycle() {
+        let a = [0x01; 32];
+        let b = [0x02; 32];
+        let c = [0x03; 32];
+        let mut graph = HashMap::new();
+        graph.insert(a, vec![b]);
+        graph.insert(b, vec![c]);
+        assert!(!BilateralControlResistance::has_cycle_from(&graph, a));
+    }
+
+    // ── tag_bytes / op_bytes / report_prefix ────────────────────────
+
+    #[test]
+    fn tag_bytes_deterministic() {
+        let t1 = BilateralControlResistance::tag_bytes(b"device_1");
+        let t2 = BilateralControlResistance::tag_bytes(b"device_1");
+        assert_eq!(t1, t2);
+    }
+
+    #[test]
+    fn tag_bytes_different_inputs_differ() {
+        let t1 = BilateralControlResistance::tag_bytes(b"device_1");
+        let t2 = BilateralControlResistance::tag_bytes(b"device_2");
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn op_bytes_deterministic() {
+        let op = Operation::Noop;
+        let b1 = BilateralControlResistance::op_bytes(&op);
+        let b2 = BilateralControlResistance::op_bytes(&op);
+        assert_eq!(b1, b2);
+    }
+
+    #[test]
+    fn report_prefix_stable() {
+        assert_eq!(
+            BilateralControlResistance::report_prefix(),
+            b"DSM/BCR/REPORT/v2\0"
+        );
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/security/manipulation_resistance.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/security/manipulation_resistance.rs
@@ -437,3 +437,363 @@ struct TransferDetails {
     amount: u64,
     recipient: Vec<u8>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::operations::TransactionMode;
+    use crate::types::state_types::{DeviceInfo, State, StateParams};
+    use crate::types::token_types::Balance;
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    fn dev_info() -> DeviceInfo {
+        DeviceInfo::new([0x11; 32], vec![0x22; 64])
+    }
+
+    fn make_state(n: u64) -> State {
+        State::new(StateParams::new(
+            n,
+            vec![0xAA; 16],
+            Operation::Noop,
+            dev_info(),
+        ))
+    }
+
+    fn make_transfer_op(amount: u64, recipient: &[u8], token_id: &[u8]) -> Operation {
+        Operation::Transfer {
+            to_device_id: recipient.to_vec(),
+            amount: Balance::from_state(amount, [0; 32], 0),
+            token_id: token_id.to_vec(),
+            mode: TransactionMode::Unilateral,
+            nonce: vec![0x01; 16],
+            verification: crate::types::operations::VerificationType::Standard,
+            pre_commit: None,
+            recipient: recipient.to_vec(),
+            to: recipient.to_vec(),
+            message: "test transfer".into(),
+            signature: vec![],
+        }
+    }
+
+    // ── extract_transfer_operation ───────────────────────────────────
+
+    #[test]
+    fn extract_transfer_from_noop_returns_none() {
+        assert!(ManipulationResistance::extract_transfer_operation(&Operation::Noop).is_none());
+    }
+
+    #[test]
+    fn extract_transfer_from_transfer_returns_details() {
+        let op = make_transfer_op(500, b"bob", b"ERA");
+        let details = ManipulationResistance::extract_transfer_operation(&op).unwrap();
+        assert_eq!(details.amount, 500);
+        assert_eq!(details.recipient, b"bob");
+    }
+
+    #[test]
+    fn extract_transfer_from_genesis_returns_none() {
+        assert!(ManipulationResistance::extract_transfer_operation(&Operation::Genesis).is_none());
+    }
+
+    // ── verify_double_spend_impossible ───────────────────────────────
+
+    #[test]
+    fn double_spend_no_proposed_states_passes() {
+        let current = make_state(5);
+        let result = ManipulationResistance::verify_double_spend_impossible(&current, &[]).unwrap();
+        assert!(result, "no proposed states means no double spend");
+    }
+
+    #[test]
+    fn double_spend_single_proposed_state_passes() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("tok".into(), Balance::from_state(100, [0; 32], 5));
+        current.hash = current.compute_hash().unwrap();
+
+        let mut proposed = make_state(6);
+        proposed.prev_state_hash = current.hash;
+        proposed.hash = proposed.compute_hash().unwrap();
+
+        let result =
+            ManipulationResistance::verify_double_spend_impossible(&current, &[proposed]).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn double_spend_conflicting_recipients_same_full_balance() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("tok".into(), Balance::from_state(100, [0; 32], 5));
+        current.hash = current.compute_hash().unwrap();
+
+        let mut proposed_a = make_state(6);
+        proposed_a.operation = make_transfer_op(100, b"alice", b"tok");
+        proposed_a.prev_state_hash = current.hash;
+
+        let mut proposed_b = make_state(6);
+        proposed_b.operation = make_transfer_op(100, b"bob", b"tok");
+        proposed_b.prev_state_hash = current.hash;
+
+        let result = ManipulationResistance::verify_double_spend_impossible(
+            &current,
+            &[proposed_a, proposed_b],
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "transferring full balance to two different recipients is a double spend"
+        );
+    }
+
+    #[test]
+    fn double_spend_exceeding_balance() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("tok".into(), Balance::from_state(100, [0; 32], 5));
+        current.hash = current.compute_hash().unwrap();
+
+        let mut proposed_a = make_state(6);
+        proposed_a.operation = make_transfer_op(60, b"alice", b"tok");
+        proposed_a.prev_state_hash = current.hash;
+
+        let mut proposed_b = make_state(6);
+        proposed_b.operation = make_transfer_op(60, b"bob", b"tok");
+        proposed_b.prev_state_hash = current.hash;
+
+        let result = ManipulationResistance::verify_double_spend_impossible(
+            &current,
+            &[proposed_a, proposed_b],
+        )
+        .unwrap();
+        assert!(!result, "60+60=120 > 100 available");
+    }
+
+    #[test]
+    fn double_spend_wrong_state_numbers() {
+        let mut current = make_state(5);
+        current.hash = current.compute_hash().unwrap();
+
+        let mut proposed_a = make_state(7); // wrong: should be 6
+        proposed_a.prev_state_hash = current.hash;
+
+        let mut proposed_b = make_state(6);
+        proposed_b.prev_state_hash = current.hash;
+
+        let result = ManipulationResistance::verify_double_spend_impossible(
+            &current,
+            &[proposed_a, proposed_b],
+        )
+        .unwrap();
+        assert!(!result, "state_number must be current + 1");
+    }
+
+    #[test]
+    fn double_spend_wrong_prev_hash() {
+        let mut current = make_state(5);
+        current.hash = current.compute_hash().unwrap();
+
+        let mut proposed_a = make_state(6);
+        proposed_a.prev_state_hash = current.hash;
+
+        let mut proposed_b = make_state(6);
+        proposed_b.prev_state_hash = [0xFF; 32]; // wrong hash
+
+        let result = ManipulationResistance::verify_double_spend_impossible(
+            &current,
+            &[proposed_a, proposed_b],
+        )
+        .unwrap();
+        assert!(!result, "prev_state_hash must match");
+    }
+
+    // ── verify_state_transition_rules ───────────────────────────────
+
+    #[test]
+    fn transition_rules_wrong_increment() {
+        let mut current = make_state(5);
+        current.hash = current.compute_hash().unwrap();
+
+        let mut next = make_state(7); // should be 6
+        next.prev_state_hash = current.hash;
+        next.hash = next.compute_hash().unwrap();
+
+        let result =
+            ManipulationResistance::verify_state_transition_rules(&current, &next).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn transition_rules_wrong_prev_hash() {
+        let mut current = make_state(5);
+        current.hash = current.compute_hash().unwrap();
+
+        let mut next = make_state(6);
+        next.prev_state_hash = [0xFF; 32]; // wrong
+        next.hash = next.compute_hash().unwrap();
+
+        let result =
+            ManipulationResistance::verify_state_transition_rules(&current, &next).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn transition_rules_balance_conservation() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("tok".into(), Balance::from_state(100, [0; 32], 5));
+        current.hash = current.compute_hash().unwrap();
+
+        let mut next = make_state(6);
+        next.token_balances
+            .insert("tok".into(), Balance::from_state(100, [0; 32], 6));
+        next.prev_state_hash = current.hash;
+
+        let result =
+            ManipulationResistance::verify_state_transition_rules(&current, &next).unwrap();
+        assert!(result, "same total balance should pass conservation check");
+    }
+
+    #[test]
+    fn transition_rules_balance_not_conserved() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("tok".into(), Balance::from_state(100, [0; 32], 5));
+        current.hash = current.compute_hash().unwrap();
+
+        let mut next = make_state(6);
+        next.token_balances
+            .insert("tok".into(), Balance::from_state(200, [0; 32], 6));
+        next.prev_state_hash = current.hash;
+
+        let result =
+            ManipulationResistance::verify_state_transition_rules(&current, &next).unwrap();
+        assert!(!result, "different total balance should fail conservation");
+    }
+
+    // ── verify_balance_conservation ─────────────────────────────────
+
+    #[test]
+    fn balance_conservation_add_relationship_unchanged() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("tok".into(), Balance::from_state(50, [0; 32], 5));
+
+        let mut next = make_state(6);
+        next.operation = Operation::AddRelationship {
+            from_id: [0x01; 32],
+            to_id: [0x02; 32],
+            relationship_type: b"bilateral".to_vec(),
+            metadata: vec![],
+            proof: vec![],
+            mode: TransactionMode::Bilateral,
+            message: "test".into(),
+        };
+        next.token_balances
+            .insert("tok".into(), Balance::from_state(50, [0; 32], 6));
+
+        let result = ManipulationResistance::verify_balance_conservation(&current, &next).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn balance_conservation_add_relationship_changed_fails() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("tok".into(), Balance::from_state(50, [0; 32], 5));
+
+        let mut next = make_state(6);
+        next.operation = Operation::AddRelationship {
+            from_id: [0x01; 32],
+            to_id: [0x02; 32],
+            relationship_type: b"bilateral".to_vec(),
+            metadata: vec![],
+            proof: vec![],
+            mode: TransactionMode::Bilateral,
+            message: "test".into(),
+        };
+        next.token_balances
+            .insert("tok".into(), Balance::from_state(999, [0; 32], 6));
+
+        let result = ManipulationResistance::verify_balance_conservation(&current, &next).unwrap();
+        assert!(!result);
+    }
+
+    // ── verify_signatures (state gap) ───────────────────────────────
+
+    #[test]
+    fn verify_signatures_excessive_gap_fails() {
+        let mut current = make_state(5);
+        current.hash = current.compute_hash().unwrap();
+
+        let mut next = make_state(200);
+        next.prev_state_hash = current.hash;
+        next.hash = next.compute_hash().unwrap();
+
+        let result = ManipulationResistance::verify_signatures(&current, &next).unwrap();
+        assert!(!result, "gap of 195 > MAX_STATE_GAP=100 should fail");
+    }
+
+    #[test]
+    fn verify_signatures_normal_gap_passes_no_sigs() {
+        let mut current = make_state(5);
+        current.hash = current.compute_hash().unwrap();
+
+        let next = make_state(6);
+
+        let result = ManipulationResistance::verify_signatures(&current, &next).unwrap();
+        assert!(result, "gap of 1 with no signatures should pass");
+    }
+
+    // ── verify_commitment_binding ───────────────────────────────────
+
+    #[test]
+    fn commitment_binding_no_commitments_passes() {
+        let s0 = make_state(0);
+        let s1 = make_state(1);
+        let s2 = make_state(2);
+        let result = ManipulationResistance::verify_commitment_binding(&[s0, s1, s2]).unwrap();
+        assert!(
+            result,
+            "no forward commitments means binding is trivially satisfied"
+        );
+    }
+
+    #[test]
+    fn commitment_binding_too_few_states() {
+        let s0 = make_state(0);
+        let s1 = make_state(1);
+        let result = ManipulationResistance::verify_commitment_binding(&[s0, s1]).unwrap();
+        assert!(
+            result,
+            "fewer than 3 states means no windows(3), trivially true"
+        );
+    }
+
+    #[test]
+    fn commitment_binding_empty() {
+        let result = ManipulationResistance::verify_commitment_binding(&[]).unwrap();
+        assert!(result);
+    }
+
+    // ── TransferDetails ─────────────────────────────────────────────
+
+    #[test]
+    fn transfer_details_debug() {
+        let td = TransferDetails {
+            amount: 42,
+            recipient: vec![1, 2, 3],
+        };
+        let dbg = format!("{:?}", td);
+        assert!(dbg.contains("42"));
+        assert!(dbg.contains("recipient"));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/bilateral.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/bilateral.rs
@@ -290,3 +290,282 @@ impl Default for BilateralStateManager {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::state_machine::relationship::KeyDerivationStrategy;
+
+    fn make_manager() -> BilateralStateManager {
+        BilateralStateManager::new()
+    }
+
+    fn dummy_key() -> Vec<u8> {
+        vec![0xAB; 32]
+    }
+
+    // ── BilateralStateManager::new ──────────────────────────────────────
+
+    #[test]
+    fn new_creates_empty_sessions() {
+        let mgr = make_manager();
+        assert!(mgr.active_sessions.is_empty());
+    }
+
+    // ── BilateralStateManager::new_with_strategy ────────────────────────
+
+    #[test]
+    fn new_with_strategy_canonical() {
+        let mgr = BilateralStateManager::new_with_strategy(KeyDerivationStrategy::Canonical);
+        assert!(mgr.active_sessions.is_empty());
+    }
+
+    #[test]
+    fn new_with_strategy_entity_centric() {
+        let mgr = BilateralStateManager::new_with_strategy(KeyDerivationStrategy::EntityCentric);
+        assert!(mgr.active_sessions.is_empty());
+    }
+
+    #[test]
+    fn new_with_strategy_hashed() {
+        let mgr = BilateralStateManager::new_with_strategy(KeyDerivationStrategy::Hashed);
+        assert!(mgr.active_sessions.is_empty());
+    }
+
+    // ── Default ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn default_is_same_as_new() {
+        let from_new = BilateralStateManager::new();
+        let from_default = BilateralStateManager::default();
+        assert_eq!(
+            from_new.active_sessions.len(),
+            from_default.active_sessions.len()
+        );
+    }
+
+    // ── id_from_32 ──────────────────────────────────────────────────────
+
+    #[test]
+    fn id_from_32_zero_bytes() {
+        let id = [0u8; 32];
+        let result = BilateralStateManager::id_from_32(&id);
+        assert_eq!(result, "0-0");
+    }
+
+    #[test]
+    fn id_from_32_known_values() {
+        let mut id = [0u8; 32];
+        id[0] = 1; // lo u64 = 1 (little-endian)
+        let result = BilateralStateManager::id_from_32(&id);
+        assert_eq!(result, "1-0");
+    }
+
+    #[test]
+    fn id_from_32_high_half() {
+        let mut id = [0u8; 32];
+        id[8] = 2; // hi u64 = 2 (little-endian)
+        let result = BilateralStateManager::id_from_32(&id);
+        assert_eq!(result, "0-2");
+    }
+
+    #[test]
+    fn id_from_32_consistency() {
+        let id = [0xFF; 32];
+        let a = BilateralStateManager::id_from_32(&id);
+        let b = BilateralStateManager::id_from_32(&id);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn id_from_32_different_inputs_differ() {
+        let id_a = [0x01; 32];
+        let id_b = [0x02; 32];
+        assert_ne!(
+            BilateralStateManager::id_from_32(&id_a),
+            BilateralStateManager::id_from_32(&id_b),
+        );
+    }
+
+    // ── label_from_bytes ────────────────────────────────────────────────
+
+    #[test]
+    fn label_from_bytes_long_input() {
+        let bytes = vec![1u8; 16];
+        let label = BilateralStateManager::label_from_bytes(&bytes);
+        assert!(label.starts_with("len16:"));
+        let lo = u64::from_le_bytes([1; 8]);
+        assert!(label.contains(&lo.to_string()));
+    }
+
+    #[test]
+    fn label_from_bytes_exactly_8() {
+        let bytes = vec![0u8; 8];
+        let label = BilateralStateManager::label_from_bytes(&bytes);
+        assert_eq!(label, "len8:0");
+    }
+
+    #[test]
+    fn label_from_bytes_short_input() {
+        let bytes = vec![0xAA; 3];
+        let label = BilateralStateManager::label_from_bytes(&bytes);
+        assert_eq!(label, "len3");
+    }
+
+    #[test]
+    fn label_from_bytes_empty() {
+        let label = BilateralStateManager::label_from_bytes(&[]);
+        assert_eq!(label, "len0");
+    }
+
+    // ── create_session / close_session ──────────────────────────────────
+
+    #[test]
+    fn create_session_returns_expected_id() {
+        let mut mgr = make_manager();
+        let sid = mgr.create_session("alice", "bob");
+        assert_eq!(sid, "session_alice_bob");
+    }
+
+    #[test]
+    fn create_session_stores_in_active_sessions() {
+        let mut mgr = make_manager();
+        let sid = mgr.create_session("alice", "bob");
+        assert!(mgr.active_sessions.contains_key(&sid));
+        assert_eq!(mgr.active_sessions.get(&sid).unwrap(), "alice:bob");
+    }
+
+    #[test]
+    fn close_session_existing_returns_true() {
+        let mut mgr = make_manager();
+        let sid = mgr.create_session("alice", "bob");
+        assert!(mgr.close_session(&sid));
+        assert!(!mgr.active_sessions.contains_key(&sid));
+    }
+
+    #[test]
+    fn close_session_nonexistent_returns_false() {
+        let mut mgr = make_manager();
+        assert!(!mgr.close_session("no_such_session"));
+    }
+
+    #[test]
+    fn close_session_twice_returns_false_second_time() {
+        let mut mgr = make_manager();
+        let sid = mgr.create_session("alice", "bob");
+        assert!(mgr.close_session(&sid));
+        assert!(!mgr.close_session(&sid));
+    }
+
+    // ── generate_entropy ────────────────────────────────────────────────
+
+    #[test]
+    fn generate_entropy_returns_32_bytes() {
+        let mgr = make_manager();
+        let entropy = mgr.generate_entropy().unwrap();
+        assert_eq!(entropy.len(), 32);
+    }
+
+    #[test]
+    fn generate_entropy_two_calls_differ() {
+        let mgr = make_manager();
+        let a = mgr.generate_entropy().unwrap();
+        let b = mgr.generate_entropy().unwrap();
+        assert_ne!(a, b);
+    }
+
+    // ── initialize_relationship ─────────────────────────────────────────
+
+    #[test]
+    fn initialize_relationship_succeeds() {
+        let mut mgr = make_manager();
+        let result = mgr.initialize_relationship("alice", "bob", dummy_key(), dummy_key());
+        assert!(result.is_ok());
+    }
+
+    // ── ensure_relationship_initialized ─────────────────────────────────
+
+    #[test]
+    fn ensure_relationship_initialized_is_idempotent() {
+        let mut mgr = make_manager();
+        let r1 = mgr.ensure_relationship_initialized("alice", "bob", dummy_key(), dummy_key());
+        assert!(r1.is_ok());
+
+        let r2 = mgr.ensure_relationship_initialized("alice", "bob", dummy_key(), dummy_key());
+        assert!(r2.is_ok());
+    }
+
+    // ── ensure_relationship_initialized_bytes ───────────────────────────
+
+    #[test]
+    fn ensure_relationship_initialized_bytes_succeeds() {
+        let mut mgr = make_manager();
+        let entity = [0x01u8; 32];
+        let counterparty = [0x02u8; 32];
+        let result = mgr.ensure_relationship_initialized_bytes(
+            &entity,
+            &counterparty,
+            dummy_key(),
+            dummy_key(),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn ensure_relationship_initialized_bytes_is_idempotent() {
+        let mut mgr = make_manager();
+        let entity = [0x11u8; 32];
+        let counterparty = [0x22u8; 32];
+        mgr.ensure_relationship_initialized_bytes(&entity, &counterparty, dummy_key(), dummy_key())
+            .unwrap();
+        let r2 = mgr.ensure_relationship_initialized_bytes(
+            &entity,
+            &counterparty,
+            dummy_key(),
+            dummy_key(),
+        );
+        assert!(r2.is_ok());
+    }
+
+    // ── update_relationship_state ───────────────────────────────────────
+
+    #[test]
+    fn update_relationship_state_accepts_pair() {
+        let mut mgr = make_manager();
+
+        let entity_id = [0x01u8; 32];
+        let counterparty_id = [0x02u8; 32];
+        let entropy_a = mgr.generate_entropy().unwrap();
+        let entropy_b = mgr.generate_entropy().unwrap();
+
+        let entity_state = State::new_genesis(entropy_a, DeviceInfo::new(entity_id, dummy_key()));
+        let counterparty_state =
+            State::new_genesis(entropy_b, DeviceInfo::new(counterparty_id, dummy_key()));
+
+        let pair = RelationshipStatePair::new(
+            entity_id,
+            counterparty_id,
+            entity_state,
+            counterparty_state,
+        )
+        .unwrap();
+
+        let result = mgr.update_relationship_state("bob", pair);
+        assert!(result.is_ok());
+    }
+
+    // ── multiple sessions coexist ───────────────────────────────────────
+
+    #[test]
+    fn multiple_sessions_coexist() {
+        let mut mgr = make_manager();
+        let s1 = mgr.create_session("alice", "bob");
+        let s2 = mgr.create_session("alice", "carol");
+        assert_ne!(s1, s2);
+        assert_eq!(mgr.active_sessions.len(), 2);
+
+        mgr.close_session(&s1);
+        assert_eq!(mgr.active_sessions.len(), 1);
+        assert!(mgr.active_sessions.contains_key(&s2));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/checkpoint.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/checkpoint.rs
@@ -255,3 +255,370 @@ impl CheckpointManager {
         checkpoint.verify_state(state)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::operations::Operation;
+    use crate::types::state_types::{DeviceInfo, StateParams};
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    fn dev_info() -> DeviceInfo {
+        DeviceInfo::new([0x11; 32], vec![0x22; 64])
+    }
+
+    fn make_dsm_state(n: u64) -> DsmState {
+        let mut s = DsmState::new(StateParams::new(
+            n,
+            vec![0xAA; 16],
+            Operation::Noop,
+            dev_info(),
+        ));
+        let hash_vec = s.compute_hash().unwrap();
+        s.hash.copy_from_slice(&hash_vec[..32]);
+        s
+    }
+
+    // ── Checkpoint::get_signing_data ────────────────────────────────
+
+    #[test]
+    fn signing_data_deterministic() {
+        let cp = Checkpoint {
+            id: "cp_1".into(),
+            state_number: 42,
+            state_hash: [0xAA; 32],
+            genesis_hash: [0xBB; 32],
+            tick: 100,
+            device_id: "device_a".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        let d1 = cp.get_signing_data();
+        let d2 = cp.get_signing_data();
+        assert_eq!(d1, d2);
+        assert!(!d1.is_empty());
+    }
+
+    #[test]
+    fn signing_data_includes_state_number() {
+        let cp = Checkpoint {
+            id: "cp".into(),
+            state_number: 0x0102030405060708,
+            state_hash: [0; 32],
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        let data = cp.get_signing_data();
+        assert_eq!(&data[0..8], &0x0102030405060708u64.to_be_bytes());
+    }
+
+    #[test]
+    fn signing_data_includes_state_hash() {
+        let cp = Checkpoint {
+            id: "cp".into(),
+            state_number: 0,
+            state_hash: [0xCC; 32],
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        let data = cp.get_signing_data();
+        assert_eq!(&data[8..40], &[0xCC; 32]);
+    }
+
+    #[test]
+    fn signing_data_includes_genesis_hash() {
+        let cp = Checkpoint {
+            id: "cp".into(),
+            state_number: 0,
+            state_hash: [0; 32],
+            genesis_hash: [0xDD; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        let data = cp.get_signing_data();
+        assert_eq!(&data[40..72], &[0xDD; 32]);
+    }
+
+    #[test]
+    fn signing_data_includes_invalidation_flag() {
+        let cp_normal = Checkpoint {
+            id: "cp".into(),
+            state_number: 0,
+            state_hash: [0; 32],
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        let cp_invalid = Checkpoint {
+            id: "cp".into(),
+            state_number: 0,
+            state_hash: [0; 32],
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: true,
+            invalidation_reason: Some("compromised".into()),
+        };
+        let d1 = cp_normal.get_signing_data();
+        let d2 = cp_invalid.get_signing_data();
+        assert_ne!(d1, d2);
+    }
+
+    // ── Checkpoint::add_merkle_proof ────────────────────────────────
+
+    #[test]
+    fn add_merkle_proof() {
+        let mut cp = Checkpoint {
+            id: "cp".into(),
+            state_number: 0,
+            state_hash: [0; 32],
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        assert!(cp.merkle_proof.is_none());
+        cp.add_merkle_proof(vec![1, 2, 3]);
+        assert_eq!(cp.merkle_proof, Some(vec![1, 2, 3]));
+    }
+
+    // ── Checkpoint::verify_state ────────────────────────────────────
+
+    #[test]
+    fn verify_state_matching() {
+        let state = make_dsm_state(10);
+        let mut state_hash = [0u8; 32];
+        let h = state.hash().unwrap();
+        state_hash.copy_from_slice(&h[0..32]);
+
+        let cp = Checkpoint {
+            id: "cp".into(),
+            state_number: 10,
+            state_hash,
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        assert!(cp.verify_state(&state).unwrap());
+    }
+
+    #[test]
+    fn verify_state_wrong_number() {
+        let state = make_dsm_state(10);
+        let mut state_hash = [0u8; 32];
+        let h = state.hash().unwrap();
+        state_hash.copy_from_slice(&h[0..32]);
+
+        let cp = Checkpoint {
+            id: "cp".into(),
+            state_number: 99, // wrong
+            state_hash,
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        assert!(!cp.verify_state(&state).unwrap());
+    }
+
+    #[test]
+    fn verify_state_wrong_hash() {
+        let state = make_dsm_state(10);
+
+        let cp = Checkpoint {
+            id: "cp".into(),
+            state_number: 10,
+            state_hash: [0xFF; 32], // wrong
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        assert!(!cp.verify_state(&state).unwrap());
+    }
+
+    // ── Checkpoint with Identity (bypasses sign for pure logic tests) ─
+
+    #[test]
+    fn checkpoint_verify_state_with_manual_construction() {
+        let state = make_dsm_state(5);
+        let hash_vec = state.hash().unwrap();
+        let mut state_hash = [0u8; 32];
+        state_hash.copy_from_slice(&hash_vec[..32]);
+
+        let cp = Checkpoint {
+            id: "cp_5".into(),
+            state_number: 5,
+            state_hash,
+            genesis_hash: [0; 32],
+            tick: 1,
+            device_id: "test_device".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+
+        assert_eq!(cp.state_number, 5);
+        assert_eq!(cp.device_id, "test_device");
+        assert!(!cp.is_invalidation);
+        assert!(cp.invalidation_reason.is_none());
+        assert!(cp.verify_state(&state).unwrap());
+    }
+
+    #[test]
+    fn checkpoint_invalidation_fields() {
+        let cp = Checkpoint {
+            id: "cp_inv".into(),
+            state_number: 3,
+            state_hash: [0; 32],
+            genesis_hash: [0; 32],
+            tick: 1,
+            device_id: "dev".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: true,
+            invalidation_reason: Some("key compromised".into()),
+        };
+        assert!(cp.is_invalidation);
+        assert_eq!(cp.invalidation_reason.as_deref(), Some("key compromised"));
+    }
+
+    // ── CheckpointManager ───────────────────────────────────────────
+
+    #[test]
+    fn checkpoint_manager_default() {
+        let mgr = CheckpointManager::default();
+        let dbg = format!("{:?}", mgr);
+        assert!(dbg.contains("CheckpointManager"));
+    }
+
+    #[test]
+    fn checkpoint_manager_new() {
+        let _mgr = CheckpointManager::new();
+    }
+
+    // ── Checkpoint struct fields ────────────────────────────────────
+
+    #[test]
+    fn checkpoint_clone() {
+        let cp = Checkpoint {
+            id: "cp_1".into(),
+            state_number: 1,
+            state_hash: [0x01; 32],
+            genesis_hash: [0x02; 32],
+            tick: 42,
+            device_id: "dev".into(),
+            signature: vec![0x03; 10],
+            merkle_proof: Some(vec![0x04; 5]),
+            is_invalidation: true,
+            invalidation_reason: Some("test".into()),
+        };
+        let cp2 = cp.clone();
+        assert_eq!(cp.id, cp2.id);
+        assert_eq!(cp.state_hash, cp2.state_hash);
+        assert_eq!(cp.merkle_proof, cp2.merkle_proof);
+        assert_eq!(cp.invalidation_reason, cp2.invalidation_reason);
+    }
+
+    #[test]
+    fn checkpoint_debug_trait() {
+        let cp = Checkpoint {
+            id: "cp_dbg".into(),
+            state_number: 7,
+            state_hash: [0xFF; 32],
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "d".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        let dbg = format!("{:?}", cp);
+        assert!(dbg.contains("cp_dbg"));
+        assert!(dbg.contains("7"));
+    }
+
+    #[test]
+    fn signing_data_varies_with_device_id() {
+        let cp_a = Checkpoint {
+            id: "cp".into(),
+            state_number: 0,
+            state_hash: [0; 32],
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "dev_a".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        let cp_b = Checkpoint {
+            id: "cp".into(),
+            state_number: 0,
+            state_hash: [0; 32],
+            genesis_hash: [0; 32],
+            tick: 0,
+            device_id: "dev_b".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        assert_ne!(cp_a.get_signing_data(), cp_b.get_signing_data());
+    }
+
+    #[test]
+    fn signing_data_varies_with_tick() {
+        let make = |tick: u64| Checkpoint {
+            id: "cp".into(),
+            state_number: 0,
+            state_hash: [0; 32],
+            genesis_hash: [0; 32],
+            tick,
+            device_id: "dev".into(),
+            signature: vec![],
+            merkle_proof: None,
+            is_invalidation: false,
+            invalidation_reason: None,
+        };
+        assert_ne!(make(1).get_signing_data(), make(2).get_signing_data());
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/policy_cache.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/policy_cache.rs
@@ -80,4 +80,136 @@ impl PolicyCache {
         let mut index = self.token_index.write();
         index.insert(token_id, anchor);
     }
+
+    pub fn get_anchor_for_token(&self, token_id: &str) -> Option<PolicyAnchor> {
+        self.token_index.read().get(token_id).cloned()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.read().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::policy_types::{PolicyCondition, PolicyFile, PolicyRole};
+
+    fn make_policy(author: &str) -> TokenPolicy {
+        let mut pf = PolicyFile::new("TestPolicy", "1.0", author);
+        pf.add_condition(PolicyCondition::OperationRestriction {
+            allowed_operations: vec!["Transfer".to_string()],
+        });
+        pf.add_role(PolicyRole {
+            id: "owner".into(),
+            name: "Owner".into(),
+            permissions: vec!["Transfer".into()],
+        });
+        TokenPolicy::new(pf).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_store_and_get_policy() {
+        let cache = PolicyCache::new(PolicyCacheConfig::default());
+        let policy = make_policy("author-stored");
+        let anchor = policy.anchor.clone();
+
+        cache.store_policy(anchor.clone(), policy.clone());
+        let retrieved = cache.get_policy(&anchor).await.unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().anchor, anchor);
+    }
+
+    #[tokio::test]
+    async fn test_get_missing_policy_returns_none() {
+        let cache = PolicyCache::new(PolicyCacheConfig::default());
+        let fake_anchor = PolicyAnchor::from_bytes([0xBB; 32]);
+        let result = cache.get_policy(&fake_anchor).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_lru_eviction_at_capacity() {
+        let config = PolicyCacheConfig {
+            max_entries: 2,
+            ttl_ticks: 100_000,
+        };
+        let cache = PolicyCache::new(config);
+
+        let p1 = make_policy("author-p1");
+        let p2 = make_policy("author-p2");
+        let p3 = make_policy("author-p3");
+
+        let a1 = p1.anchor.clone();
+        let a2 = p2.anchor.clone();
+        let a3 = p3.anchor.clone();
+
+        cache.store_policy(a1.clone(), p1);
+        cache.store_policy(a2.clone(), p2);
+        assert_eq!(cache.len(), 2);
+
+        cache.store_policy(a3.clone(), p3);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.entries.read().contains_key(&a3));
+    }
+
+    #[test]
+    fn test_index_token_policy_and_lookup() {
+        let cache = PolicyCache::new(PolicyCacheConfig::default());
+        let policy = make_policy("author-indexed");
+        let anchor = policy.anchor.clone();
+
+        cache.store_policy(anchor.clone(), policy);
+        cache.index_token_policy("tok-123".to_string(), anchor.clone());
+
+        let looked_up = cache.get_anchor_for_token("tok-123");
+        assert_eq!(looked_up, Some(anchor));
+    }
+
+    #[test]
+    fn test_index_token_policy_missing_returns_none() {
+        let cache = PolicyCache::new(PolicyCacheConfig::default());
+        assert!(cache.get_anchor_for_token("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_default_config_values() {
+        let config = PolicyCacheConfig::default();
+        assert_eq!(config.max_entries, 1000);
+        assert_eq!(config.ttl_ticks, 10_000);
+    }
+
+    #[test]
+    fn test_is_empty_and_len() {
+        let cache = PolicyCache::new(PolicyCacheConfig::default());
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+
+        let policy = make_policy("author-len");
+        let anchor = policy.anchor.clone();
+        cache.store_policy(anchor, policy);
+
+        assert!(!cache.is_empty());
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn test_overwrite_same_anchor() {
+        let config = PolicyCacheConfig {
+            max_entries: 2,
+            ttl_ticks: 100_000,
+        };
+        let cache = PolicyCache::new(config);
+
+        let policy = make_policy("author-same");
+        let anchor = policy.anchor.clone();
+
+        cache.store_policy(anchor.clone(), policy.clone());
+        cache.store_policy(anchor.clone(), policy);
+        assert_eq!(cache.len(), 1);
+    }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/token_factory.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/token_factory.rs
@@ -216,3 +216,513 @@ pub fn derive_sub_token_genesis(
         contributions,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pid(n: u8) -> ParticipantId {
+        [n; 32]
+    }
+
+    fn contrib(n: u8) -> TokenContribution {
+        TokenContribution {
+            participant: pid(n),
+            material: [n + 100; 32],
+        }
+    }
+
+    fn three_participants() -> Vec<ParticipantId> {
+        vec![pid(1), pid(2), pid(3)]
+    }
+
+    fn three_contributions() -> Vec<TokenContribution> {
+        vec![contrib(1), contrib(2), contrib(3)]
+    }
+
+    fn descriptor() -> &'static [u8] {
+        b"test-token-descriptor"
+    }
+
+    // ── ensure_min_threshold (via create_token_genesis) ─────────────
+
+    #[test]
+    fn fewer_than_3_participants_is_rejected() {
+        let result = create_token_genesis(
+            3,
+            vec![pid(1), pid(2)],
+            descriptor(),
+            None,
+            vec![contrib(1), contrib(2)],
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("≥3 participants"), "got: {msg}");
+    }
+
+    #[test]
+    fn threshold_below_3_is_rejected() {
+        let result = create_token_genesis(
+            2,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("threshold ≥3"), "got: {msg}");
+    }
+
+    #[test]
+    fn threshold_exceeding_participants_is_rejected() {
+        let result = create_token_genesis(
+            4,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("threshold must be ≤ participants"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn exactly_3_participants_3_threshold_succeeds() {
+        let result = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn five_participants_threshold_3_succeeds() {
+        let participants = vec![pid(1), pid(2), pid(3), pid(4), pid(5)];
+        let contributions = vec![contrib(1), contrib(2), contrib(3), contrib(4), contrib(5)];
+        let result = create_token_genesis(3, participants, descriptor(), None, contributions);
+        assert!(result.is_ok());
+        let genesis = result.unwrap();
+        assert_eq!(genesis.threshold, 3);
+        assert_eq!(genesis.participants.len(), 5);
+        assert_eq!(genesis.contributions.len(), 3);
+    }
+
+    // ── create_token_genesis success cases ──────────────────────────
+
+    #[test]
+    fn produces_valid_token_genesis() {
+        let genesis = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_eq!(genesis.threshold, 3);
+        assert_eq!(genesis.participants.len(), 3);
+        assert_eq!(genesis.contributions.len(), 3);
+        assert_eq!(genesis.token_hash.len(), 32);
+        assert_eq!(genesis.token_entropy.len(), 32);
+        assert!(genesis.policy_anchor.is_none());
+        assert_ne!(genesis.token_hash, [0u8; 32]);
+        assert_ne!(genesis.token_entropy, [0u8; 32]);
+    }
+
+    #[test]
+    fn participants_are_sorted_in_output() {
+        let participants = vec![pid(3), pid(1), pid(2)];
+        let genesis =
+            create_token_genesis(3, participants, descriptor(), None, three_contributions())
+                .unwrap();
+
+        assert_eq!(genesis.participants[0], pid(1));
+        assert_eq!(genesis.participants[1], pid(2));
+        assert_eq!(genesis.participants[2], pid(3));
+    }
+
+    #[test]
+    fn contributions_are_sorted_by_participant() {
+        let contributions = vec![contrib(3), contrib(1), contrib(2)];
+        let genesis =
+            create_token_genesis(3, three_participants(), descriptor(), None, contributions)
+                .unwrap();
+
+        assert_eq!(genesis.contributions[0].participant, pid(1));
+        assert_eq!(genesis.contributions[1].participant, pid(2));
+        assert_eq!(genesis.contributions[2].participant, pid(3));
+    }
+
+    #[test]
+    fn token_hash_and_entropy_are_32_bytes() {
+        let genesis = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_eq!(genesis.token_hash.len(), 32);
+        assert_eq!(genesis.token_entropy.len(), 32);
+    }
+
+    #[test]
+    fn different_descriptors_produce_different_hashes() {
+        let g1 = create_token_genesis(
+            3,
+            three_participants(),
+            b"descriptor-A",
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        let g2 = create_token_genesis(
+            3,
+            three_participants(),
+            b"descriptor-B",
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_ne!(g1.token_hash, g2.token_hash);
+        assert_ne!(g1.token_entropy, g2.token_entropy);
+    }
+
+    #[test]
+    fn same_inputs_produce_same_hash_determinism() {
+        let g1 = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        let g2 = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_eq!(g1.token_hash, g2.token_hash);
+        assert_eq!(g1.token_entropy, g2.token_entropy);
+    }
+
+    // ── create_token_genesis error cases ────────────────────────────
+
+    #[test]
+    fn contribution_from_non_participant_is_rejected() {
+        let outsider = TokenContribution {
+            participant: pid(99),
+            material: [0xAA; 32],
+        };
+        let contributions = vec![contrib(1), contrib(2), outsider];
+        let result =
+            create_token_genesis(3, three_participants(), descriptor(), None, contributions);
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("not in participants set"), "got: {msg}");
+    }
+
+    #[test]
+    fn duplicate_contribution_for_same_participant_is_rejected() {
+        let dup = TokenContribution {
+            participant: pid(1),
+            material: [0xBB; 32],
+        };
+        let contributions = vec![contrib(1), dup, contrib(2)];
+        let result =
+            create_token_genesis(3, three_participants(), descriptor(), None, contributions);
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("duplicate contribution"), "got: {msg}");
+    }
+
+    #[test]
+    fn insufficient_contributions_is_rejected() {
+        let contributions = vec![contrib(1), contrib(2)];
+        let result =
+            create_token_genesis(3, three_participants(), descriptor(), None, contributions);
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("insufficient contributions"), "got: {msg}");
+    }
+
+    // ── create_token_genesis with policy anchor ─────────────────────
+
+    #[test]
+    fn policy_anchor_changes_token_hash() {
+        let anchor = PolicyAnchor([0x42; 32]);
+
+        let without = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        let with = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            Some(anchor.clone()),
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_ne!(without.token_hash, with.token_hash);
+        assert_ne!(without.token_entropy, with.token_entropy);
+    }
+
+    #[test]
+    fn policy_anchor_propagates_to_result() {
+        let anchor = PolicyAnchor([0x42; 32]);
+        let genesis = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            Some(anchor.clone()),
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_eq!(genesis.policy_anchor, Some(anchor));
+    }
+
+    // ── derive_sub_token_genesis ────────────────────────────────────
+
+    #[test]
+    fn derive_produces_valid_sub_token_genesis() {
+        let parent = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        let sub = derive_sub_token_genesis(
+            &parent,
+            b"sub-1",
+            3,
+            three_participants(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_eq!(sub.threshold, 3);
+        assert_eq!(sub.participants.len(), 3);
+        assert_ne!(sub.token_hash, [0u8; 32]);
+        assert_ne!(sub.token_hash, parent.token_hash);
+    }
+
+    #[test]
+    fn different_sub_id_produces_different_result() {
+        let parent = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        let sub_a = derive_sub_token_genesis(
+            &parent,
+            b"sub-A",
+            3,
+            three_participants(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        let sub_b = derive_sub_token_genesis(
+            &parent,
+            b"sub-B",
+            3,
+            three_participants(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_ne!(sub_a.token_hash, sub_b.token_hash);
+        assert_ne!(sub_a.token_entropy, sub_b.token_entropy);
+    }
+
+    #[test]
+    fn derive_inherits_parent_policy_anchor_when_none_provided() {
+        let anchor = PolicyAnchor([0x77; 32]);
+        let parent = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            Some(anchor.clone()),
+            three_contributions(),
+        )
+        .unwrap();
+
+        let sub = derive_sub_token_genesis(
+            &parent,
+            b"sub-inherit",
+            3,
+            three_participants(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_eq!(sub.policy_anchor, Some(anchor));
+    }
+
+    #[test]
+    fn derive_overrides_policy_anchor_when_provided() {
+        let parent_anchor = PolicyAnchor([0x77; 32]);
+        let child_anchor = PolicyAnchor([0x88; 32]);
+        let parent = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            Some(parent_anchor),
+            three_contributions(),
+        )
+        .unwrap();
+
+        let sub = derive_sub_token_genesis(
+            &parent,
+            b"sub-override",
+            3,
+            three_participants(),
+            Some(child_anchor.clone()),
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_eq!(sub.policy_anchor, Some(child_anchor));
+    }
+
+    // ── Determinism tests ───────────────────────────────────────────
+
+    #[test]
+    fn identical_inputs_produce_identical_results() {
+        let make = || {
+            create_token_genesis(
+                3,
+                three_participants(),
+                descriptor(),
+                None,
+                three_contributions(),
+            )
+            .unwrap()
+        };
+
+        let a = make();
+        let b = make();
+        assert_eq!(a.token_hash, b.token_hash);
+        assert_eq!(a.token_entropy, b.token_entropy);
+        assert_eq!(a.threshold, b.threshold);
+        assert_eq!(a.participants, b.participants);
+        assert_eq!(a.contributions.len(), b.contributions.len());
+        for (ca, cb) in a.contributions.iter().zip(b.contributions.iter()) {
+            assert_eq!(ca.participant, cb.participant);
+            assert_eq!(ca.material, cb.material);
+        }
+    }
+
+    #[test]
+    fn contribution_order_does_not_affect_result() {
+        let g1 = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            vec![contrib(1), contrib(2), contrib(3)],
+        )
+        .unwrap();
+
+        let g2 = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            vec![contrib(3), contrib(1), contrib(2)],
+        )
+        .unwrap();
+
+        assert_eq!(g1.token_hash, g2.token_hash);
+        assert_eq!(g1.token_entropy, g2.token_entropy);
+    }
+
+    #[test]
+    fn participant_order_does_not_affect_result() {
+        let g1 = create_token_genesis(
+            3,
+            vec![pid(1), pid(2), pid(3)],
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        let g2 = create_token_genesis(
+            3,
+            vec![pid(3), pid(1), pid(2)],
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_eq!(g1.token_hash, g2.token_hash);
+        assert_eq!(g1.token_entropy, g2.token_entropy);
+    }
+
+    #[test]
+    fn only_threshold_contributions_are_kept() {
+        let participants = vec![pid(1), pid(2), pid(3), pid(4), pid(5)];
+        let contributions = vec![contrib(1), contrib(2), contrib(3), contrib(4), contrib(5)];
+        let genesis =
+            create_token_genesis(3, participants, descriptor(), None, contributions).unwrap();
+
+        assert_eq!(genesis.contributions.len(), 3);
+        assert_eq!(genesis.contributions[0].participant, pid(1));
+        assert_eq!(genesis.contributions[1].participant, pid(2));
+        assert_eq!(genesis.contributions[2].participant, pid(3));
+    }
+
+    #[test]
+    fn token_hash_differs_from_token_entropy() {
+        let genesis = create_token_genesis(
+            3,
+            three_participants(),
+            descriptor(),
+            None,
+            three_contributions(),
+        )
+        .unwrap();
+
+        assert_ne!(genesis.token_hash, genesis.token_entropy);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/token_registry.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/token_registry.rs
@@ -347,3 +347,340 @@ impl TokenRegistry {
         Ok((total, unique_targets.len()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::token_types::{Balance, Token, TokenStatus};
+
+    fn make_registry() -> TokenRegistry {
+        let tsm = Arc::new(TokenStateManager::new());
+        TokenRegistry::new(tsm)
+    }
+
+    fn make_token(owner: &str, data: &[u8]) -> Token {
+        Token::new(
+            owner,
+            data.to_vec(),
+            vec![],
+            Balance::from_state(100, [0; 32], 1),
+            [0xAA; 32],
+        )
+    }
+
+    // ── Construction ────────────────────────────────────────────────
+
+    #[test]
+    fn new_registry_is_empty() {
+        let reg = make_registry();
+        assert_eq!(reg.token_count(), 0);
+        assert!(reg.get_all_token_ids().unwrap().is_empty());
+    }
+
+    // ── register_token ──────────────────────────────────────────────
+
+    #[test]
+    fn register_and_get_token_from_cache() {
+        let reg = make_registry();
+        let t = make_token("alice", b"tok_data_1");
+        let id = t.id().to_string();
+
+        reg.register_token(t.clone(), Some("MyToken".into()))
+            .unwrap();
+        assert_eq!(reg.token_count(), 1);
+
+        let fetched = reg.get_token(&id).unwrap();
+        assert_eq!(fetched.owner_id(), "alice");
+    }
+
+    #[test]
+    fn register_without_friendly_name() {
+        let reg = make_registry();
+        let t = make_token("bob", b"tok_data_2");
+        let id = t.id().to_string();
+
+        reg.register_token(t, None).unwrap();
+        assert_eq!(reg.token_count(), 1);
+
+        let names = reg.all_friendly_names().unwrap();
+        assert!(names.is_empty());
+
+        assert!(reg.get_token(&id).is_ok());
+    }
+
+    // ── get_token_by_name ───────────────────────────────────────────
+
+    #[test]
+    fn get_token_by_name_found() {
+        let reg = make_registry();
+        let t = make_token("alice", b"named_tok");
+        reg.register_token(t.clone(), Some("Friendly".into()))
+            .unwrap();
+
+        let found = reg.get_token_by_name("Friendly").unwrap();
+        assert_eq!(found.id(), t.id());
+    }
+
+    #[test]
+    fn get_token_by_name_not_found() {
+        let reg = make_registry();
+        assert!(reg.get_token_by_name("NonExistent").is_err());
+    }
+
+    // ── get_token not in cache or state manager ─────────────────────
+
+    #[test]
+    fn get_token_not_found() {
+        let reg = make_registry();
+        assert!(reg.get_token("unknown_id").is_err());
+    }
+
+    // ── find_tokens ─────────────────────────────────────────────────
+
+    #[test]
+    fn find_tokens_no_filter() {
+        let reg = make_registry();
+        let t1 = make_token("alice", b"t1");
+        let t2 = make_token("bob", b"t2");
+        reg.register_token(t1, None).unwrap();
+        reg.register_token(t2, None).unwrap();
+
+        let found = reg.find_tokens(None, None, 100).unwrap();
+        assert_eq!(found.len(), 2);
+    }
+
+    #[test]
+    fn find_tokens_by_owner() {
+        let reg = make_registry();
+        let t1 = make_token("alice", b"ta");
+        let t2 = make_token("bob", b"tb");
+        reg.register_token(t1, None).unwrap();
+        reg.register_token(t2, None).unwrap();
+
+        let found = reg.find_tokens(Some("alice"), None, 100).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].owner_id(), "alice");
+    }
+
+    #[test]
+    fn find_tokens_by_status() {
+        let reg = make_registry();
+        let mut t1 = make_token("alice", b"ts1");
+        t1.set_status(TokenStatus::Revoked);
+        let t2 = make_token("bob", b"ts2");
+
+        reg.register_token(t1, None).unwrap();
+        reg.register_token(t2, None).unwrap();
+
+        let found = reg
+            .find_tokens(None, Some(TokenStatus::Active), 100)
+            .unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].owner_id(), "bob");
+    }
+
+    #[test]
+    fn find_tokens_respects_limit() {
+        let reg = make_registry();
+        for i in 0..10 {
+            let t = make_token("alice", &[i as u8; 4]);
+            reg.register_token(t, None).unwrap();
+        }
+        let found = reg.find_tokens(None, None, 3).unwrap();
+        assert_eq!(found.len(), 3);
+    }
+
+    #[test]
+    fn find_tokens_sorted_by_id() {
+        let reg = make_registry();
+        for i in 0..5 {
+            let t = make_token("alice", &[i as u8; 8]);
+            reg.register_token(t, None).unwrap();
+        }
+        let found = reg.find_tokens(None, None, 100).unwrap();
+        for w in found.windows(2) {
+            assert!(w[0].id() <= w[1].id(), "results must be sorted by id");
+        }
+    }
+
+    // ── verify_token ────────────────────────────────────────────────
+
+    #[test]
+    fn verify_token_active_returns_true() {
+        let reg = make_registry();
+        let t = make_token("alice", b"vt");
+        let id = t.id().to_string();
+        reg.register_token(t, None).unwrap();
+        assert!(reg.verify_token(&id).unwrap());
+    }
+
+    #[test]
+    fn verify_token_revoked_returns_false() {
+        let reg = make_registry();
+        let mut t = make_token("alice", b"vr");
+        t.set_status(TokenStatus::Revoked);
+        let id = t.id().to_string();
+        reg.register_token(t, None).unwrap();
+        assert!(!reg.verify_token(&id).unwrap());
+    }
+
+    #[test]
+    fn verify_token_not_found_returns_false() {
+        let reg = make_registry();
+        assert!(!reg.verify_token("nonexistent").unwrap());
+    }
+
+    // ── update_token_name ───────────────────────────────────────────
+
+    #[test]
+    fn update_token_name() {
+        let reg = make_registry();
+        let t = make_token("alice", b"un");
+        let id = t.id().to_string();
+        reg.register_token(t, Some("OldName".into())).unwrap();
+
+        reg.update_token_name(&id, "NewName").unwrap();
+        let found = reg.get_token_by_name("NewName").unwrap();
+        assert_eq!(found.id(), id);
+
+        assert!(
+            reg.get_token_by_name("OldName").is_err(),
+            "old name should be removed"
+        );
+    }
+
+    #[test]
+    fn update_token_name_nonexistent_token_fails() {
+        let reg = make_registry();
+        assert!(reg.update_token_name("nope", "Any").is_err());
+    }
+
+    // ── get_all_token_ids ───────────────────────────────────────────
+
+    #[test]
+    fn get_all_token_ids_sorted() {
+        let reg = make_registry();
+        for i in 0..5 {
+            let t = make_token("alice", &[i as u8; 8]);
+            reg.register_token(t, None).unwrap();
+        }
+        let ids = reg.get_all_token_ids().unwrap();
+        assert_eq!(ids.len(), 5);
+        for w in ids.windows(2) {
+            assert!(w[0] <= w[1]);
+        }
+    }
+
+    // ── revoke_token and update_token_metadata ──────────────────────
+
+    #[test]
+    fn revoke_token_returns_error() {
+        let reg = make_registry();
+        assert!(reg.revoke_token("any").is_err());
+    }
+
+    #[test]
+    fn update_token_metadata_returns_error() {
+        let reg = make_registry();
+        assert!(reg.update_token_metadata("any", vec![1, 2]).is_err());
+    }
+
+    #[test]
+    fn refresh_registry_returns_error() {
+        let reg = make_registry();
+        assert!(reg.refresh_registry().is_err());
+    }
+
+    // ── clear_cache and remove_from_cache ───────────────────────────
+
+    #[test]
+    fn clear_cache_empties_tokens() {
+        let reg = make_registry();
+        reg.register_token(make_token("a", b"c1"), None).unwrap();
+        reg.register_token(make_token("b", b"c2"), None).unwrap();
+        assert_eq!(reg.token_count(), 2);
+
+        reg.clear_cache().unwrap();
+        assert_eq!(reg.token_count(), 0);
+    }
+
+    #[test]
+    fn remove_from_cache() {
+        let reg = make_registry();
+        let t = make_token("alice", b"rm");
+        let id = t.id().to_string();
+        reg.register_token(t, None).unwrap();
+        assert_eq!(reg.token_count(), 1);
+
+        reg.remove_from_cache(&id).unwrap();
+        assert_eq!(reg.token_count(), 0);
+    }
+
+    #[test]
+    fn remove_from_cache_nonexistent_is_ok() {
+        let reg = make_registry();
+        reg.remove_from_cache("nope").unwrap();
+    }
+
+    // ── names_for_token ─────────────────────────────────────────────
+
+    #[test]
+    fn names_for_token_found() {
+        let reg = make_registry();
+        let t = make_token("alice", b"nft");
+        let id = t.id().to_string();
+        reg.register_token(t, Some("AToken".into())).unwrap();
+
+        let names = reg.names_for_token(&id).unwrap();
+        assert_eq!(names, vec!["AToken"]);
+    }
+
+    #[test]
+    fn names_for_token_no_names() {
+        let reg = make_registry();
+        let names = reg.names_for_token("nothing").unwrap();
+        assert!(names.is_empty());
+    }
+
+    // ── all_friendly_names ──────────────────────────────────────────
+
+    #[test]
+    fn all_friendly_names_sorted() {
+        let reg = make_registry();
+        let t1 = make_token("a", b"fn1");
+        let t2 = make_token("b", b"fn2");
+        reg.register_token(t1, Some("Zeta".into())).unwrap();
+        reg.register_token(t2, Some("Alpha".into())).unwrap();
+
+        let names = reg.all_friendly_names().unwrap();
+        assert_eq!(names, vec!["Alpha", "Zeta"]);
+    }
+
+    // ── name_registry_stats ─────────────────────────────────────────
+
+    #[test]
+    fn name_registry_stats_empty() {
+        let reg = make_registry();
+        let (total, unique) = reg.name_registry_stats().unwrap();
+        assert_eq!(total, 0);
+        assert_eq!(unique, 0);
+    }
+
+    #[test]
+    fn name_registry_stats_with_entries() {
+        let reg = make_registry();
+        let t = make_token("alice", b"st");
+        let id = t.id().to_string();
+        reg.register_token(t, Some("Name1".into())).unwrap();
+
+        // Add a second name pointing to the same token manually
+        {
+            let mut names = reg.name_registry.write().unwrap();
+            names.insert("Name2".into(), id);
+        }
+
+        let (total, unique) = reg.name_registry_stats().unwrap();
+        assert_eq!(total, 2);
+        assert_eq!(unique, 1);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/utility/labeling.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/utility/labeling.rs
@@ -56,3 +56,98 @@ pub fn hash_to_short_id(hash: &[u8]) -> String {
     };
     num.to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::identity::Identity;
+
+    fn make_identity_with_hash(hash: [u8; 32]) -> Identity {
+        let mut genesis =
+            crate::core::identity::genesis::GenesisState::new().expect("genesis creation");
+        genesis.hash = hash;
+        Identity::with_genesis("test".into(), genesis)
+    }
+
+    #[test]
+    fn identity_to_string_deterministic() {
+        let id = make_identity_with_hash([0xAA; 32]);
+        let s1 = identity_to_string(&id);
+        let s2 = identity_to_string(&id);
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn identity_to_string_uses_first_16_bytes() {
+        let mut h = [0u8; 32];
+        h[0..8].copy_from_slice(&42u64.to_le_bytes());
+        h[8..16].copy_from_slice(&99u64.to_le_bytes());
+        let id = make_identity_with_hash(h);
+        assert_eq!(identity_to_string(&id), "42-99");
+    }
+
+    #[test]
+    fn identity_to_string_zero_hash() {
+        let id = make_identity_with_hash([0u8; 32]);
+        assert_eq!(identity_to_string(&id), "0-0");
+    }
+
+    #[test]
+    fn identity_short_id_deterministic() {
+        let id = make_identity_with_hash([0xBB; 32]);
+        let s1 = identity_short_id(&id);
+        let s2 = identity_short_id(&id);
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn identity_short_id_uses_first_8_bytes() {
+        let mut h = [0u8; 32];
+        h[0..8].copy_from_slice(&12345u64.to_le_bytes());
+        let id = make_identity_with_hash(h);
+        assert_eq!(identity_short_id(&id), "12345");
+    }
+
+    #[test]
+    fn identity_short_id_zero_hash() {
+        let id = make_identity_with_hash([0u8; 32]);
+        assert_eq!(identity_short_id(&id), "0");
+    }
+
+    #[test]
+    fn hash_to_short_id_full_32_bytes() {
+        let mut h = [0u8; 32];
+        h[0..8].copy_from_slice(&777u64.to_le_bytes());
+        assert_eq!(hash_to_short_id(&h), "777");
+    }
+
+    #[test]
+    fn hash_to_short_id_exactly_8_bytes() {
+        let bytes = 999u64.to_le_bytes();
+        assert_eq!(hash_to_short_id(&bytes), "999");
+    }
+
+    #[test]
+    fn hash_to_short_id_short_input_returns_zero() {
+        assert_eq!(hash_to_short_id(&[1, 2, 3]), "0");
+    }
+
+    #[test]
+    fn hash_to_short_id_empty_input_returns_zero() {
+        assert_eq!(hash_to_short_id(&[]), "0");
+    }
+
+    #[test]
+    fn hash_to_short_id_max_value() {
+        let bytes = u64::MAX.to_le_bytes();
+        assert_eq!(hash_to_short_id(&bytes), u64::MAX.to_string());
+    }
+
+    #[test]
+    fn different_hashes_produce_different_labels() {
+        let id_a = make_identity_with_hash([0x01; 32]);
+        let id_b = make_identity_with_hash([0x02; 32]);
+        assert_ne!(identity_to_string(&id_a), identity_to_string(&id_b));
+        assert_ne!(identity_short_id(&id_a), identity_short_id(&id_b));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/verification/dual_mode_verifier.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/verification/dual_mode_verifier.rs
@@ -351,3 +351,193 @@ impl DualModeVerifier {
         Ok(true)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::state_types::{DeviceInfo, State, StateParams, RelationshipContext};
+
+    fn make_device_info() -> DeviceInfo {
+        DeviceInfo::new([0x11; 32], vec![0x22; 64])
+    }
+
+    fn make_genesis() -> StateTypesState {
+        let di = make_device_info();
+        let mut state = State::new_genesis([0xAA; 32], di);
+        state
+            .token_balances
+            .insert("ERA".to_string(), Balance::from_state(1000, [0u8; 32], 0));
+        state
+    }
+
+    fn make_next_state(
+        prev: &StateTypesState,
+        operation: Operation,
+        entropy: Vec<u8>,
+    ) -> StateTypesState {
+        let di = make_device_info();
+        let prev_hash = prev.hash().unwrap();
+        let mut params = StateParams::new(prev.state_number + 1, entropy, operation, di);
+        params.prev_state_hash = prev_hash;
+        let mut s = State::new(params);
+        s.token_balances = prev.token_balances.clone();
+        s
+    }
+
+    #[test]
+    fn verify_transition_rejects_non_sequential_state_number() {
+        let current = make_genesis();
+        let di = make_device_info();
+        let prev_hash = current.hash().unwrap();
+        let mut params = StateParams::new(
+            5, // gap in state numbers
+            vec![0xBB; 32],
+            Operation::Noop,
+            di,
+        );
+        params.prev_state_hash = prev_hash;
+        let mut next = State::new(params);
+        next.token_balances = current.token_balances.clone();
+
+        let result =
+            DualModeVerifier::verify_transition(&current, &next, &Operation::Noop).unwrap();
+        assert!(!result, "should reject non-sequential state numbers");
+    }
+
+    #[test]
+    fn verify_transition_rejects_wrong_prev_hash() {
+        let current = make_genesis();
+        let di = make_device_info();
+        let mut params = StateParams::new(1, vec![0xCC; 32], Operation::Noop, di);
+        params.prev_state_hash = [0xFF; 32]; // wrong hash
+        let mut next = State::new(params);
+        next.token_balances = current.token_balances.clone();
+
+        let result =
+            DualModeVerifier::verify_transition(&current, &next, &Operation::Noop).unwrap();
+        assert!(!result, "should reject wrong prev_state_hash");
+    }
+
+    #[test]
+    fn verify_transition_rejects_same_entropy() {
+        let current = make_genesis();
+        let di = make_device_info();
+        let prev_hash = current.hash().unwrap();
+        let mut params = StateParams::new(
+            1,
+            current.entropy.clone(), // same entropy as current
+            Operation::Noop,
+            di,
+        );
+        params.prev_state_hash = prev_hash;
+        let mut next = State::new(params);
+        next.token_balances = current.token_balances.clone();
+
+        let result =
+            DualModeVerifier::verify_transition(&current, &next, &Operation::Noop).unwrap();
+        assert!(!result, "should reject identical entropy");
+    }
+
+    #[test]
+    fn verify_transition_rejects_missing_token() {
+        let current = make_genesis();
+        let next = make_next_state(&current, Operation::Noop, vec![0xDD; 32]);
+        // Remove a token that exists in current
+        let mut altered_next = next;
+        altered_next.token_balances.clear();
+
+        let result =
+            DualModeVerifier::verify_transition(&current, &altered_next, &Operation::Noop).unwrap();
+        assert!(!result, "should reject when token disappears");
+    }
+
+    #[test]
+    fn verify_basic_transition_succeeds_for_valid_pair() {
+        let current = make_genesis();
+        let next = make_next_state(&current, Operation::Noop, vec![0xEE; 32]);
+
+        let result =
+            DualModeVerifier::verify_transition(&current, &next, &Operation::Noop).unwrap();
+        assert!(result, "valid basic transition should pass");
+    }
+
+    #[test]
+    fn verify_bilateral_rejects_missing_sigs() {
+        let current = make_genesis();
+        let transfer = Operation::Transfer {
+            to_device_id: vec![0x33; 32],
+            amount: Balance::from_state(10, [0u8; 32], 0),
+            token_id: b"ERA".to_vec(),
+            mode: TransactionMode::Bilateral,
+            nonce: vec![1],
+            verification: crate::types::operations::VerificationType::Standard,
+            pre_commit: None,
+            recipient: vec![0x33; 32],
+            to: vec![0x33; 32],
+            message: String::new(),
+            signature: vec![],
+        };
+        let next = make_next_state(&current, transfer.clone(), vec![0xFF; 32]);
+
+        let result = DualModeVerifier::verify_transition(&current, &next, &transfer).unwrap();
+        assert!(!result, "bilateral transfer without signatures should fail");
+    }
+
+    #[test]
+    fn verify_unilateral_rejects_missing_entity_sig() {
+        let current = make_genesis();
+        let transfer = Operation::Transfer {
+            to_device_id: vec![0x33; 32],
+            amount: Balance::from_state(10, [0u8; 32], 0),
+            token_id: b"ERA".to_vec(),
+            mode: TransactionMode::Unilateral,
+            nonce: vec![1],
+            verification: crate::types::operations::VerificationType::Standard,
+            pre_commit: None,
+            recipient: vec![0x33; 32],
+            to: vec![0x33; 32],
+            message: String::new(),
+            signature: vec![],
+        };
+        let next = make_next_state(&current, transfer.clone(), vec![0xAA; 32]);
+
+        let result = DualModeVerifier::verify_transition(&current, &next, &transfer).unwrap();
+        assert!(!result, "unilateral without entity_sig should fail");
+    }
+
+    #[test]
+    fn verify_batch_with_empty_or_single() {
+        assert!(DualModeVerifier::verify_transition_batch(&[]).unwrap());
+        let genesis = make_genesis();
+        assert!(DualModeVerifier::verify_transition_batch(&[genesis]).unwrap());
+    }
+
+    #[test]
+    fn verify_batch_valid_chain() {
+        let s0 = make_genesis();
+        let s1 = make_next_state(&s0, Operation::Noop, vec![0x11; 32]);
+        let s2 = make_next_state(&s1, Operation::Noop, vec![0x22; 32]);
+
+        let result = DualModeVerifier::verify_transition_batch(&[s0, s1, s2]).unwrap();
+        assert!(result, "valid chain batch should pass");
+    }
+
+    #[test]
+    fn verify_recipient_identity_accepts_no_relationship() {
+        let state = make_genesis();
+        let result = DualModeVerifier::verify_recipient_identity(&state).unwrap();
+        assert!(result, "no relationship context is acceptable");
+    }
+
+    #[test]
+    fn verify_recipient_identity_rejects_empty_counterparty() {
+        let mut state = make_genesis();
+        state.relationship_context = Some(RelationshipContext::new(
+            [0x01; 32],
+            [0u8; 32], // empty counterparty_id (all zeros, but non-empty bytes)
+            vec![],    // empty counterparty_public_key
+        ));
+        let result = DualModeVerifier::verify_recipient_identity(&state).unwrap();
+        assert!(!result, "empty counterparty public key should fail");
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/core/verification/identity_verifier.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/verification/identity_verifier.rs
@@ -117,3 +117,184 @@ impl IdentityVerifier {
         Ok(anchor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::state_types::DeviceInfo;
+    use std::collections::HashMap;
+
+    fn compute_claim_hash(identity_id: &str, tick: u64, expires_at_tick: u64) -> Vec<u8> {
+        let mut hasher = crate::crypto::blake3::dsm_domain_hasher("DSM/identity/claim");
+        hasher.update(identity_id.as_bytes());
+        hasher.update(&tick.to_le_bytes());
+        hasher.update(&expires_at_tick.to_le_bytes());
+        hasher.finalize().as_bytes().to_vec()
+    }
+
+    fn compute_anchor_commitment(
+        identity_id: &str,
+        created_at_tick: u64,
+        revoked_at_tick: Option<u64>,
+    ) -> Vec<u8> {
+        let mut hasher = crate::crypto::blake3::dsm_domain_hasher("DSM/identity/anchor");
+        hasher.update(identity_id.as_bytes());
+        hasher.update(&created_at_tick.to_le_bytes());
+        hasher.update(&revoked_at_tick.unwrap_or(0).to_le_bytes());
+        hasher.finalize().as_bytes().to_vec()
+    }
+
+    fn make_valid_claim_and_anchor() -> (IdentityClaim, IdentityAnchor) {
+        let identity_id = "test-identity-1";
+        let tick = 10u64;
+        let expires_at_tick = 100u64;
+        let created_at_tick = 5u64;
+
+        let claim_hash = compute_claim_hash(identity_id, tick, expires_at_tick);
+        let anchor_commitment = compute_anchor_commitment(identity_id, created_at_tick, None);
+
+        let claim = IdentityClaim {
+            identity_id: identity_id.to_string(),
+            tick,
+            expires_at_tick,
+            public_key: vec![0x42; 32],
+            signature: vec![0xFF; 64], // non-empty
+            claim_hash,
+            anchor_commitment,
+            device_info: DeviceInfo::default(),
+            meta_data: HashMap::new(),
+        };
+
+        let anchor = IdentityAnchor {
+            identity_id: identity_id.to_string(),
+            public_key: vec![0x42; 32],
+            created_at_tick,
+            revoked_at_tick: None,
+            meta_data: HashMap::new(),
+        };
+
+        (claim, anchor)
+    }
+
+    #[test]
+    fn verify_valid_claim_succeeds() {
+        let (claim, anchor) = make_valid_claim_and_anchor();
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn verify_rejects_mismatched_identity_id() {
+        let (mut claim, anchor) = make_valid_claim_and_anchor();
+        claim.identity_id = "wrong-identity".to_string();
+
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(!result, "mismatched identity_id should fail");
+    }
+
+    #[test]
+    fn verify_rejects_empty_signature() {
+        let (mut claim, anchor) = make_valid_claim_and_anchor();
+        claim.signature = vec![];
+
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(!result, "empty signature should fail");
+    }
+
+    #[test]
+    fn verify_rejects_wrong_claim_hash() {
+        let (mut claim, anchor) = make_valid_claim_and_anchor();
+        claim.claim_hash = vec![0x00; 32]; // wrong hash
+
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(!result, "wrong claim hash should fail");
+    }
+
+    #[test]
+    fn verify_rejects_wrong_anchor_commitment() {
+        let (mut claim, anchor) = make_valid_claim_and_anchor();
+        claim.anchor_commitment = vec![0x00; 32]; // wrong commitment
+
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(!result, "wrong anchor commitment should fail");
+    }
+
+    #[test]
+    fn verify_rejects_revoked_anchor_with_old_commitment() {
+        let (claim, mut anchor) = make_valid_claim_and_anchor();
+        anchor.revoked_at_tick = Some(50);
+        // anchor commitment was computed with revoked_at_tick=None, so it should mismatch
+
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(!result, "revoked anchor should fail commitment check");
+    }
+
+    #[test]
+    fn create_identity_anchor_succeeds_for_valid_claim() {
+        dt::reset_for_tests();
+        let (claim, _) = make_valid_claim_and_anchor();
+
+        let anchor = IdentityVerifier::create_identity_anchor(&claim).unwrap();
+        assert_eq!(anchor.identity_id, claim.identity_id);
+        assert_eq!(anchor.public_key, claim.public_key);
+        assert!(anchor.revoked_at_tick.is_none());
+    }
+
+    #[test]
+    fn create_identity_anchor_rejects_invalid_claim() {
+        let (mut claim, _) = make_valid_claim_and_anchor();
+        claim.signature = vec![]; // invalid
+
+        let result = IdentityVerifier::create_identity_anchor(&claim);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_claim_signature_checks_hash_determinism() {
+        let identity_id = "determinism-test";
+        let tick = 42u64;
+        let expires = 999u64;
+        let hash1 = compute_claim_hash(identity_id, tick, expires);
+        let hash2 = compute_claim_hash(identity_id, tick, expires);
+        assert_eq!(hash1, hash2);
+
+        let hash_different_tick = compute_claim_hash(identity_id, tick + 1, expires);
+        assert_ne!(hash1, hash_different_tick);
+    }
+
+    #[test]
+    fn verify_with_matching_revoked_anchor() {
+        let identity_id = "revoked-test";
+        let tick = 10u64;
+        let expires = 100u64;
+        let created_at_tick = 5u64;
+        let revoked_at_tick = Some(50u64);
+
+        let claim_hash = compute_claim_hash(identity_id, tick, expires);
+        let anchor_commitment =
+            compute_anchor_commitment(identity_id, created_at_tick, revoked_at_tick);
+
+        let claim = IdentityClaim {
+            identity_id: identity_id.to_string(),
+            tick,
+            expires_at_tick: expires,
+            public_key: vec![0x42; 32],
+            signature: vec![0xFF; 64],
+            claim_hash,
+            anchor_commitment,
+            device_info: DeviceInfo::default(),
+            meta_data: HashMap::new(),
+        };
+
+        let anchor = IdentityAnchor {
+            identity_id: identity_id.to_string(),
+            public_key: vec![0x42; 32],
+            created_at_tick,
+            revoked_at_tick,
+            meta_data: HashMap::new(),
+        };
+
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(result, "matching revoked anchor commitment should pass");
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/cpta/default_policy.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/cpta/default_policy.rs
@@ -177,3 +177,205 @@ pub fn create_policy(params: PolicyParameters) -> Result<PolicyFile, DsmError> {
 
     Ok(policy)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_default_policy_basic_fields() {
+        let policy = generate_default_policy("tok-1", "MyToken", "creator-abc").unwrap();
+
+        assert_eq!(policy.name, "Default Policy for MyToken");
+        assert_eq!(policy.author, "creator-abc");
+        assert!(policy.description.as_ref().unwrap().contains("tok-1"));
+    }
+
+    #[test]
+    fn test_generate_default_policy_conditions() {
+        let policy = generate_default_policy("tok-1", "MyToken", "creator-abc").unwrap();
+
+        let has_identity = policy.conditions.iter().any(|c| {
+            matches!(
+                c,
+                PolicyCondition::IdentityConstraint {
+                    allowed_identities,
+                    allow_derived: true,
+                } if allowed_identities == &["creator-abc".to_string()]
+            )
+        });
+        assert!(
+            has_identity,
+            "default policy must include identity constraint for creator"
+        );
+
+        let has_ops = policy.conditions.iter().any(|c| {
+            matches!(
+                c,
+                PolicyCondition::OperationRestriction { allowed_operations }
+                if allowed_operations == &["Transfer".to_string()]
+            )
+        });
+        assert!(
+            has_ops,
+            "default policy must restrict operations to Transfer"
+        );
+    }
+
+    #[test]
+    fn test_generate_default_policy_roles() {
+        let policy = generate_default_policy("tok-1", "MyToken", "creator-abc").unwrap();
+
+        assert_eq!(policy.roles.len(), 2);
+        assert_eq!(policy.roles[0].id, "owner");
+        assert_eq!(policy.roles[1].id, "user");
+        assert!(policy.roles[1]
+            .permissions
+            .contains(&"LockToken".to_string()));
+        assert!(policy.roles[1]
+            .permissions
+            .contains(&"UnlockToken".to_string()));
+    }
+
+    #[test]
+    fn test_generate_default_policy_metadata() {
+        let policy = generate_default_policy("tok-42", "TestToken", "alice").unwrap();
+
+        assert_eq!(policy.metadata.get("token_id").unwrap(), "tok-42");
+        assert_eq!(policy.metadata.get("is_default_policy").unwrap(), "true");
+    }
+
+    #[test]
+    fn test_specialized_policy_time_locked_rejected() {
+        let params = HashMap::new();
+        let result = generate_specialized_policy("t1", "T", "c", "TimeLocked", &params);
+
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("Time-based policies are not supported"));
+    }
+
+    #[test]
+    fn test_specialized_policy_unknown_type_rejected() {
+        let params = HashMap::new();
+        let result = generate_specialized_policy("t1", "T", "c", "Bogus", &params);
+
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("Unknown policy type"));
+    }
+
+    #[test]
+    fn test_specialized_policy_identity_bound_custom_ids() {
+        let mut params = HashMap::new();
+        params.insert("allowed_identities".to_string(), "alice, bob".to_string());
+        params.insert("allow_derived".to_string(), "true".to_string());
+
+        let policy =
+            generate_specialized_policy("t1", "TestToken", "creator", "IdentityBound", &params)
+                .unwrap();
+
+        assert!(policy.name.contains("IdentityBound"));
+
+        let id_constraint = policy
+            .conditions
+            .iter()
+            .find(|c| matches!(c, PolicyCondition::IdentityConstraint { .. }));
+        match id_constraint {
+            Some(PolicyCondition::IdentityConstraint {
+                allowed_identities,
+                allow_derived,
+            }) => {
+                assert_eq!(
+                    allowed_identities,
+                    &["alice".to_string(), "bob".to_string()]
+                );
+                assert!(*allow_derived);
+            }
+            _ => panic!("expected IdentityConstraint"),
+        }
+    }
+
+    #[test]
+    fn test_specialized_policy_identity_bound_defaults() {
+        let params = HashMap::new();
+        let policy =
+            generate_specialized_policy("t1", "T", "creator", "IdentityBound", &params).unwrap();
+
+        let id_constraint = policy
+            .conditions
+            .iter()
+            .find(|c| matches!(c, PolicyCondition::IdentityConstraint { .. }));
+        match id_constraint {
+            Some(PolicyCondition::IdentityConstraint {
+                allowed_identities,
+                allow_derived,
+            }) => {
+                assert_eq!(allowed_identities, &["creator".to_string()]);
+                assert!(!*allow_derived);
+            }
+            _ => panic!("expected IdentityConstraint"),
+        }
+    }
+
+    #[test]
+    fn test_specialized_policy_restricted_operations() {
+        let mut params = HashMap::new();
+        params.insert(
+            "allowed_operations".to_string(),
+            "Transfer, Burn".to_string(),
+        );
+
+        let policy =
+            generate_specialized_policy("t1", "T", "c", "RestrictedOperations", &params).unwrap();
+
+        let ops_condition = policy
+            .conditions
+            .iter()
+            .find(|c| matches!(c, PolicyCondition::OperationRestriction { .. }));
+        match ops_condition {
+            Some(PolicyCondition::OperationRestriction { allowed_operations }) => {
+                assert_eq!(
+                    allowed_operations,
+                    &["Transfer".to_string(), "Burn".to_string()]
+                );
+            }
+            _ => panic!("expected OperationRestriction"),
+        }
+    }
+
+    #[test]
+    fn test_specialized_policy_restricted_operations_defaults_to_transfer() {
+        let params = HashMap::new();
+        let policy =
+            generate_specialized_policy("t1", "T", "c", "RestrictedOperations", &params).unwrap();
+
+        let ops_condition = policy
+            .conditions
+            .iter()
+            .find(|c| matches!(c, PolicyCondition::OperationRestriction { .. }));
+        match ops_condition {
+            Some(PolicyCondition::OperationRestriction { allowed_operations }) => {
+                assert_eq!(allowed_operations, &["Transfer".to_string()]);
+            }
+            _ => panic!("expected OperationRestriction"),
+        }
+    }
+
+    #[test]
+    fn test_create_policy_basic() {
+        let params = PolicyParameters {
+            mode: TransactionMode::Bilateral,
+            verification: VerificationType::Standard,
+            name: "Custom".to_string(),
+            version: "2.0".to_string(),
+            author: "bob".to_string(),
+        };
+        let policy = create_policy(params).unwrap();
+
+        assert_eq!(policy.name, "Custom");
+        assert_eq!(policy.version, "2.0");
+        assert_eq!(policy.author, "bob");
+        assert!(!policy.conditions.is_empty());
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/cpta/policy_store.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/cpta/policy_store.rs
@@ -276,3 +276,192 @@ impl PolicyStore {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::policy_types::{PolicyCondition, PolicyFile, PolicyRole};
+
+    #[derive(Debug)]
+    struct MockPersistence {
+        store: Arc<RwLock<HashMap<PolicyAnchor, Vec<u8>>>>,
+    }
+
+    impl MockPersistence {
+        fn new() -> Self {
+            Self {
+                store: Arc::new(RwLock::new(HashMap::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PolicyPersistence for MockPersistence {
+        async fn read(&self, anchor: &PolicyAnchor) -> Result<Vec<u8>, DsmError> {
+            self.store
+                .read()
+                .get(anchor)
+                .cloned()
+                .ok_or_else(|| DsmError::invalid_operation("not found"))
+        }
+
+        async fn write(&self, anchor: &PolicyAnchor, data: &[u8]) -> Result<(), DsmError> {
+            self.store.write().insert(anchor.clone(), data.to_vec());
+            Ok(())
+        }
+
+        async fn delete(&self, anchor: &PolicyAnchor) -> Result<(), DsmError> {
+            self.store.write().remove(anchor);
+            Ok(())
+        }
+
+        async fn list_anchors(&self) -> Result<Vec<PolicyAnchor>, DsmError> {
+            Ok(self.store.read().keys().cloned().collect())
+        }
+    }
+
+    fn make_policy_file(author: &str) -> PolicyFile {
+        let mut pf = PolicyFile::new("TestPolicy", "1.0", author);
+        pf.add_condition(PolicyCondition::OperationRestriction {
+            allowed_operations: vec!["Transfer".to_string()],
+        });
+        pf.add_role(PolicyRole {
+            id: "owner".to_string(),
+            name: "Owner".to_string(),
+            permissions: vec!["Transfer".to_string()],
+        });
+        pf
+    }
+
+    fn make_store(persistence: Arc<MockPersistence>) -> PolicyStore {
+        PolicyStore::with_cache_settings(persistence, 4, 100_000)
+    }
+
+    #[tokio::test]
+    async fn test_store_and_retrieve_policy() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = make_store(persistence);
+
+        let pf = make_policy_file("author-alpha");
+        let anchor = store.store_policy(&pf).await.unwrap();
+        let retrieved = store.get_policy(&anchor).await.unwrap();
+
+        assert_eq!(retrieved.anchor, anchor);
+    }
+
+    #[tokio::test]
+    async fn test_get_from_cache_after_store() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = make_store(persistence);
+
+        let pf = make_policy_file("author-beta");
+        let anchor = store.store_policy(&pf).await.unwrap();
+
+        let cached = store.get_from_cache(&anchor);
+        assert!(cached.is_some());
+        assert_eq!(cached.unwrap().anchor, anchor);
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss_returns_none() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = make_store(persistence);
+
+        let fake_anchor = PolicyAnchor::from_bytes([0xAA; 32]);
+        assert!(store.get_from_cache(&fake_anchor).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_clear_cache_empties_it() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = make_store(persistence);
+
+        let pf = make_policy_file("author-gamma");
+        let anchor = store.store_policy(&pf).await.unwrap();
+        assert!(store.get_from_cache(&anchor).is_some());
+
+        store.clear_cache();
+        assert!(store.get_from_cache(&anchor).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_policy_removes_from_cache_and_persistence() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = make_store(persistence.clone());
+
+        let pf = make_policy_file("author-delta");
+        let anchor = store.store_policy(&pf).await.unwrap();
+
+        store.delete_policy(&anchor).await.unwrap();
+        assert!(store.get_from_cache(&anchor).is_none());
+        assert!(persistence.read(&anchor).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_policy_anchors() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = make_store(persistence);
+
+        let a1 = store
+            .store_policy(&make_policy_file("author-x"))
+            .await
+            .unwrap();
+        let a2 = store
+            .store_policy(&make_policy_file("author-y"))
+            .await
+            .unwrap();
+
+        let mut anchors = store.list_policy_anchors().await.unwrap();
+        anchors.sort_by_key(|a| a.0);
+        let mut expected = vec![a1, a2];
+        expected.sort_by_key(|a| a.0);
+        assert_eq!(anchors, expected);
+    }
+
+    #[tokio::test]
+    async fn test_lru_eviction_when_cache_full() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = PolicyStore::with_cache_settings(persistence, 2, 100_000);
+
+        let a1 = store
+            .store_policy(&make_policy_file("author-1"))
+            .await
+            .unwrap();
+        let a2 = store
+            .store_policy(&make_policy_file("author-2"))
+            .await
+            .unwrap();
+        let _a3 = store
+            .store_policy(&make_policy_file("author-3"))
+            .await
+            .unwrap();
+
+        // a1 was the LRU entry and should have been evicted from cache
+        assert!(store.get_from_cache(&a1).is_none());
+        assert!(store.get_from_cache(&a2).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_verify_and_get_with_inline_data_rejected() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = make_store(persistence);
+
+        let pf = make_policy_file("author-v");
+        let anchor = store.store_policy(&pf).await.unwrap();
+
+        let result = store.verify_and_get_policy(&anchor, Some(b"inline")).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_verify_and_get_without_data_succeeds() {
+        let persistence = Arc::new(MockPersistence::new());
+        let store = make_store(persistence);
+
+        let pf = make_policy_file("author-v2");
+        let anchor = store.store_policy(&pf).await.unwrap();
+
+        let policy = store.verify_and_get_policy(&anchor, None).await.unwrap();
+        assert_eq!(policy.anchor, anchor);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/crypto/canonical_lp.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/crypto/canonical_lp.rs
@@ -52,3 +52,93 @@ pub fn hash_lp3(domain: &[u8], a: &[u8], b: &[u8], c: &[u8]) -> [u8; 32] {
     write_lp(&mut h, c);
     *h.finalize().as_bytes()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_lp_prepends_length_prefix() {
+        let mut h = dsm_domain_hasher("DSM/test");
+        write_lp(&mut h, b"hello");
+        let digest = h.finalize();
+        assert_eq!(digest.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn write_lp_empty_input() {
+        let mut h = dsm_domain_hasher("DSM/test");
+        write_lp(&mut h, b"");
+        let digest = h.finalize();
+        assert_eq!(digest.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn hash_lp1_deterministic() {
+        let a = hash_lp1(b"domain-a", b"field1");
+        let b = hash_lp1(b"domain-a", b"field1");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hash_lp1_different_domain_different_hash() {
+        let a = hash_lp1(b"domain-a", b"data");
+        let b = hash_lp1(b"domain-b", b"data");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_lp1_different_data_different_hash() {
+        let a = hash_lp1(b"dom", b"x");
+        let b = hash_lp1(b"dom", b"y");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_lp2_deterministic() {
+        let a = hash_lp2(b"dom", b"f1", b"f2");
+        let b = hash_lp2(b"dom", b"f1", b"f2");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hash_lp2_order_matters() {
+        let a = hash_lp2(b"dom", b"first", b"second");
+        let b = hash_lp2(b"dom", b"second", b"first");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_lp3_deterministic() {
+        let a = hash_lp3(b"dom", b"a", b"b", b"c");
+        let b = hash_lp3(b"dom", b"a", b"b", b"c");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hash_lp3_differs_from_lp2() {
+        let h2 = hash_lp2(b"dom", b"a", b"b");
+        let h3 = hash_lp3(b"dom", b"a", b"b", b"");
+        assert_ne!(h2, h3);
+    }
+
+    #[test]
+    fn hash_lp1_empty_inputs() {
+        let h = hash_lp1(b"", b"");
+        assert_eq!(h.len(), 32);
+    }
+
+    #[test]
+    fn length_prefix_prevents_concatenation_collision() {
+        let a = hash_lp2(b"dom", b"ab", b"cd");
+        let b = hash_lp2(b"dom", b"abc", b"d");
+        assert_ne!(a, b, "length prefix must prevent ab|cd == abc|d collision");
+    }
+
+    #[test]
+    fn all_outputs_are_32_bytes() {
+        assert_eq!(hash_lp1(b"d", b"a").len(), 32);
+        assert_eq!(hash_lp2(b"d", b"a", b"b").len(), 32);
+        assert_eq!(hash_lp3(b"d", b"a", b"b", b"c").len(), 32);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/crypto_verification/quantum_resistant_binding.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/crypto_verification/quantum_resistant_binding.rs
@@ -248,3 +248,132 @@ impl QuantumResistantBinding {
         blake3(&genesis_data)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::kyber::generate_kyber_keypair;
+
+    fn make_keypairs() -> (SignatureKeyPair, KyberKeyPair) {
+        let sphincs = SignatureKeyPair::new().unwrap();
+        let kyber = generate_kyber_keypair().unwrap();
+        (sphincs, kyber)
+    }
+
+    #[test]
+    fn test_binding_creation_succeeds() {
+        let (sphincs, kyber) = make_keypairs();
+        let binding = QuantumResistantBinding::new("app-1", b"seed-share", &sphincs, &kyber);
+        assert!(binding.is_ok());
+    }
+
+    #[test]
+    fn test_device_hash_is_deterministic_for_instance() {
+        let (sphincs, kyber) = make_keypairs();
+        let binding = QuantumResistantBinding::new("app-1", b"seed", &sphincs, &kyber).unwrap();
+        let h1 = *binding.device_hash();
+        let h2 = *binding.device_hash();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_verify_with_correct_params() {
+        let (sphincs, kyber) = make_keypairs();
+        let binding =
+            QuantumResistantBinding::new("app-1", b"seed-share", &sphincs, &kyber).unwrap();
+
+        let valid = binding.verify("app-1", b"seed-share").unwrap();
+        assert!(valid);
+    }
+
+    #[test]
+    fn test_verify_with_wrong_app_id_fails() {
+        let (sphincs, kyber) = make_keypairs();
+        let binding =
+            QuantumResistantBinding::new("app-1", b"seed-share", &sphincs, &kyber).unwrap();
+
+        let valid = binding.verify("app-WRONG", b"seed-share").unwrap();
+        assert!(!valid);
+    }
+
+    #[test]
+    fn test_verify_with_wrong_seed_fails() {
+        let (sphincs, kyber) = make_keypairs();
+        let binding =
+            QuantumResistantBinding::new("app-1", b"seed-share", &sphincs, &kyber).unwrap();
+
+        let valid = binding.verify("app-1", b"wrong-seed").unwrap();
+        assert!(!valid);
+    }
+
+    #[test]
+    fn test_genesis_hash_differs_for_different_keys() {
+        let (sphincs1, kyber1) = make_keypairs();
+        let (sphincs2, kyber2) = make_keypairs();
+
+        let b1 = QuantumResistantBinding::new("app", b"seed", &sphincs1, &kyber1).unwrap();
+        let b2 = QuantumResistantBinding::new("app", b"seed", &sphincs2, &kyber2).unwrap();
+
+        assert_ne!(b1.genesis_hash(), b2.genesis_hash());
+    }
+
+    #[test]
+    fn test_create_attestation_succeeds() {
+        let (sphincs, kyber) = make_keypairs();
+        let binding = QuantumResistantBinding::new("app-1", b"seed", &sphincs, &kyber).unwrap();
+
+        let attestation = binding.create_attestation(&sphincs, &kyber, b"entropy");
+        assert!(attestation.is_ok());
+        let att = attestation.unwrap();
+        assert_eq!(att.device_hash, *binding.device_hash());
+        assert!(!att.encapsulated_state.is_empty());
+        assert!(!att.signature.is_empty());
+    }
+
+    #[test]
+    fn test_verify_own_attestation() {
+        let (sphincs, kyber) = make_keypairs();
+        let binding = QuantumResistantBinding::new("app-1", b"seed", &sphincs, &kyber).unwrap();
+
+        let att = binding.create_attestation(&sphincs, &kyber, b"").unwrap();
+        let valid = binding
+            .verify_attestation(&att, &sphincs.public_key)
+            .unwrap();
+        assert!(valid);
+    }
+
+    #[test]
+    fn test_verify_attestation_wrong_device_hash() {
+        let (sphincs1, kyber1) = make_keypairs();
+        let (sphincs2, kyber2) = make_keypairs();
+
+        let binding1 = QuantumResistantBinding::new("app", b"s1", &sphincs1, &kyber1).unwrap();
+        let binding2 = QuantumResistantBinding::new("app", b"s2", &sphincs2, &kyber2).unwrap();
+
+        let att = binding1
+            .create_attestation(&sphincs1, &kyber1, b"")
+            .unwrap();
+        let valid = binding2
+            .verify_attestation(&att, &sphincs1.public_key)
+            .unwrap();
+        assert!(
+            !valid,
+            "attestation from a different binding should fail device hash check"
+        );
+    }
+
+    #[test]
+    fn test_different_entropy_produces_different_verification_entropy() {
+        let (sphincs, kyber) = make_keypairs();
+        let binding = QuantumResistantBinding::new("app-1", b"seed", &sphincs, &kyber).unwrap();
+
+        let att1 = binding
+            .create_attestation(&sphincs, &kyber, b"entropy-A")
+            .unwrap();
+        let att2 = binding
+            .create_attestation(&sphincs, &kyber, b"entropy-B")
+            .unwrap();
+
+        assert_ne!(att1.verification_entropy, att2.verification_entropy);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/emissions/shard_activation_accumulator.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/emissions/shard_activation_accumulator.rs
@@ -84,3 +84,122 @@ impl Default for ShardActivationAccumulator {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_accumulator_is_empty() {
+        let acc = ShardActivationAccumulator::new();
+        assert!(acc.is_empty());
+        assert_eq!(acc.len(), 0);
+        assert_eq!(acc.root(), [0u8; 32]);
+    }
+
+    #[test]
+    fn default_equals_new() {
+        let from_new = ShardActivationAccumulator::new();
+        let from_default = ShardActivationAccumulator::default();
+        assert_eq!(from_new.leaves, from_default.leaves);
+        assert_eq!(from_new.root(), from_default.root());
+    }
+
+    #[test]
+    fn append_increases_len() {
+        let mut acc = ShardActivationAccumulator::new();
+        acc.append([0xAA; 32]);
+        assert_eq!(acc.len(), 1);
+        assert!(!acc.is_empty());
+
+        acc.append([0xBB; 32]);
+        assert_eq!(acc.len(), 2);
+    }
+
+    #[test]
+    fn get_leaf_returns_correct_values() {
+        let mut acc = ShardActivationAccumulator::new();
+        let id = [0x01; 32];
+        acc.append(id);
+
+        let leaf = acc.get_leaf(0);
+        assert!(leaf.is_some());
+        let expected = domain_hash_bytes("DJTE.ACTIVE", &id);
+        assert_eq!(leaf.unwrap(), expected);
+
+        assert!(acc.get_leaf(1).is_none());
+        assert!(acc.get_leaf(999).is_none());
+    }
+
+    #[test]
+    fn root_single_leaf_is_deterministic() {
+        let mut acc = ShardActivationAccumulator::new();
+        acc.append([0x42; 32]);
+        let root1 = acc.root();
+
+        let mut acc2 = ShardActivationAccumulator::new();
+        acc2.append([0x42; 32]);
+        let root2 = acc2.root();
+
+        assert_eq!(root1, root2);
+        assert_ne!(root1, [0u8; 32]);
+    }
+
+    #[test]
+    fn root_changes_with_different_ids() {
+        let mut acc_a = ShardActivationAccumulator::new();
+        acc_a.append([0x01; 32]);
+        let root_a = acc_a.root();
+
+        let mut acc_b = ShardActivationAccumulator::new();
+        acc_b.append([0x02; 32]);
+        let root_b = acc_b.root();
+
+        assert_ne!(root_a, root_b);
+    }
+
+    #[test]
+    fn root_changes_when_leaf_appended() {
+        let mut acc = ShardActivationAccumulator::new();
+        acc.append([0x01; 32]);
+        let root_before = acc.root();
+
+        acc.append([0x02; 32]);
+        let root_after = acc.root();
+
+        assert_ne!(root_before, root_after);
+    }
+
+    #[test]
+    fn root_with_odd_number_of_leaves_duplicates_last() {
+        let mut acc = ShardActivationAccumulator::new();
+        acc.append([0x01; 32]);
+        acc.append([0x02; 32]);
+        acc.append([0x03; 32]);
+        assert_eq!(acc.len(), 3);
+        let root = acc.root();
+        assert_ne!(root, [0u8; 32]);
+    }
+
+    #[test]
+    fn root_with_power_of_two_leaves() {
+        let mut acc = ShardActivationAccumulator::new();
+        for i in 0..4u8 {
+            acc.append([i; 32]);
+        }
+        assert_eq!(acc.len(), 4);
+        let root = acc.root();
+        assert_ne!(root, [0u8; 32]);
+    }
+
+    #[test]
+    fn leaf_is_domain_hashed() {
+        let id = [0xFF; 32];
+        let mut acc = ShardActivationAccumulator::new();
+        acc.append(id);
+
+        let stored = acc.get_leaf(0).unwrap();
+        assert_ne!(stored, id, "leaf must be domain-hashed, not raw id");
+        assert_eq!(stored, domain_hash_bytes("DJTE.ACTIVE", &id));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/emissions/shard_count_smt.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/emissions/shard_count_smt.rs
@@ -93,3 +93,110 @@ impl ShardCountSmt {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_smt_has_zero_total() {
+        let smt = ShardCountSmt::new(2);
+        assert_eq!(smt.total(), 0);
+        assert_eq!(smt.shard_depth, 2);
+    }
+
+    #[test]
+    fn get_count_returns_zero_for_absent_keys() {
+        let smt = ShardCountSmt::new(3);
+        assert_eq!(smt.get_count(1), 0);
+        assert_eq!(smt.get_count(42), 0);
+        assert_eq!(smt.get_count(u64::MAX), 0);
+    }
+
+    #[test]
+    fn increment_updates_leaf_and_ancestors() {
+        let mut smt = ShardCountSmt::new(2);
+        // depth=2 → leaves at heap indices 4,5,6,7 (shard_index 0,1,2,3)
+        smt.increment(0).unwrap();
+
+        // Leaf at heap_index = 2^2 + 0 = 4
+        assert_eq!(smt.get_count(4), 1);
+        // Parent at heap_index = 2^1 + 0 = 2
+        assert_eq!(smt.get_count(2), 1);
+        // Root at heap_index = 2^0 + 0 = 1
+        assert_eq!(smt.get_count(1), 1);
+        assert_eq!(smt.total(), 1);
+    }
+
+    #[test]
+    fn increment_multiple_shards_accumulates_correctly() {
+        let mut smt = ShardCountSmt::new(2);
+        smt.increment(0).unwrap();
+        smt.increment(1).unwrap();
+        smt.increment(0).unwrap();
+
+        // Shard 0 leaf (heap 4): incremented twice
+        assert_eq!(smt.get_count(4), 2);
+        // Shard 1 leaf (heap 5): incremented once
+        assert_eq!(smt.get_count(5), 1);
+        // Left subtree (heap 2): both shard 0 and 1 roll up here
+        assert_eq!(smt.get_count(2), 3);
+        // Root (heap 1): total
+        assert_eq!(smt.total(), 3);
+    }
+
+    #[test]
+    fn root_is_deterministic() {
+        let mut smt1 = ShardCountSmt::new(2);
+        smt1.increment(0).unwrap();
+        smt1.increment(1).unwrap();
+
+        let mut smt2 = ShardCountSmt::new(2);
+        smt2.increment(0).unwrap();
+        smt2.increment(1).unwrap();
+
+        assert_eq!(smt1.root(), smt2.root());
+    }
+
+    #[test]
+    fn root_changes_on_increment() {
+        let mut smt = ShardCountSmt::new(2);
+        let root_before = smt.root();
+
+        smt.increment(0).unwrap();
+        let root_after = smt.root();
+
+        assert_ne!(root_before, root_after);
+    }
+
+    #[test]
+    fn root_differs_for_different_shards() {
+        let mut smt_a = ShardCountSmt::new(2);
+        smt_a.increment(0).unwrap();
+
+        let mut smt_b = ShardCountSmt::new(2);
+        smt_b.increment(1).unwrap();
+
+        assert_ne!(smt_a.root(), smt_b.root());
+    }
+
+    #[test]
+    fn depth_one_has_two_shards() {
+        let mut smt = ShardCountSmt::new(1);
+        // depth=1 → leaves at heap indices 2,3 (shard_index 0,1)
+        smt.increment(0).unwrap();
+        smt.increment(1).unwrap();
+
+        assert_eq!(smt.get_count(2), 1); // left leaf
+        assert_eq!(smt.get_count(3), 1); // right leaf
+        assert_eq!(smt.total(), 2);
+    }
+
+    #[test]
+    fn root_not_all_zeros() {
+        let smt = ShardCountSmt::new(2);
+        let root = smt.root();
+        // Even with zero counts, the Merkle hashing should produce a non-trivial root
+        assert_ne!(root, [0u8; 32]);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/emissions/spent_proof_smt.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/emissions/spent_proof_smt.rs
@@ -82,3 +82,119 @@ impl Default for SpentProofSmt {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_smt_is_empty() {
+        let smt = SpentProofSmt::new();
+        assert!(smt.is_empty());
+        assert_eq!(smt.len(), 0);
+    }
+
+    #[test]
+    fn default_equals_new() {
+        let from_new = SpentProofSmt::new();
+        let from_default = SpentProofSmt::default();
+        assert_eq!(from_new.spent.len(), from_default.spent.len());
+        assert_eq!(from_new.root(), from_default.root());
+    }
+
+    #[test]
+    fn mark_spent_tracks_jap_hash() {
+        let mut smt = SpentProofSmt::new();
+        let jap = [0xAA; 32];
+
+        assert!(!smt.is_spent(&jap));
+        smt.mark_spent(jap);
+        assert!(smt.is_spent(&jap));
+        assert_eq!(smt.len(), 1);
+        assert!(!smt.is_empty());
+    }
+
+    #[test]
+    fn is_spent_returns_false_for_unknown() {
+        let smt = SpentProofSmt::new();
+        assert!(!smt.is_spent(&[0x01; 32]));
+        assert!(!smt.is_spent(&[0x00; 32]));
+    }
+
+    #[test]
+    fn multiple_marks_are_idempotent_on_len() {
+        let mut smt = SpentProofSmt::new();
+        let jap = [0x42; 32];
+        smt.mark_spent(jap);
+        smt.mark_spent(jap);
+        assert_eq!(smt.len(), 1);
+        assert!(smt.is_spent(&jap));
+    }
+
+    #[test]
+    fn root_empty_is_deterministic() {
+        let smt1 = SpentProofSmt::new();
+        let smt2 = SpentProofSmt::new();
+        assert_eq!(smt1.root(), smt2.root());
+    }
+
+    #[test]
+    fn root_changes_when_jap_marked() {
+        let mut smt = SpentProofSmt::new();
+        let root_empty = smt.root();
+
+        smt.mark_spent([0x01; 32]);
+        let root_one = smt.root();
+        assert_ne!(root_empty, root_one);
+
+        smt.mark_spent([0x02; 32]);
+        let root_two = smt.root();
+        assert_ne!(root_one, root_two);
+    }
+
+    #[test]
+    fn root_is_order_independent() {
+        let mut smt_a = SpentProofSmt::new();
+        smt_a.mark_spent([0x01; 32]);
+        smt_a.mark_spent([0x02; 32]);
+
+        let mut smt_b = SpentProofSmt::new();
+        smt_b.mark_spent([0x02; 32]);
+        smt_b.mark_spent([0x01; 32]);
+
+        assert_eq!(
+            smt_a.root(),
+            smt_b.root(),
+            "root should be deterministic regardless of insertion order"
+        );
+    }
+
+    #[test]
+    fn root_differs_for_different_keys() {
+        let mut smt_a = SpentProofSmt::new();
+        smt_a.mark_spent([0xAA; 32]);
+
+        let mut smt_b = SpentProofSmt::new();
+        smt_b.mark_spent([0xBB; 32]);
+
+        assert_ne!(smt_a.root(), smt_b.root());
+    }
+
+    #[test]
+    fn many_entries_tracked_correctly() {
+        let mut smt = SpentProofSmt::new();
+        for i in 0..100u8 {
+            let mut key = [0u8; 32];
+            key[0] = i;
+            smt.mark_spent(key);
+        }
+        assert_eq!(smt.len(), 100);
+
+        let mut check_key = [0u8; 32];
+        check_key[0] = 50;
+        assert!(smt.is_spent(&check_key));
+
+        check_key[0] = 200;
+        assert!(!smt.is_spent(&check_key));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/envelope.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/envelope.rs
@@ -303,4 +303,110 @@ mod tests {
             .expect("decoding should succeed even with version mismatch");
         assert_eq!(decoded.version, 99);
     }
+
+    #[test]
+    fn transfer_signing_bytes_v3_is_deterministic() {
+        let from = [1u8; 32];
+        let to = [2u8; 32];
+        let tip = [3u8; 32];
+        let a =
+            compute_transfer_signing_bytes_v3(&from, &to, "tok", 100, &tip, 1, b"nonce", "memo");
+        let b =
+            compute_transfer_signing_bytes_v3(&from, &to, "tok", 100, &tip, 1, b"nonce", "memo");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 32);
+    }
+
+    #[test]
+    fn transfer_signing_bytes_v3_different_amounts_differ() {
+        let from = [1u8; 32];
+        let to = [2u8; 32];
+        let tip = [3u8; 32];
+        let a = compute_transfer_signing_bytes_v3(&from, &to, "tok", 100, &tip, 1, b"n", "");
+        let b = compute_transfer_signing_bytes_v3(&from, &to, "tok", 200, &tip, 1, b"n", "");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn transfer_signing_bytes_v3_different_token_ids_differ() {
+        let from = [1u8; 32];
+        let to = [2u8; 32];
+        let tip = [3u8; 32];
+        let a = compute_transfer_signing_bytes_v3(&from, &to, "tok_a", 100, &tip, 1, b"n", "");
+        let b = compute_transfer_signing_bytes_v3(&from, &to, "tok_b", 100, &tip, 1, b"n", "");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn online_message_signing_bytes_v3_is_deterministic() {
+        let from = [10u8; 32];
+        let to = [20u8; 32];
+        let tip = [30u8; 32];
+        let a = compute_online_message_signing_bytes_v3(
+            &from, &to, &tip, 5, b"nonce", b"payload", "hi",
+        );
+        let b = compute_online_message_signing_bytes_v3(
+            &from, &to, &tip, 5, b"nonce", b"payload", "hi",
+        );
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 32);
+    }
+
+    #[test]
+    fn online_message_signing_bytes_v3_different_payloads_differ() {
+        let from = [10u8; 32];
+        let to = [20u8; 32];
+        let tip = [30u8; 32];
+        let a = compute_online_message_signing_bytes_v3(&from, &to, &tip, 5, b"n", b"alpha", "");
+        let b = compute_online_message_signing_bytes_v3(&from, &to, &tip, 5, b"n", b"beta", "");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn online_message_nonce_v3_is_deterministic() {
+        let from = [0xAAu8; 32];
+        let to = [0xBBu8; 32];
+        let tip = [0xCCu8; 32];
+        let a = compute_online_message_nonce_v3(&from, &to, &tip, 7, b"data", "m");
+        let b = compute_online_message_nonce_v3(&from, &to, &tip, 7, b"data", "m");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn online_message_nonce_v3_different_seq_differ() {
+        let from = [0xAAu8; 32];
+        let to = [0xBBu8; 32];
+        let tip = [0xCCu8; 32];
+        let a = compute_online_message_nonce_v3(&from, &to, &tip, 1, b"d", "");
+        let b = compute_online_message_nonce_v3(&from, &to, &tip, 2, b"d", "");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn minimal_envelope_roundtrip() {
+        let env = Envelope {
+            version: 3,
+            headers: None,
+            message_id: vec![],
+            payload: None,
+        };
+        let bytes = to_canonical_bytes(&env);
+        let decoded = from_canonical_bytes(&bytes).unwrap();
+        assert_eq!(decoded.version, 3);
+        assert!(decoded.headers.is_none());
+        assert!(decoded.payload.is_none());
+    }
+
+    #[test]
+    fn transfer_and_online_message_signing_bytes_differ_same_inputs() {
+        let from = [1u8; 32];
+        let to = [2u8; 32];
+        let tip = [3u8; 32];
+        let transfer = compute_transfer_signing_bytes_v3(&from, &to, "", 0, &tip, 0, b"", "");
+        let online = compute_online_message_signing_bytes_v3(&from, &to, &tip, 0, b"", b"", "");
+        assert_ne!(
+            transfer, online,
+            "Different domain tags must produce different hashes"
+        );
+    }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/envelope/transport.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/envelope/transport.rs
@@ -174,4 +174,82 @@ mod tests {
             _ => panic!("Payload not UniversalRx"),
         }
     }
+
+    #[test]
+    fn encode_universal_rx_empty_results() {
+        let headers = sample_headers();
+        let rx = UniversalRx { results: vec![] };
+        let bytes = encode_universal_rx(&headers, rx).expect("encode");
+        let env = from_transport_bytes(&bytes).expect("decode");
+        assert_eq!(env.version, 3);
+        match env.payload {
+            Some(envelope::Payload::UniversalRx(r)) => {
+                assert!(r.results.is_empty());
+            }
+            _ => panic!("Expected UniversalRx payload"),
+        }
+    }
+
+    #[test]
+    fn encode_universal_rx_message_id_is_deterministic() {
+        let headers = sample_headers();
+        let rx = UniversalRx { results: vec![] };
+        let bytes1 = encode_universal_rx(&headers, rx.clone()).unwrap();
+        let bytes2 = encode_universal_rx(&headers, rx).unwrap();
+        let env1 = from_transport_bytes(&bytes1).unwrap();
+        let env2 = from_transport_bytes(&bytes2).unwrap();
+        assert_eq!(env1.message_id, env2.message_id);
+        assert_eq!(env1.message_id.len(), 16);
+    }
+
+    #[test]
+    fn encode_universal_rx_different_headers_different_message_ids() {
+        let h1 = sample_headers();
+        let mut h2 = sample_headers();
+        h2.seq = 999;
+        let rx = UniversalRx { results: vec![] };
+
+        let b1 = encode_universal_rx(&h1, rx.clone()).unwrap();
+        let b2 = encode_universal_rx(&h2, rx).unwrap();
+        let e1 = from_transport_bytes(&b1).unwrap();
+        let e2 = from_transport_bytes(&b2).unwrap();
+        assert_ne!(e1.message_id, e2.message_id);
+    }
+
+    #[test]
+    fn transport_roundtrip_preserves_all_header_fields() {
+        let env = Envelope {
+            version: 3,
+            headers: Some(Headers {
+                device_id: vec![0xAA; 32],
+                chain_tip: vec![0xBB; 32],
+                genesis_hash: vec![0xCC; 32],
+                seq: 12345,
+            }),
+            message_id: vec![0xDD; 16],
+            payload: None,
+        };
+        let bytes = to_transport_bytes(&env).unwrap();
+        let decoded = from_transport_bytes(&bytes).unwrap();
+        let h = decoded.headers.unwrap();
+        assert_eq!(h.device_id, vec![0xAA; 32]);
+        assert_eq!(h.chain_tip, vec![0xBB; 32]);
+        assert_eq!(h.genesis_hash, vec![0xCC; 32]);
+        assert_eq!(h.seq, 12345);
+        assert_eq!(decoded.message_id, vec![0xDD; 16]);
+    }
+
+    #[test]
+    fn minimal_envelope_transport_roundtrip() {
+        let env = Envelope {
+            version: 0,
+            headers: None,
+            message_id: vec![],
+            payload: None,
+        };
+        let bytes = to_transport_bytes(&env).unwrap();
+        let decoded = from_transport_bytes(&bytes).unwrap();
+        assert!(decoded.headers.is_none());
+        assert!(decoded.payload.is_none());
+    }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/pbi.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/pbi.rs
@@ -90,3 +90,165 @@ impl PlatformContext {
         Ok(arr)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_inputs() -> RawPlatformInputs {
+        RawPlatformInputs {
+            device_id_raw: vec![0xAA; 32],
+            genesis_hash_raw: vec![0xBB; 32],
+            cdbrw_hw_entropy: vec![0xCC; 32],
+            cdbrw_env_fingerprint: vec![0xDD; 32],
+            cdbrw_salt: vec![0xEE; 32],
+        }
+    }
+
+    #[test]
+    fn canonize_identifier_exact_32_bytes() {
+        let input = vec![0x42u8; 32];
+        let result = PlatformContext::canonize_identifier(&input, "DSM/test\0");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), [0x42u8; 32]);
+    }
+
+    #[test]
+    fn canonize_identifier_too_short() {
+        let input = vec![0x01u8; 16];
+        let result = PlatformContext::canonize_identifier(&input, "DSM/test\0");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DsmError::Validation { context, .. } => {
+                assert!(context.contains("expected 32"));
+                assert!(context.contains("got 16"));
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn canonize_identifier_too_long() {
+        let input = vec![0x01u8; 64];
+        let result = PlatformContext::canonize_identifier(&input, "DSM/test\0");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DsmError::Validation { context, .. } => {
+                assert!(context.contains("expected 32"));
+                assert!(context.contains("got 64"));
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn canonize_identifier_empty() {
+        let result = PlatformContext::canonize_identifier(&[], "DSM/test\0");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn canonize_identifier_preserves_bytes() {
+        let input: Vec<u8> = (0..32).collect();
+        let arr = PlatformContext::canonize_identifier(&input, "DSM/devid\0").unwrap();
+        assert_eq!(&arr[..], &input[..]);
+    }
+
+    #[test]
+    fn bootstrap_valid_inputs_succeeds() {
+        let ctx = PlatformContext::bootstrap(valid_inputs()).expect("bootstrap should succeed");
+        assert_eq!(ctx.device_id, [0xAA; 32]);
+        assert_eq!(ctx.genesis_hash, [0xBB; 32]);
+        assert_eq!(ctx.cdbrw_binding.len(), 32);
+        assert_ne!(ctx.cdbrw_binding, [0u8; 32]);
+    }
+
+    #[test]
+    fn bootstrap_short_device_id_fails() {
+        let mut inputs = valid_inputs();
+        inputs.device_id_raw = vec![0xAA; 10];
+        let result = PlatformContext::bootstrap(inputs);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DsmError::Validation { context, .. } => {
+                assert!(context.contains("expected 32"));
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bootstrap_short_genesis_hash_fails() {
+        let mut inputs = valid_inputs();
+        inputs.genesis_hash_raw = vec![0xBB; 5];
+        let result = PlatformContext::bootstrap(inputs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bootstrap_empty_hw_entropy_fails() {
+        let mut inputs = valid_inputs();
+        inputs.cdbrw_hw_entropy = vec![];
+        let result = PlatformContext::bootstrap(inputs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bootstrap_empty_env_fingerprint_fails() {
+        let mut inputs = valid_inputs();
+        inputs.cdbrw_env_fingerprint = vec![];
+        let result = PlatformContext::bootstrap(inputs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bootstrap_empty_salt_fails() {
+        let mut inputs = valid_inputs();
+        inputs.cdbrw_salt = vec![];
+        let result = PlatformContext::bootstrap(inputs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn raw_platform_inputs_construction() {
+        let raw = RawPlatformInputs {
+            device_id_raw: vec![1; 32],
+            genesis_hash_raw: vec![2; 32],
+            cdbrw_hw_entropy: vec![3; 16],
+            cdbrw_env_fingerprint: vec![4; 16],
+            cdbrw_salt: vec![5; 8],
+        };
+        assert_eq!(raw.device_id_raw.len(), 32);
+        assert_eq!(raw.genesis_hash_raw.len(), 32);
+        assert_eq!(raw.cdbrw_hw_entropy.len(), 16);
+        assert_eq!(raw.cdbrw_env_fingerprint.len(), 16);
+        assert_eq!(raw.cdbrw_salt.len(), 8);
+    }
+
+    #[test]
+    fn platform_context_fields_correct_after_bootstrap() {
+        let inputs = valid_inputs();
+        let ctx = PlatformContext::bootstrap(inputs).unwrap();
+
+        assert_eq!(ctx.device_id, [0xAA; 32]);
+        assert_eq!(ctx.genesis_hash, [0xBB; 32]);
+
+        // cdbrw_binding should match a direct call to derive_cdbrw_binding_key
+        let expected_binding = cdbrw_binding::derive_cdbrw_binding_key(
+            &vec![0xCC; 32],
+            &vec![0xDD; 32],
+            &vec![0xEE; 32],
+        )
+        .unwrap();
+        assert_eq!(ctx.cdbrw_binding, expected_binding);
+    }
+
+    #[test]
+    fn bootstrap_deterministic() {
+        let ctx1 = PlatformContext::bootstrap(valid_inputs()).unwrap();
+        let ctx2 = PlatformContext::bootstrap(valid_inputs()).unwrap();
+        assert_eq!(ctx1.device_id, ctx2.device_id);
+        assert_eq!(ctx1.genesis_hash, ctx2.genesis_hash);
+        assert_eq!(ctx1.cdbrw_binding, ctx2.cdbrw_binding);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/pbi.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/pbi.rs
@@ -234,12 +234,8 @@ mod tests {
         assert_eq!(ctx.genesis_hash, [0xBB; 32]);
 
         // cdbrw_binding should match a direct call to derive_cdbrw_binding_key
-        let expected_binding = cdbrw_binding::derive_cdbrw_binding_key(
-            &vec![0xCC; 32],
-            &vec![0xDD; 32],
-            &vec![0xEE; 32],
-        )
-        .unwrap();
+        let expected_binding =
+            cdbrw_binding::derive_cdbrw_binding_key(&[0xCC; 32], &[0xDD; 32], &[0xEE; 32]).unwrap();
         assert_eq!(ctx.cdbrw_binding, expected_binding);
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/serialization/canonical_bytes.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/serialization/canonical_bytes.rs
@@ -102,3 +102,206 @@ impl CanonicalBytesWriter {
 pub trait ToCanonicalBytes {
     fn to_canonical_bytes(&self) -> Result<Vec<u8>, DsmError>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_empty_writer() {
+        let w = CanonicalBytesWriter::new();
+        assert!(w.as_slice().is_empty());
+        assert_eq!(w.into_vec().len(), 0);
+    }
+
+    #[test]
+    fn with_capacity_creates_empty_writer() {
+        let w = CanonicalBytesWriter::with_capacity(1024);
+        assert!(w.as_slice().is_empty());
+        assert_eq!(w.into_vec().len(), 0);
+    }
+
+    #[test]
+    fn default_creates_empty_writer() {
+        let w = CanonicalBytesWriter::default();
+        assert!(w.as_slice().is_empty());
+    }
+
+    #[test]
+    fn push_u32_le_encodes_correctly() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u32_le(0x04030201);
+        assert_eq!(w.as_slice(), &[0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn push_u32_le_zero() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u32_le(0);
+        assert_eq!(w.as_slice(), &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn push_u32_le_max() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u32_le(u32::MAX);
+        assert_eq!(w.as_slice(), &[0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn push_u64_le_encodes_correctly() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u64_le(0x0807060504030201);
+        assert_eq!(
+            w.as_slice(),
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        );
+    }
+
+    #[test]
+    fn push_u64_le_zero() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u64_le(0);
+        assert_eq!(w.as_slice(), &[0; 8]);
+    }
+
+    #[test]
+    fn push_len_prefixed_encodes_length_and_data() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_len_prefixed(b"abc");
+        // length prefix: 3u32 LE = [3, 0, 0, 0], then payload
+        assert_eq!(w.as_slice(), &[3, 0, 0, 0, b'a', b'b', b'c']);
+    }
+
+    #[test]
+    fn push_len_prefixed_empty_data() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_len_prefixed(b"");
+        assert_eq!(w.as_slice(), &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn push_opt_len_prefixed_some() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_opt_len_prefixed(Some(b"xy"));
+        assert_eq!(w.as_slice(), &[2, 0, 0, 0, b'x', b'y']);
+    }
+
+    #[test]
+    fn push_opt_len_prefixed_none() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_opt_len_prefixed(None);
+        assert_eq!(w.as_slice(), &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn push_opt_none_same_as_empty_slice() {
+        let mut w_none = CanonicalBytesWriter::new();
+        w_none.push_opt_len_prefixed(None);
+
+        let mut w_empty = CanonicalBytesWriter::new();
+        w_empty.push_len_prefixed(b"");
+
+        assert_eq!(w_none.as_slice(), w_empty.as_slice());
+    }
+
+    #[test]
+    fn push_str_encodes_as_bytes() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_str("hi");
+        assert_eq!(w.as_slice(), &[2, 0, 0, 0, b'h', b'i']);
+    }
+
+    #[test]
+    fn push_str_empty() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_str("");
+        assert_eq!(w.as_slice(), &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn push_bytes32_encodes_fixed_array() {
+        let mut w = CanonicalBytesWriter::new();
+        let arr = [0xAB_u8; 32];
+        w.push_bytes32(&arr);
+        // length prefix: 32u32 LE = [32, 0, 0, 0], then 32 bytes of 0xAB
+        assert_eq!(w.as_slice().len(), 4 + 32);
+        assert_eq!(&w.as_slice()[..4], &[32, 0, 0, 0]);
+        assert_eq!(&w.as_slice()[4..], &[0xAB; 32]);
+    }
+
+    #[test]
+    fn push_vec_of_bytes32_empty() {
+        let mut w = CanonicalBytesWriter::new();
+        let items: &[[u8; 32]] = &[];
+        w.push_vec_of_bytes32(items);
+        // count = 0 u32 LE
+        assert_eq!(w.as_slice(), &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn push_vec_of_bytes32_two_items() {
+        let mut w = CanonicalBytesWriter::new();
+        let a = [0x11_u8; 32];
+        let b = [0x22_u8; 32];
+        w.push_vec_of_bytes32(&[a, b]);
+
+        // count(2) + 2*(len_prefix(32) + 32 bytes)
+        let expected_len = 4 + 2 * (4 + 32);
+        assert_eq!(w.as_slice().len(), expected_len);
+        // Count
+        assert_eq!(&w.as_slice()[..4], &[2, 0, 0, 0]);
+        // First item length prefix
+        assert_eq!(&w.as_slice()[4..8], &[32, 0, 0, 0]);
+        // First item data
+        assert_eq!(&w.as_slice()[8..40], &[0x11; 32]);
+        // Second item length prefix
+        assert_eq!(&w.as_slice()[40..44], &[32, 0, 0, 0]);
+        // Second item data
+        assert_eq!(&w.as_slice()[44..76], &[0x22; 32]);
+    }
+
+    #[test]
+    fn into_vec_returns_buffer() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u32_le(42);
+        let v = w.into_vec();
+        assert_eq!(v, 42u32.to_le_bytes());
+    }
+
+    #[test]
+    fn as_slice_returns_reference() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u32_le(7);
+        let s = w.as_slice();
+        assert_eq!(s, &7u32.to_le_bytes());
+        // Writer is still usable after as_slice
+        w.push_u32_le(8);
+        assert_eq!(w.as_slice().len(), 8);
+    }
+
+    #[test]
+    fn multiple_pushes_concatenate() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u32_le(1);
+        w.push_u64_le(2);
+        w.push_str("z");
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&1u32.to_le_bytes());
+        expected.extend_from_slice(&2u64.to_le_bytes());
+        expected.extend_from_slice(&1u32.to_le_bytes()); // length prefix for "z"
+        expected.push(b'z');
+        assert_eq!(w.into_vec(), expected);
+    }
+
+    #[test]
+    fn clone_produces_independent_copy() {
+        let mut w = CanonicalBytesWriter::new();
+        w.push_u32_le(99);
+        let mut w2 = w.clone();
+        w2.push_u32_le(100);
+        assert_eq!(w.as_slice().len(), 4);
+        assert_eq!(w2.as_slice().len(), 8);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/telemetry.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/telemetry.rs
@@ -506,3 +506,215 @@ pub fn get_global_metrics_snapshot() -> Vec<u8> {
     )
     .into_bytes()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── TelemetryConfig ─────────────────────────────────────────────
+
+    #[test]
+    fn telemetry_config_default() {
+        let cfg = TelemetryConfig::default();
+        assert_eq!(cfg.service_name, "dsm");
+        assert_eq!(cfg.environment, "development");
+        assert!(cfg.enable_metrics);
+        assert!(cfg.enable_structured_logging);
+        assert_eq!(cfg.log_level, "info");
+    }
+
+    #[test]
+    fn telemetry_config_clone() {
+        let cfg = TelemetryConfig {
+            service_name: "test".into(),
+            environment: "staging".into(),
+            enable_metrics: false,
+            enable_structured_logging: false,
+            log_level: "debug".into(),
+        };
+        let cloned = cfg.clone();
+        assert_eq!(cloned.service_name, "test");
+        assert_eq!(cloned.environment, "staging");
+        assert!(!cloned.enable_metrics);
+        assert!(!cloned.enable_structured_logging);
+        assert_eq!(cloned.log_level, "debug");
+    }
+
+    #[test]
+    fn telemetry_config_debug() {
+        let cfg = TelemetryConfig::default();
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("TelemetryConfig"));
+        assert!(dbg.contains("dsm"));
+    }
+
+    // ── get_global_metrics_snapshot ─────────────────────────────────
+
+    #[test]
+    fn metrics_snapshot_starts_with_header() {
+        let snap = get_global_metrics_snapshot();
+        let text = String::from_utf8(snap).expect("valid utf-8");
+        assert!(text.starts_with("dsm_metrics_v1\n"), "got: {text}");
+    }
+
+    #[test]
+    fn metrics_snapshot_contains_tick_line() {
+        let snap = get_global_metrics_snapshot();
+        let text = String::from_utf8(snap).unwrap();
+        assert!(
+            text.lines().any(|l| l.starts_with("tick=")),
+            "missing tick= line in: {text}"
+        );
+    }
+
+    #[test]
+    fn metrics_snapshot_contains_sdk_version() {
+        let snap = get_global_metrics_snapshot();
+        let text = String::from_utf8(snap).unwrap();
+        let expected_prefix = format!("sdk_version={}", env!("CARGO_PKG_VERSION"));
+        assert!(
+            text.contains(&expected_prefix),
+            "missing sdk_version in: {text}"
+        );
+    }
+
+    #[test]
+    fn metrics_snapshot_trailing_newline() {
+        let snap = get_global_metrics_snapshot();
+        let text = String::from_utf8(snap).unwrap();
+        assert!(text.ends_with('\n'));
+    }
+
+    #[test]
+    fn metrics_snapshot_no_json() {
+        let snap = get_global_metrics_snapshot();
+        let text = String::from_utf8(snap).unwrap();
+        assert!(!text.contains('{'));
+        assert!(!text.contains('}'));
+    }
+
+    #[test]
+    fn metrics_snapshot_deterministic_across_calls() {
+        let a = get_global_metrics_snapshot();
+        let b = get_global_metrics_snapshot();
+        assert_eq!(a, b, "consecutive calls should produce identical output");
+    }
+
+    // ── telemetry_metrics (pure functions, no subscriber needed) ─────
+
+    #[test]
+    fn increment_counter_does_not_panic() {
+        telemetry_metrics::increment_counter("test_counter", &[("k", "v")]);
+    }
+
+    #[test]
+    fn increment_counter_empty_labels() {
+        telemetry_metrics::increment_counter("test_counter", &[]);
+    }
+
+    #[test]
+    fn record_histogram_does_not_panic() {
+        telemetry_metrics::record_histogram("test_hist", 42, &[("op", "read")]);
+    }
+
+    #[test]
+    fn set_gauge_does_not_panic() {
+        telemetry_metrics::set_gauge("test_gauge", 100, &[("comp", "vault")]);
+    }
+
+    #[test]
+    fn record_operation_ticks_success() {
+        telemetry_metrics::record_operation_ticks("op", 10, true);
+    }
+
+    #[test]
+    fn record_operation_ticks_failure() {
+        telemetry_metrics::record_operation_ticks("op", 10, false);
+    }
+
+    #[test]
+    fn record_request_does_not_panic() {
+        telemetry_metrics::record_request("genesis", "success");
+    }
+
+    #[test]
+    fn record_error_does_not_panic() {
+        telemetry_metrics::record_error("transfer", "crypto");
+    }
+
+    // ── health module ───────────────────────────────────────────────
+
+    #[test]
+    fn health_check_healthy() {
+        health::record_health_check("db", true);
+    }
+
+    #[test]
+    fn health_check_unhealthy() {
+        health::record_health_check("db", false);
+    }
+
+    #[test]
+    fn record_startup_does_not_panic() {
+        health::record_startup("vault");
+    }
+
+    #[test]
+    fn record_shutdown_does_not_panic() {
+        health::record_shutdown("vault");
+    }
+
+    // ── security module ─────────────────────────────────────────────
+
+    #[test]
+    fn log_auth_attempt_success() {
+        security::log_auth_attempt("alice", true, "sphincs");
+    }
+
+    #[test]
+    fn log_auth_attempt_failure() {
+        security::log_auth_attempt("alice", false, "sphincs");
+    }
+
+    #[test]
+    fn log_auth_decision_allowed() {
+        security::log_auth_decision("alice", "vault", "read", true);
+    }
+
+    #[test]
+    fn log_auth_decision_denied() {
+        security::log_auth_decision("alice", "vault", "write", false);
+    }
+
+    #[test]
+    fn log_crypto_operation_success() {
+        security::log_crypto_operation("sign", "sphincs+", true);
+    }
+
+    #[test]
+    fn log_crypto_operation_failure() {
+        security::log_crypto_operation("verify", "blake3", false);
+    }
+
+    // ── performance module ──────────────────────────────────────────
+
+    #[test]
+    fn record_db_operation_fast() {
+        performance::record_db_operation("insert", "states", 5, true);
+    }
+
+    #[test]
+    fn record_db_operation_slow_triggers_warning() {
+        performance::record_db_operation("scan", "states", 2000, true);
+    }
+
+    #[test]
+    fn record_network_operation_does_not_panic() {
+        performance::record_network_operation("fetch", "/api/state", 50, true);
+    }
+
+    #[test]
+    fn record_memory_usage_does_not_panic() {
+        performance::record_memory_usage("cache", 1024 * 1024);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/contact_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/contact_types.rs
@@ -162,3 +162,209 @@ pub struct ContactRequest {
     /// Optional human-readable message.
     pub message: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_contact(
+        verified: bool,
+        chain_tip: Option<[u8; 32]>,
+        proof: Option<ChainTipSmtProof>,
+    ) -> DsmVerifiedContact {
+        DsmVerifiedContact {
+            alias: "Alice".into(),
+            device_id: [1u8; 32],
+            genesis_hash: [2u8; 32],
+            public_key: vec![3u8; 64],
+            genesis_material: vec![4u8; 128],
+            chain_tip,
+            chain_tip_smt_proof: proof,
+            genesis_verified_online: verified,
+            verified_at_commit_height: 100,
+            added_at_commit_height: 50,
+            last_updated_commit_height: 100,
+            verifying_storage_nodes: vec![],
+            ble_address: None,
+        }
+    }
+
+    fn make_matching_proof(state_hash: [u8; 32]) -> ChainTipSmtProof {
+        ChainTipSmtProof {
+            smt_root: [0xAA; 32],
+            state_hash,
+            smt_key: [0xBB; 32],
+            proof_path: vec![[0xCC; 32]],
+            state_index: 42,
+            proof_commit_height: 100,
+        }
+    }
+
+    // --- can_perform_bilateral_transaction ---
+
+    #[test]
+    fn bilateral_allowed_when_genesis_verified() {
+        let contact = make_contact(true, None, None);
+        assert!(contact.can_perform_bilateral_transaction());
+    }
+
+    #[test]
+    fn bilateral_denied_when_genesis_not_verified() {
+        let contact = make_contact(false, None, None);
+        assert!(!contact.can_perform_bilateral_transaction());
+    }
+
+    // --- needs_reverification_commit_height ---
+
+    #[test]
+    fn needs_reverification_when_stale() {
+        let contact = make_contact(true, None, None);
+        assert!(contact.needs_reverification_commit_height(1100, 500));
+    }
+
+    #[test]
+    fn no_reverification_when_fresh() {
+        let contact = make_contact(true, None, None);
+        assert!(!contact.needs_reverification_commit_height(200, 500));
+    }
+
+    #[test]
+    fn reverification_exact_boundary() {
+        let contact = make_contact(true, None, None);
+        // now=600, verified_at=100, max_age=500 → age=500, not > 500
+        assert!(!contact.needs_reverification_commit_height(600, 500));
+        // now=601 → age=501, > 500
+        assert!(contact.needs_reverification_commit_height(601, 500));
+    }
+
+    // --- update_chain_tip_with_proof ---
+
+    #[test]
+    fn update_chain_tip_sets_values() {
+        let mut contact = make_contact(true, None, None);
+        let new_tip = [0xDD; 32];
+        let proof = make_matching_proof(new_tip);
+
+        contact.update_chain_tip_with_proof(new_tip, Some(proof.clone()));
+
+        assert_eq!(contact.chain_tip, Some(new_tip));
+        assert!(contact.chain_tip_smt_proof.is_some());
+        assert_eq!(contact.chain_tip_smt_proof.unwrap().state_index, 42);
+    }
+
+    #[test]
+    fn update_chain_tip_clears_proof_when_none() {
+        let tip = [0xEE; 32];
+        let proof = make_matching_proof(tip);
+        let mut contact = make_contact(true, Some(tip), Some(proof));
+
+        contact.update_chain_tip_with_proof([0xFF; 32], None);
+
+        assert_eq!(contact.chain_tip, Some([0xFF; 32]));
+        assert!(contact.chain_tip_smt_proof.is_none());
+    }
+
+    // --- verify_chain_tip_proof ---
+
+    #[test]
+    fn verify_chain_tip_proof_matching() {
+        let tip = [0xAB; 32];
+        let proof = make_matching_proof(tip);
+        let contact = make_contact(true, Some(tip), Some(proof));
+        assert!(contact.verify_chain_tip_proof());
+    }
+
+    #[test]
+    fn verify_chain_tip_proof_mismatched_hash() {
+        let tip = [0xAB; 32];
+        let mut proof = make_matching_proof(tip);
+        proof.state_hash = [0xFF; 32]; // mismatch
+        let contact = make_contact(true, Some(tip), Some(proof));
+        assert!(!contact.verify_chain_tip_proof());
+    }
+
+    #[test]
+    fn verify_chain_tip_proof_no_tip() {
+        let contact = make_contact(true, None, None);
+        assert!(!contact.verify_chain_tip_proof());
+    }
+
+    #[test]
+    fn verify_chain_tip_proof_no_proof() {
+        let contact = make_contact(true, Some([0xAB; 32]), None);
+        assert!(!contact.verify_chain_tip_proof());
+    }
+
+    // --- has_verified_chain_tip ---
+
+    #[test]
+    fn has_verified_chain_tip_true() {
+        let tip = [0xCD; 32];
+        let proof = make_matching_proof(tip);
+        let contact = make_contact(true, Some(tip), Some(proof));
+        assert!(contact.has_verified_chain_tip());
+    }
+
+    #[test]
+    fn has_verified_chain_tip_false_no_proof() {
+        let contact = make_contact(true, Some([0xCD; 32]), None);
+        assert!(!contact.has_verified_chain_tip());
+    }
+
+    // --- Struct construction ---
+
+    #[test]
+    fn inbox_message_fields() {
+        let msg = InboxMessage {
+            id: "msg-1".into(),
+            msg_type: "bilateral_prepare".into(),
+            payload: "data".into(),
+            hash: "h".into(),
+            prev_hash: Some("prev".into()),
+            tick: 42,
+            from_device: "dev_a".into(),
+            to_device: "dev_b".into(),
+            signature: "sig".into(),
+        };
+        assert_eq!(msg.id, "msg-1");
+        assert_eq!(msg.tick, 42);
+        assert_eq!(msg.prev_hash, Some("prev".into()));
+    }
+
+    #[test]
+    fn transaction_data_fields() {
+        let tx = TransactionData {
+            from: "alice".into(),
+            to: "bob".into(),
+            amount: 1000,
+            memo: "payment".into(),
+            tick: 5,
+            signature: "sig".into(),
+            hash: "h".into(),
+        };
+        assert_eq!(tx.amount, 1000);
+        assert_eq!(tx.memo, "payment");
+    }
+
+    #[test]
+    fn contact_request_optional_message() {
+        let req = ContactRequest {
+            from_device_id: "d1".into(),
+            to_device_id: "d2".into(),
+            genesis_hash: "gh".into(),
+            public_key: vec![1, 2, 3],
+            tick: 10,
+            signature: "sig".into(),
+            message: None,
+        };
+        assert!(req.message.is_none());
+    }
+
+    #[test]
+    fn chain_tip_smt_proof_clone() {
+        let proof = make_matching_proof([0x11; 32]);
+        let cloned = proof.clone();
+        assert_eq!(cloned.smt_root, proof.smt_root);
+        assert_eq!(cloned.proof_path.len(), 1);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/crypto_error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/crypto_error.rs
@@ -29,3 +29,94 @@ impl fmt::Display for CryptoError {
 }
 
 impl std::error::Error for CryptoError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_without_source() {
+        let err = CryptoError {
+            context: "key derivation failed".into(),
+            operation: "blake3_hash".into(),
+            source: None,
+        };
+        assert_eq!(
+            err.to_string(),
+            "CryptoError [blake3_hash]: key derivation failed"
+        );
+    }
+
+    #[test]
+    fn display_with_source() {
+        let err = CryptoError {
+            context: "sign failed".into(),
+            operation: "sphincs_sign".into(),
+            source: Some("invalid key material".into()),
+        };
+        let msg = err.to_string();
+        assert_eq!(
+            msg,
+            "CryptoError [sphincs_sign]: sign failed (source: invalid key material)"
+        );
+    }
+
+    #[test]
+    fn display_empty_fields() {
+        let err = CryptoError {
+            context: String::new(),
+            operation: String::new(),
+            source: None,
+        };
+        assert_eq!(err.to_string(), "CryptoError []: ");
+    }
+
+    #[test]
+    fn debug_format() {
+        let err = CryptoError {
+            context: "ctx".into(),
+            operation: "op".into(),
+            source: Some("src".into()),
+        };
+        let dbg = format!("{err:?}");
+        assert!(dbg.contains("CryptoError"));
+        assert!(dbg.contains("ctx"));
+        assert!(dbg.contains("op"));
+        assert!(dbg.contains("src"));
+    }
+
+    #[test]
+    fn implements_error_trait() {
+        let err = CryptoError {
+            context: "test".into(),
+            operation: "test_op".into(),
+            source: None,
+        };
+        let dyn_err: &dyn std::error::Error = &err;
+        assert!(std::error::Error::source(dyn_err).is_none());
+    }
+
+    #[test]
+    fn fields_accessible() {
+        let err = CryptoError {
+            context: "ctx".into(),
+            operation: "ml_kem_encaps".into(),
+            source: Some("rng failure".into()),
+        };
+        assert_eq!(err.context, "ctx");
+        assert_eq!(err.operation, "ml_kem_encaps");
+        assert_eq!(err.source.as_deref(), Some("rng failure"));
+    }
+
+    fn accepts_std_error(_e: &dyn std::error::Error) {}
+
+    #[test]
+    fn usable_as_dyn_error() {
+        let err = CryptoError {
+            context: "test".into(),
+            operation: "test".into(),
+            source: None,
+        };
+        accepts_std_error(&err);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/error.rs
@@ -1862,3 +1862,439 @@ impl From<crate::core::token::policy::policy_enforcement::EnforcementError> for 
 }
 
 // This conversion must be implemented in the SDK crate, not in the core DSM crate.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- DeterministicSafetyClass ---
+
+    #[test]
+    fn deterministic_safety_class_as_str() {
+        assert_eq!(
+            DeterministicSafetyClass::ParentConsumed.as_str(),
+            "ParentConsumed"
+        );
+        assert_eq!(
+            DeterministicSafetyClass::StalePrecommit.as_str(),
+            "StalePrecommit"
+        );
+        assert_eq!(
+            DeterministicSafetyClass::TipMismatch.as_str(),
+            "TipMismatch"
+        );
+    }
+
+    #[test]
+    fn deterministic_safety_class_equality_and_clone() {
+        let a = DeterministicSafetyClass::ParentConsumed;
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    // --- Sub-error type as_str coverage ---
+
+    #[test]
+    fn bitcoin_error_type_as_str_all_variants() {
+        let pairs = [
+            (BitcoinErrorType::InvalidAddress, "InvalidAddress"),
+            (BitcoinErrorType::InsufficientBalance, "InsufficientBalance"),
+            (BitcoinErrorType::BroadcastFailure, "BroadcastFailure"),
+            (BitcoinErrorType::ConfirmationTimeout, "ConfirmationTimeout"),
+            (BitcoinErrorType::InvalidTransaction, "InvalidTransaction"),
+            (BitcoinErrorType::NetworkError, "NetworkError"),
+            (
+                BitcoinErrorType::ScriptValidationError,
+                "ScriptValidationError",
+            ),
+            (BitcoinErrorType::FeeEstimationError, "FeeEstimationError"),
+            (BitcoinErrorType::UtxoSelectionError, "UtxoSelectionError"),
+            (BitcoinErrorType::TransactionTooLarge, "TransactionTooLarge"),
+            (BitcoinErrorType::InvalidSignature, "InvalidSignature"),
+            (BitcoinErrorType::BlockNotFound, "BlockNotFound"),
+            (BitcoinErrorType::TransactionNotFound, "TransactionNotFound"),
+            (
+                BitcoinErrorType::InsufficientConfirmations,
+                "InsufficientConfirmations",
+            ),
+            (BitcoinErrorType::DustAmount, "DustAmount"),
+            (BitcoinErrorType::InvalidNetwork, "InvalidNetwork"),
+        ];
+        for (variant, expected) in pairs {
+            assert_eq!(variant.as_str(), expected);
+        }
+    }
+
+    #[test]
+    fn htlc_error_type_as_str_all_variants() {
+        assert_eq!(HtlcErrorType::HashLockMismatch.as_str(), "HashLockMismatch");
+        assert_eq!(HtlcErrorType::AlreadyClaimed.as_str(), "AlreadyClaimed");
+        assert_eq!(HtlcErrorType::AmountMismatch.as_str(), "AmountMismatch");
+    }
+
+    #[test]
+    fn storage_node_error_type_as_str() {
+        assert_eq!(
+            StorageNodeErrorType::CapacityExceeded.as_str(),
+            "CapacityExceeded"
+        );
+        assert_eq!(
+            StorageNodeErrorType::MaintenanceMode.as_str(),
+            "MaintenanceMode"
+        );
+    }
+
+    #[test]
+    fn vault_error_type_as_str() {
+        assert_eq!(VaultErrorType::VaultNotFound.as_str(), "VaultNotFound");
+        assert_eq!(VaultErrorType::EncryptionError.as_str(), "EncryptionError");
+    }
+
+    #[test]
+    fn replication_error_type_as_str() {
+        assert_eq!(
+            ReplicationErrorType::PartnerUnavailable.as_str(),
+            "PartnerUnavailable"
+        );
+        assert_eq!(ReplicationErrorType::QueueFull.as_str(), "QueueFull");
+    }
+
+    #[test]
+    fn resource_type_as_str() {
+        assert_eq!(ResourceType::StorageSpace.as_str(), "StorageSpace");
+        assert_eq!(ResourceType::Memory.as_str(), "Memory");
+    }
+
+    #[test]
+    fn consensus_error_type_as_str() {
+        assert_eq!(ConsensusErrorType::Timeout.as_str(), "Timeout");
+        assert_eq!(
+            ConsensusErrorType::ProtocolViolation.as_str(),
+            "ProtocolViolation"
+        );
+    }
+
+    // --- DsmError constructors ---
+
+    #[test]
+    fn crypto_constructor_without_source() {
+        let err = DsmError::crypto("bad key", None::<String>);
+        let msg = format!("{err}");
+        assert!(msg.contains("bad key"));
+    }
+
+    #[test]
+    fn crypto_op_constructor() {
+        let err = DsmError::crypto_op("sphincs_sign", "signature failed", Some("oops"));
+        let msg = format!("{err}");
+        assert!(msg.contains("signature failed"));
+    }
+
+    #[test]
+    fn state_machine_constructor() {
+        let err = DsmError::state_machine("invalid transition");
+        assert!(matches!(err, DsmError::StateMachine(ref m) if m == "invalid transition"));
+    }
+
+    #[test]
+    fn not_found_constructor() {
+        let err = DsmError::not_found("Token", Some("tok_123"));
+        let msg = format!("{err}");
+        assert!(msg.contains("Token"));
+        assert!(msg.contains("tok_123"));
+    }
+
+    #[test]
+    fn token_not_found_constructor() {
+        let err = DsmError::token_not_found("ERA".to_string());
+        let msg = format!("{err}");
+        assert!(msg.contains("Token"));
+        assert!(msg.contains("ERA"));
+    }
+
+    #[test]
+    fn internal_constructor_with_source() {
+        let err = DsmError::internal("bug", Some("root cause"));
+        let msg = format!("{err}");
+        assert!(msg.contains("bug"));
+        assert!(msg.contains("root cause"));
+    }
+
+    #[test]
+    fn invalid_parameter_constructor() {
+        let err = DsmError::invalid_parameter("negative amount");
+        assert!(matches!(err, DsmError::InvalidParameter(ref m) if m == "negative amount"));
+    }
+
+    #[test]
+    fn insufficient_balance_constructor() {
+        let err = DsmError::insufficient_balance("ERA", 50, 100);
+        let msg = format!("{err}");
+        assert!(msg.contains("ERA"));
+        assert!(msg.contains("50"));
+        assert!(msg.contains("100"));
+    }
+
+    #[test]
+    fn deterministic_safety_constructor() {
+        let err =
+            DsmError::deterministic_safety(DeterministicSafetyClass::TipMismatch, "tips diverged");
+        let msg = format!("{err}");
+        assert!(msg.contains("TipMismatch"));
+        assert!(msg.contains("tips diverged"));
+    }
+
+    #[test]
+    fn lock_error_constructor() {
+        let err = DsmError::lock_error();
+        assert!(matches!(err, DsmError::LockError));
+        assert_eq!(format!("{err}"), "Failed to acquire lock");
+    }
+
+    #[test]
+    fn timeout_constructor() {
+        let err = DsmError::timeout("5s exceeded");
+        assert!(matches!(err, DsmError::TimeError(ref m) if m == "5s exceeded"));
+    }
+
+    #[test]
+    fn config_simple_constructor() {
+        let err = DsmError::config_simple("missing key");
+        let msg = format!("{err}");
+        assert!(msg.contains("Configuration error"));
+        assert!(msg.contains("missing key"));
+    }
+
+    #[test]
+    fn capacity_limit_constructor() {
+        let err = DsmError::capacity_limit("objects full", ResourceType::ObjectCount, 1000, 1000);
+        let msg = format!("{err}");
+        assert!(msg.contains("ObjectCount"));
+        assert!(msg.contains("1000"));
+    }
+
+    #[test]
+    fn consensus_constructor() {
+        let err = DsmError::consensus(
+            "round failed",
+            ConsensusErrorType::Conflict,
+            Some("two proposals"),
+        );
+        let msg = format!("{err}");
+        assert!(msg.contains("Conflict"));
+        assert!(msg.contains("two proposals"));
+    }
+
+    // --- is_recoverable ---
+
+    #[test]
+    fn is_recoverable_true_for_network() {
+        let err = DsmError::Network {
+            context: "timeout".into(),
+            source: None,
+            entity: String::new(),
+            details: None,
+        };
+        assert!(err.is_recoverable());
+    }
+
+    #[test]
+    fn is_recoverable_true_for_storage() {
+        let err = DsmError::Storage {
+            context: "disk full".into(),
+            source: None,
+        };
+        assert!(err.is_recoverable());
+    }
+
+    #[test]
+    fn is_recoverable_true_for_lock_error() {
+        assert!(DsmError::LockError.is_recoverable());
+    }
+
+    #[test]
+    fn is_recoverable_false_for_serialization() {
+        let err = DsmError::Serialization {
+            context: "bad proto".into(),
+            source: None,
+            entity: "State".into(),
+            details: None,
+        };
+        assert!(!err.is_recoverable());
+    }
+
+    #[test]
+    fn is_recoverable_false_for_state() {
+        assert!(!DsmError::State("bad".into()).is_recoverable());
+    }
+
+    #[test]
+    fn is_recoverable_false_for_deterministic_safety() {
+        let err =
+            DsmError::deterministic_safety(DeterministicSafetyClass::ParentConsumed, "consumed");
+        assert!(!err.is_recoverable());
+    }
+
+    // --- Display coverage ---
+
+    #[test]
+    fn display_serialization_with_details_and_source() {
+        let src: Box<dyn Error + Send + Sync> = Box::new(std::fmt::Error);
+        let err = DsmError::Serialization {
+            context: "encoding".into(),
+            source: Some(src),
+            entity: "Envelope".into(),
+            details: Some("field missing".into()),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("Envelope"));
+        assert!(msg.contains("encoding"));
+        assert!(msg.contains("field missing"));
+        assert!(msg.contains("caused by"));
+    }
+
+    #[test]
+    fn display_clock_drift() {
+        let err = DsmError::ClockDrift {
+            message: "diverged".into(),
+            local_height: 10,
+            remote_height: 20,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("10"));
+        assert!(msg.contains("20"));
+        assert!(msg.contains("diverged"));
+    }
+
+    #[test]
+    fn display_unit_variants() {
+        assert_eq!(
+            format!("{}", DsmError::InvalidSignature),
+            "Invalid signature"
+        );
+        assert_eq!(
+            format!("{}", DsmError::InvalidPublicKey),
+            "Invalid public key"
+        );
+        assert_eq!(
+            format!("{}", DsmError::InvalidSecretKey),
+            "Invalid secret key"
+        );
+        assert_eq!(
+            format!("{}", DsmError::InvalidKeyLength),
+            "Invalid key length"
+        );
+        assert_eq!(
+            format!("{}", DsmError::InvalidCiphertext),
+            "Invalid ciphertext"
+        );
+        assert_eq!(
+            format!("{}", DsmError::InvalidIndex),
+            "Invalid or out-of-bounds index"
+        );
+        assert_eq!(
+            format!("{}", DsmError::MintNotAllowed),
+            "Minting not allowed on this network"
+        );
+        assert_eq!(
+            format!("{}", DsmError::BurnNotAllowed),
+            "Burning not allowed on this network"
+        );
+        assert_eq!(
+            format!("{}", DsmError::FaucetDisabled),
+            "Faucet is currently disabled"
+        );
+        assert_eq!(
+            format!("{}", DsmError::FaucetNotAvailable),
+            "Faucet is not available on this network"
+        );
+    }
+
+    #[test]
+    fn display_bitcoin_tap_safety() {
+        let err = DsmError::BitcoinTapSafety {
+            invariant: "dust_floor".into(),
+            message: "below 546 sats".into(),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("dust_floor"));
+        assert!(msg.contains("below 546 sats"));
+    }
+
+    #[test]
+    fn display_feature_not_available() {
+        let err = DsmError::FeatureNotAvailable {
+            feature: "ble".into(),
+            context: Some("not compiled".into()),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("ble"));
+        assert!(msg.contains("not compiled"));
+    }
+
+    // --- From impls ---
+
+    #[test]
+    fn from_io_error_not_found() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let dsm: DsmError = io_err.into();
+        assert!(matches!(dsm, DsmError::NotFound { .. }));
+    }
+
+    #[test]
+    fn from_io_error_permission_denied() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "forbidden");
+        let dsm: DsmError = io_err.into();
+        assert!(matches!(dsm, DsmError::Storage { .. }));
+    }
+
+    #[test]
+    fn from_io_error_connection_refused() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+        let dsm: DsmError = io_err.into();
+        assert!(matches!(dsm, DsmError::Network { .. }));
+    }
+
+    #[test]
+    fn from_fmt_error() {
+        let dsm: DsmError = std::fmt::Error.into();
+        assert!(matches!(dsm, DsmError::Generic { .. }));
+    }
+
+    #[test]
+    fn from_utf8_error() {
+        let bad = vec![0xFF, 0xFE];
+        let utf8_err = std::str::from_utf8(&bad).unwrap_err();
+        let dsm: DsmError = utf8_err.into();
+        assert!(matches!(dsm, DsmError::SerializationError(_)));
+    }
+
+    #[test]
+    fn from_parse_int_error() {
+        let e = "abc".parse::<i32>().unwrap_err();
+        let dsm: DsmError = e.into();
+        assert!(matches!(dsm, DsmError::Validation { .. }));
+    }
+
+    #[test]
+    fn from_parse_float_error() {
+        let e = "xyz".parse::<f64>().unwrap_err();
+        let dsm: DsmError = e.into();
+        assert!(matches!(dsm, DsmError::Validation { .. }));
+    }
+
+    // --- Error trait source() ---
+
+    #[test]
+    fn error_source_is_none_for_simple_variants() {
+        let err = DsmError::InvalidSignature;
+        assert!(err.source().is_none());
+    }
+
+    #[test]
+    fn error_source_present_for_storage_with_source() {
+        let inner = std::io::Error::new(std::io::ErrorKind::Other, "disk");
+        let err = DsmError::storage("write failed", Some(inner));
+        assert!(err.source().is_some());
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/error.rs
@@ -2293,7 +2293,7 @@ mod tests {
 
     #[test]
     fn error_source_present_for_storage_with_source() {
-        let inner = std::io::Error::new(std::io::ErrorKind::Other, "disk");
+        let inner = std::io::Error::other("disk");
         let err = DsmError::storage("write failed", Some(inner));
         assert!(err.source().is_some());
     }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/general.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/general.rs
@@ -307,4 +307,139 @@ mod tests {
         );
         assert_eq!(result.verification_path, vec![0, 1, 3, 7]);
     }
+
+    #[test]
+    fn generic_ops_new_and_accessors() {
+        let op = GenericOps::new("transfer", vec![1, 2, 3]);
+        assert_eq!(op.get_operation_type(), "transfer");
+        assert_eq!(op.get_data(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn generic_ops_default() {
+        let op = GenericOps::default();
+        assert_eq!(op.get_operation_type(), "default");
+        assert!(op.get_data().is_empty());
+    }
+
+    #[test]
+    fn generic_ops_display() {
+        let op = GenericOps::new("mint", vec![0xAB]);
+        let display = format!("{}", op);
+        assert!(display.contains("mint"));
+        assert!(display.contains("171")); // 0xAB = 171
+    }
+
+    #[test]
+    fn generic_ops_equality() {
+        let a = GenericOps::new("op", vec![1]);
+        let b = GenericOps::new("op", vec![1]);
+        let c = GenericOps::new("op", vec![2]);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn id_token_is_valid_with_all_fields() {
+        let token = IdToken {
+            token_id: "t1".to_string(),
+            issuer: "iss".to_string(),
+            subject: "sub".to_string(),
+            public_key: vec![1, 2, 3],
+            signature: vec![4, 5, 6],
+        };
+        assert!(token.is_valid());
+    }
+
+    #[test]
+    fn id_token_is_invalid_with_empty_token_id() {
+        let token = IdToken {
+            token_id: "".to_string(),
+            issuer: "iss".to_string(),
+            subject: "sub".to_string(),
+            public_key: vec![],
+            signature: vec![],
+        };
+        assert!(!token.is_valid());
+    }
+
+    #[test]
+    fn id_token_is_invalid_with_empty_issuer() {
+        let token = IdToken {
+            token_id: "t1".to_string(),
+            issuer: "".to_string(),
+            subject: "sub".to_string(),
+            public_key: vec![],
+            signature: vec![],
+        };
+        assert!(!token.is_valid());
+    }
+
+    #[test]
+    fn id_token_never_expires() {
+        let token = IdToken {
+            token_id: "t1".to_string(),
+            issuer: "iss".to_string(),
+            subject: "sub".to_string(),
+            public_key: vec![],
+            signature: vec![],
+        };
+        assert!(!token.has_expired());
+    }
+
+    #[test]
+    fn security_level_equality_and_copy() {
+        let a = SecurityLevel::Standard128;
+        let b = a; // Copy
+        assert_eq!(a, b);
+        assert_ne!(SecurityLevel::Standard128, SecurityLevel::Medium192);
+        assert_ne!(SecurityLevel::Medium192, SecurityLevel::High256);
+    }
+
+    #[test]
+    fn verification_result_failure() {
+        let result = VerificationResult {
+            is_valid: false,
+            reason: Some("Hash mismatch".to_string()),
+            details: None,
+            verification_path: vec![],
+        };
+        assert!(!result.is_valid);
+        assert_eq!(result.reason.as_deref(), Some("Hash mismatch"));
+        assert!(result.details.is_none());
+        assert!(result.verification_path.is_empty());
+    }
+
+    #[test]
+    fn directory_entry_with_invalidation_markers() {
+        let entry = DirectoryEntry {
+            id: "dir1".to_string(),
+            genesis_hash: vec![0xFF; 32],
+            invalidation_markers: vec![vec![1, 2], vec![3, 4]],
+        };
+        assert_eq!(entry.invalidation_markers.len(), 2);
+        assert_eq!(entry.invalidation_markers[0], vec![1, 2]);
+    }
+
+    #[test]
+    fn commitment_without_co_signature() {
+        let c = Commitment {
+            hash: vec![1],
+            signature: vec![2],
+            co_signature: None,
+        };
+        assert!(c.co_signature.is_none());
+        assert_eq!(c.hash, vec![1]);
+    }
+
+    #[test]
+    fn keypair_debug_with_short_public_key() {
+        let kp = KeyPair {
+            public_key: vec![1, 2],
+            private_key: vec![99],
+        };
+        let dbg = format!("{:?}", kp);
+        assert!(dbg.contains("[REDACTED]"));
+        assert!(!dbg.contains("99"));
+    }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/genesis_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/genesis_types.rs
@@ -335,4 +335,151 @@ mod tests {
 
         assert!(gs.verify_integrity().unwrap());
     }
+
+    fn make_valid_genesis() -> GenesisState {
+        use crate::crypto::blake3::domain_hash as dh;
+        let keys = GenesisPublicKeys::new(b"sign-key".to_vec(), b"kem-key".to_vec());
+        let proof_data = b"random-walk-data".to_vec();
+        let env_hash = *dh("DSM/genesis/dbrw-env", &proof_data).as_bytes();
+        let dbrw = DBRWProof::new(
+            vec![0xDE, 0xAD],
+            env_hash,
+            proof_data,
+            *blake3::hash(b"attestation").as_bytes(),
+        );
+        let mpc = vec![MPCContribution::new(
+            "node1".into(),
+            *blake3::hash(b"contrib1").as_bytes(),
+            vec![1, 2, 3],
+            0,
+        )];
+        let device_id: [u8; 32] = *blake3::hash(b"device").as_bytes();
+        let mut gs = GenesisState::new(device_id, [0u8; 32], mpc, dbrw, keys, 42);
+        gs.genesis_hash = gs.recompute_genesis_hash().unwrap();
+        gs
+    }
+
+    #[test]
+    fn integrity_fails_with_empty_mpc() {
+        let mut gs = make_valid_genesis();
+        gs.mpc_contributions.clear();
+        assert!(!gs.verify_integrity().unwrap());
+    }
+
+    #[test]
+    fn integrity_fails_with_empty_signing_key() {
+        let mut gs = make_valid_genesis();
+        gs.public_keys.signing_key.clear();
+        assert!(!gs.verify_integrity().unwrap());
+    }
+
+    #[test]
+    fn integrity_fails_with_empty_encapsulation_key() {
+        let mut gs = make_valid_genesis();
+        gs.public_keys.encapsulation_key.clear();
+        assert!(!gs.verify_integrity().unwrap());
+    }
+
+    #[test]
+    fn integrity_fails_with_empty_device_fingerprint() {
+        let mut gs = make_valid_genesis();
+        gs.dbrw_proof.device_fingerprint.clear();
+        assert!(!gs.verify_integrity().unwrap());
+    }
+
+    #[test]
+    fn integrity_fails_with_wrong_env_hash() {
+        let mut gs = make_valid_genesis();
+        gs.dbrw_proof.env_state_hash = [0xFFu8; 32];
+        assert!(!gs.verify_integrity().unwrap());
+    }
+
+    #[test]
+    fn integrity_fails_with_wrong_key_hash() {
+        let mut gs = make_valid_genesis();
+        gs.public_keys.key_hash = [0xFFu8; 32];
+        assert!(!gs.verify_integrity().unwrap());
+    }
+
+    #[test]
+    fn integrity_fails_with_wrong_genesis_hash() {
+        let mut gs = make_valid_genesis();
+        gs.genesis_hash = [0xFFu8; 32];
+        assert!(!gs.verify_integrity().unwrap());
+    }
+
+    #[test]
+    fn mpc_order_does_not_affect_genesis_hash() {
+        let h1 = *blake3::hash(b"c1").as_bytes();
+        let h2 = *blake3::hash(b"c2").as_bytes();
+        let keys = GenesisPublicKeys::new(b"S".to_vec(), b"K".to_vec());
+        let pd = b"pdata".to_vec();
+        let env = *domain_hash("DSM/genesis/dbrw-env", &pd).as_bytes();
+        let dbrw = DBRWProof::new(vec![1], env, pd, *blake3::hash(b"v").as_bytes());
+        let did: [u8; 32] = *blake3::hash(b"d").as_bytes();
+
+        let mpc_ab = vec![
+            MPCContribution::new("a".into(), h1, vec![], 0),
+            MPCContribution::new("b".into(), h2, vec![], 0),
+        ];
+        let mpc_ba = vec![
+            MPCContribution::new("b".into(), h2, vec![], 0),
+            MPCContribution::new("a".into(), h1, vec![], 0),
+        ];
+
+        let gs1 = GenesisState::new(did, [0u8; 32], mpc_ab, dbrw.clone(), keys.clone(), 0);
+        let gs2 = GenesisState::new(did, [0u8; 32], mpc_ba, dbrw, keys, 0);
+        assert_eq!(
+            gs1.recompute_genesis_hash().unwrap(),
+            gs2.recompute_genesis_hash().unwrap(),
+            "MPC contribution order must not affect canonical hash"
+        );
+    }
+
+    #[test]
+    fn genesis_state_new_metadata_is_empty() {
+        let gs = make_valid_genesis();
+        assert!(gs.metadata.is_empty());
+    }
+
+    #[test]
+    fn ct_eq_with_different_lengths() {
+        assert!(!ct_eq(&[1, 2], &[1, 2, 3]));
+    }
+
+    #[test]
+    fn ct_eq_with_equal_bytes() {
+        assert!(ct_eq(&[0xAB; 32], &[0xAB; 32]));
+    }
+
+    #[test]
+    fn ct_eq_with_single_bit_difference() {
+        let a = [0u8; 32];
+        let mut b = [0u8; 32];
+        b[31] = 1;
+        assert!(!ct_eq(&a, &b));
+    }
+
+    #[test]
+    fn different_device_ids_produce_different_hashes() {
+        let keys = GenesisPublicKeys::new(b"S".to_vec(), b"K".to_vec());
+        let pd = b"p".to_vec();
+        let env = *domain_hash("DSM/genesis/dbrw-env", &pd).as_bytes();
+        let dbrw = DBRWProof::new(vec![1], env, pd, [0u8; 32]);
+        let mpc = vec![MPCContribution::new("n".into(), [0u8; 32], vec![], 0)];
+
+        let gs1 = GenesisState::new(
+            [1u8; 32],
+            [0u8; 32],
+            mpc.clone(),
+            dbrw.clone(),
+            keys.clone(),
+            0,
+        );
+        let gs2 = GenesisState::new([2u8; 32], [0u8; 32], mpc, dbrw, keys, 0);
+        assert_ne!(
+            gs1.recompute_genesis_hash().unwrap(),
+            gs2.recompute_genesis_hash().unwrap()
+        );
+    }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/identifiers.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/identifiers.rs
@@ -310,3 +310,274 @@ impl fmt::Display for Signature {
         write!(f, "Signature({} bytes)", self.0.len())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- encode_crockford ---
+
+    #[test]
+    fn crockford_empty_input() {
+        assert_eq!(encode_crockford(&[]), "");
+    }
+
+    #[test]
+    fn crockford_single_byte() {
+        let result = encode_crockford(&[0xFF]);
+        assert!(!result.is_empty());
+        for c in result.chars() {
+            assert!("0123456789ABCDEFGHJKMNPQRSTVWXYZ".contains(c));
+        }
+    }
+
+    #[test]
+    fn crockford_deterministic() {
+        let data = b"hello";
+        assert_eq!(encode_crockford(data), encode_crockford(data));
+    }
+
+    // --- Macro-generated ID types (VaultId, SessionId, NodeId, TransactionId) ---
+
+    #[test]
+    fn vault_id_new_from_string() {
+        let id = VaultId::new("my-vault");
+        assert_eq!(id.as_bytes(), b"my-vault");
+    }
+
+    #[test]
+    fn vault_id_from_bytes() {
+        let id = VaultId::from_bytes(vec![1, 2, 3]);
+        assert_eq!(id.as_bytes(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn vault_id_display_has_prefix() {
+        let id = VaultId::new("test");
+        let display = format!("{id}");
+        assert!(display.starts_with("vault_"));
+    }
+
+    #[test]
+    fn vault_id_into_vec() {
+        let id = VaultId::new("abc");
+        let bytes: Vec<u8> = id.into();
+        assert_eq!(bytes, b"abc");
+    }
+
+    #[test]
+    fn vault_id_as_ref() {
+        let id = VaultId::new("ref");
+        let slice: &[u8] = id.as_ref();
+        assert_eq!(slice, b"ref");
+    }
+
+    #[test]
+    fn session_id_display_prefix() {
+        let id = SessionId::new("s1");
+        assert!(format!("{id}").starts_with("session_"));
+    }
+
+    #[test]
+    fn node_id_display_prefix() {
+        let id = NodeId::new("n1");
+        assert!(format!("{id}").starts_with("node_"));
+    }
+
+    #[test]
+    fn transaction_id_display_prefix() {
+        let id = TransactionId::new("t1");
+        assert!(format!("{id}").starts_with("tx_"));
+    }
+
+    #[test]
+    fn id_type_equality() {
+        let a = VaultId::new("same");
+        let b = VaultId::new("same");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn id_type_inequality() {
+        let a = VaultId::new("one");
+        let b = VaultId::new("two");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn id_type_clone() {
+        let a = NodeId::new("cloned");
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn id_type_hash_consistency() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(VaultId::new("x"));
+        set.insert(VaultId::new("x"));
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn id_generate_is_unique() {
+        let a = VaultId::generate();
+        let b = VaultId::generate();
+        assert_ne!(a, b);
+    }
+
+    // --- GenesisHash ---
+
+    #[test]
+    fn genesis_hash_new_and_accessors() {
+        let bytes = [0xAB; 32];
+        let gh = GenesisHash::new(bytes);
+        assert_eq!(gh.as_bytes(), &bytes);
+        assert_eq!(gh.as_slice(), &bytes[..]);
+    }
+
+    #[test]
+    fn genesis_hash_from_bytes_valid() {
+        let bytes = vec![0x42u8; 32];
+        let gh = GenesisHash::from_bytes(&bytes).unwrap();
+        assert_eq!(gh.as_bytes(), &[0x42; 32]);
+    }
+
+    #[test]
+    fn genesis_hash_from_bytes_too_short() {
+        let err = GenesisHash::from_bytes(&[0u8; 16]).unwrap_err();
+        assert_eq!(err, GenesisHashError::Length(16));
+    }
+
+    #[test]
+    fn genesis_hash_from_bytes_too_long() {
+        let err = GenesisHash::from_bytes(&[0u8; 64]).unwrap_err();
+        assert_eq!(err, GenesisHashError::Length(64));
+    }
+
+    #[test]
+    fn genesis_hash_from_bytes_empty() {
+        let err = GenesisHash::from_bytes(&[]).unwrap_err();
+        assert_eq!(err, GenesisHashError::Length(0));
+    }
+
+    #[test]
+    fn genesis_hash_into_inner() {
+        let bytes = [0xCD; 32];
+        let gh = GenesisHash::new(bytes);
+        assert_eq!(gh.into_inner(), bytes);
+    }
+
+    #[test]
+    fn genesis_hash_from_array() {
+        let arr = [0xEF; 32];
+        let gh: GenesisHash = arr.into();
+        assert_eq!(gh.as_bytes(), &arr);
+    }
+
+    #[test]
+    fn genesis_hash_into_array() {
+        let gh = GenesisHash::new([0x11; 32]);
+        let arr: [u8; 32] = gh.into();
+        assert_eq!(arr, [0x11; 32]);
+    }
+
+    #[test]
+    fn genesis_hash_display() {
+        let gh = GenesisHash::new([0; 32]);
+        assert_eq!(format!("{gh}"), "genesis_hash[32 bytes]");
+    }
+
+    #[test]
+    fn genesis_hash_error_display() {
+        let err = GenesisHashError::Length(5);
+        let msg = format!("{err}");
+        assert!(msg.contains("32 bytes"));
+        assert!(msg.contains("5"));
+    }
+
+    // --- Entropy ---
+
+    #[test]
+    fn entropy_new_and_accessors() {
+        let e = Entropy::new(vec![1, 2, 3, 4]);
+        assert_eq!(e.as_bytes(), &[1, 2, 3, 4]);
+        assert_eq!(e.len(), 4);
+        assert!(!e.is_empty());
+    }
+
+    #[test]
+    fn entropy_empty() {
+        let e = Entropy::new(vec![]);
+        assert!(e.is_empty());
+        assert_eq!(e.len(), 0);
+    }
+
+    #[test]
+    fn entropy_from_vec() {
+        let e: Entropy = vec![10, 20].into();
+        assert_eq!(e.as_bytes(), &[10, 20]);
+    }
+
+    #[test]
+    fn entropy_into_vec() {
+        let e = Entropy::new(vec![5, 6, 7]);
+        let v: Vec<u8> = e.into();
+        assert_eq!(v, vec![5, 6, 7]);
+    }
+
+    #[test]
+    fn entropy_display() {
+        let e = Entropy::new(vec![0; 32]);
+        assert_eq!(format!("{e}"), "Entropy(32 bytes)");
+    }
+
+    #[test]
+    fn entropy_generate_is_32_bytes() {
+        let e = Entropy::generate();
+        assert_eq!(e.len(), 32);
+    }
+
+    // --- Signature ---
+
+    #[test]
+    fn signature_new_and_accessors() {
+        let s = Signature::new(vec![0xAA; 64]);
+        assert_eq!(s.as_bytes().len(), 64);
+        assert_eq!(s.len(), 64);
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn signature_empty() {
+        let s = Signature::new(vec![]);
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn signature_from_vec() {
+        let s: Signature = vec![1, 2, 3].into();
+        assert_eq!(s.len(), 3);
+    }
+
+    #[test]
+    fn signature_into_vec() {
+        let s = Signature::new(vec![10, 20]);
+        let v: Vec<u8> = s.into();
+        assert_eq!(v, vec![10, 20]);
+    }
+
+    #[test]
+    fn signature_display() {
+        let s = Signature::new(vec![0; 128]);
+        assert_eq!(format!("{s}"), "Signature(128 bytes)");
+    }
+
+    #[test]
+    fn signature_as_ref() {
+        let s = Signature::new(vec![9, 8, 7]);
+        let slice: &[u8] = s.as_ref();
+        assert_eq!(slice, &[9, 8, 7]);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/identity.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/identity.rs
@@ -56,3 +56,122 @@ pub struct IdentityAnchor {
     /// Additional metadata
     pub meta_data: HashMap<String, Vec<u8>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::state_types::DeviceInfo;
+
+    #[test]
+    fn identity_claim_roundtrip_fields() {
+        let claim = IdentityClaim {
+            identity_id: "id-001".into(),
+            tick: 42,
+            expires_at_tick: 100,
+            public_key: vec![1, 2, 3],
+            signature: vec![4, 5, 6],
+            claim_hash: vec![7, 8, 9],
+            anchor_commitment: vec![10, 11],
+            device_info: DeviceInfo::new([0xAA; 32], vec![0xBB; 4]),
+            meta_data: HashMap::new(),
+        };
+        assert_eq!(claim.identity_id, "id-001");
+        assert_eq!(claim.tick, 42);
+        assert_eq!(claim.expires_at_tick, 100);
+        assert_eq!(claim.public_key, vec![1, 2, 3]);
+        assert_eq!(claim.signature, vec![4, 5, 6]);
+        assert_eq!(claim.claim_hash, vec![7, 8, 9]);
+        assert_eq!(claim.anchor_commitment, vec![10, 11]);
+    }
+
+    #[test]
+    fn identity_claim_with_metadata() {
+        let mut meta = HashMap::new();
+        meta.insert("label".into(), b"phone".to_vec());
+
+        let claim = IdentityClaim {
+            identity_id: "id-002".into(),
+            tick: 0,
+            expires_at_tick: u64::MAX,
+            public_key: vec![],
+            signature: vec![],
+            claim_hash: vec![],
+            anchor_commitment: vec![],
+            device_info: DeviceInfo::new([0; 32], vec![]),
+            meta_data: meta,
+        };
+        assert_eq!(claim.meta_data.get("label").unwrap(), b"phone");
+    }
+
+    #[test]
+    fn identity_claim_clone() {
+        let claim = IdentityClaim {
+            identity_id: "clone-me".into(),
+            tick: 1,
+            expires_at_tick: 2,
+            public_key: vec![0xFF],
+            signature: vec![],
+            claim_hash: vec![],
+            anchor_commitment: vec![],
+            device_info: DeviceInfo::new([0; 32], vec![]),
+            meta_data: HashMap::new(),
+        };
+        let cloned = claim.clone();
+        assert_eq!(cloned.identity_id, "clone-me");
+        assert_eq!(cloned.public_key, vec![0xFF]);
+    }
+
+    #[test]
+    fn identity_anchor_basic() {
+        let anchor = IdentityAnchor {
+            identity_id: "anchor-1".into(),
+            public_key: vec![1, 2, 3, 4],
+            created_at_tick: 10,
+            revoked_at_tick: None,
+            meta_data: HashMap::new(),
+        };
+        assert_eq!(anchor.identity_id, "anchor-1");
+        assert_eq!(anchor.created_at_tick, 10);
+        assert!(anchor.revoked_at_tick.is_none());
+    }
+
+    #[test]
+    fn identity_anchor_revoked() {
+        let anchor = IdentityAnchor {
+            identity_id: "anchor-2".into(),
+            public_key: vec![],
+            created_at_tick: 5,
+            revoked_at_tick: Some(50),
+            meta_data: HashMap::new(),
+        };
+        assert_eq!(anchor.revoked_at_tick, Some(50));
+    }
+
+    #[test]
+    fn identity_anchor_clone() {
+        let anchor = IdentityAnchor {
+            identity_id: "anchor-3".into(),
+            public_key: vec![9],
+            created_at_tick: 0,
+            revoked_at_tick: Some(99),
+            meta_data: HashMap::new(),
+        };
+        let cloned = anchor.clone();
+        assert_eq!(cloned.identity_id, "anchor-3");
+        assert_eq!(cloned.revoked_at_tick, Some(99));
+    }
+
+    #[test]
+    fn identity_anchor_debug() {
+        let anchor = IdentityAnchor {
+            identity_id: "dbg".into(),
+            public_key: vec![],
+            created_at_tick: 0,
+            revoked_at_tick: None,
+            meta_data: HashMap::new(),
+        };
+        let dbg = format!("{anchor:?}");
+        assert!(dbg.contains("IdentityAnchor"));
+        assert!(dbg.contains("dbg"));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -2047,3 +2047,1095 @@ impl From<StateTransition> for Operation {
         transition.operation
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_balance(value: u64) -> Balance {
+        Balance::from_parts(value, 0, 0, Some([0xAB; 32]))
+    }
+
+    fn roundtrip(op: &Operation) -> Operation {
+        let bytes = op.to_bytes();
+        let decoded = Operation::from_bytes(&bytes).expect("from_bytes failed");
+        assert_eq!(
+            op,
+            &decoded,
+            "round-trip mismatch for {:?}",
+            op.get_operation_type()
+        );
+        let rebytes = decoded.to_bytes();
+        assert_eq!(bytes, rebytes, "re-encode mismatch");
+        decoded
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Round-trip tests for every variant
+    // ------------------------------------------------------------------ //
+    mod roundtrip {
+        use super::*;
+
+        #[test]
+        fn genesis() {
+            roundtrip(&Operation::Genesis);
+        }
+
+        #[test]
+        fn noop() {
+            roundtrip(&Operation::Noop);
+        }
+
+        #[test]
+        fn create() {
+            roundtrip(&Operation::Create {
+                message: "create identity".into(),
+                identity_data: vec![1, 2, 3],
+                public_key: vec![4, 5, 6],
+                metadata: vec![7, 8],
+                commitment: vec![9],
+                proof: vec![10, 11],
+                mode: TransactionMode::Bilateral,
+            });
+        }
+
+        #[test]
+        fn update_with_forward_link() {
+            roundtrip(&Operation::Update {
+                message: "update id".into(),
+                identity_id: vec![0xAA; 16],
+                updated_data: vec![0xBB; 8],
+                proof: vec![0xCC; 4],
+                forward_link: Some(vec![0xDD; 32]),
+            });
+        }
+
+        #[test]
+        fn update_without_forward_link() {
+            roundtrip(&Operation::Update {
+                message: "no fwd".into(),
+                identity_id: vec![1],
+                updated_data: vec![2],
+                proof: vec![3],
+                forward_link: None,
+            });
+        }
+
+        #[test]
+        fn transfer_no_precommit() {
+            roundtrip(&Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(500),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![0xFF; 16],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![0x02; 32],
+                to: vec![0x03; 32],
+                message: "send tokens".into(),
+                signature: vec![0xAA; 64],
+            });
+        }
+
+        #[test]
+        fn transfer_with_precommit() {
+            let mut fixed = HashMap::new();
+            fixed.insert("recipient".into(), vec![0x01; 32]);
+            fixed.insert("amount".into(), vec![0, 0, 0, 100]);
+            let pc = PreCommitmentOp {
+                fixed_parameters: fixed,
+                variable_parameters: vec!["nonce".into(), "timestamp".into()],
+                security_params: SecurityParameters::default(),
+            };
+            roundtrip(&Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(1000),
+                token_id: b"TKN".to_vec(),
+                mode: TransactionMode::Unilateral,
+                nonce: vec![0x11; 8],
+                verification: VerificationType::PreCommitted,
+                pre_commit: Some(pc),
+                recipient: vec![0x02; 32],
+                to: vec![0x03; 32],
+                message: "pre-committed transfer".into(),
+                signature: vec![0xBB; 48],
+            });
+        }
+
+        #[test]
+        fn transfer_custom_verification() {
+            roundtrip(&Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(42),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![0x99],
+                verification: VerificationType::Custom(vec![0xDE, 0xAD]),
+                pre_commit: None,
+                recipient: vec![],
+                to: vec![],
+                message: String::new(),
+                signature: vec![],
+            });
+        }
+
+        #[test]
+        fn mint() {
+            roundtrip(&Operation::Mint {
+                amount: test_balance(10_000),
+                token_id: b"ERA".to_vec(),
+                authorized_by: vec![0xAA; 32],
+                proof_of_authorization: vec![0xBB; 64],
+                message: "mint tokens".into(),
+            });
+        }
+
+        #[test]
+        fn burn() {
+            roundtrip(&Operation::Burn {
+                amount: test_balance(200),
+                token_id: b"TKN".to_vec(),
+                proof_of_ownership: vec![0xCC; 64],
+                message: "burn tokens".into(),
+            });
+        }
+
+        #[test]
+        fn lock_token() {
+            roundtrip(&Operation::LockToken {
+                token_id: b"ERA".to_vec(),
+                amount: 500,
+                purpose: b"escrow".to_vec(),
+                mode: TransactionMode::Unilateral,
+                signature: vec![0xDD; 32],
+            });
+        }
+
+        #[test]
+        fn unlock_token() {
+            roundtrip(&Operation::UnlockToken {
+                token_id: b"ERA".to_vec(),
+                amount: 250,
+                purpose: b"escrow".to_vec(),
+                mode: TransactionMode::Bilateral,
+                signature: vec![0xEE; 32],
+            });
+        }
+
+        #[test]
+        fn lock() {
+            roundtrip(&Operation::Lock {
+                token_id: b"TKN".to_vec(),
+                amount: test_balance(100),
+                purpose: b"collateral".to_vec(),
+                owner: vec![0x11; 32],
+                message: "lock for collateral".into(),
+                signature: vec![0x22; 48],
+            });
+        }
+
+        #[test]
+        fn unlock() {
+            roundtrip(&Operation::Unlock {
+                token_id: b"TKN".to_vec(),
+                amount: test_balance(50),
+                purpose: b"collateral".to_vec(),
+                owner: vec![0x33; 32],
+                message: "release collateral".into(),
+                signature: vec![0x44; 48],
+            });
+        }
+
+        #[test]
+        fn add_relationship() {
+            roundtrip(&Operation::AddRelationship {
+                from_id: [0x01; 32],
+                to_id: [0x02; 32],
+                relationship_type: b"bilateral_transfer".to_vec(),
+                metadata: vec![0xAA; 10],
+                proof: vec![0xBB; 64],
+                mode: TransactionMode::Bilateral,
+                message: "add rel".into(),
+            });
+        }
+
+        #[test]
+        fn create_relationship() {
+            roundtrip(&Operation::CreateRelationship {
+                message: "create rel".into(),
+                counterparty_id: vec![0x01; 32],
+                commitment: vec![0x02; 16],
+                proof: vec![0x03; 64],
+                mode: TransactionMode::Unilateral,
+            });
+        }
+
+        #[test]
+        fn remove_relationship() {
+            roundtrip(&Operation::RemoveRelationship {
+                from_id: [0xAA; 32],
+                to_id: [0xBB; 32],
+                relationship_type: b"expired".to_vec(),
+                proof: vec![0xCC; 64],
+                mode: TransactionMode::Bilateral,
+                message: "remove rel".into(),
+            });
+        }
+
+        #[test]
+        fn recovery() {
+            roundtrip(&Operation::Recovery {
+                message: "recover chain".into(),
+                state_number: 42,
+                state_hash: vec![0x11; 32],
+                state_entropy: vec![0x22; 32],
+                invalidation_data: vec![0x33; 16],
+                new_state_data: vec![0x44; 64],
+                new_state_number: 43,
+                new_state_hash: vec![0x55; 32],
+                new_state_entropy: vec![0x66; 32],
+                compromise_proof: vec![0x77; 128],
+                authority_sigs: vec![vec![0x88; 64], vec![0x99; 64]],
+            });
+        }
+
+        #[test]
+        fn delete() {
+            roundtrip(&Operation::Delete {
+                reason: "resource expired".into(),
+                proof: vec![0xAA; 64],
+                mode: TransactionMode::Unilateral,
+                id: vec![0xBB; 16],
+            });
+        }
+
+        #[test]
+        fn link() {
+            roundtrip(&Operation::Link {
+                target_id: vec![0x01; 32],
+                link_type: b"forward".to_vec(),
+                proof: vec![0x02; 64],
+                mode: TransactionMode::Bilateral,
+            });
+        }
+
+        #[test]
+        fn unlink() {
+            roundtrip(&Operation::Unlink {
+                target_id: vec![0x01; 32],
+                proof: vec![0x02; 64],
+                mode: TransactionMode::Unilateral,
+            });
+        }
+
+        #[test]
+        fn invalidate() {
+            roundtrip(&Operation::Invalidate {
+                reason: "clone detected".into(),
+                proof: vec![0xDE; 64],
+                mode: TransactionMode::Bilateral,
+            });
+        }
+
+        #[test]
+        fn generic() {
+            roundtrip(&Operation::Generic {
+                operation_type: b"custom_op".to_vec(),
+                data: vec![1, 2, 3, 4, 5],
+                message: "generic op".into(),
+                signature: vec![0xFF; 32],
+            });
+        }
+
+        #[test]
+        fn receive_with_sender_state_hash() {
+            roundtrip(&Operation::Receive {
+                token_id: b"ERA".to_vec(),
+                from_device_id: vec![0x01; 32],
+                amount: test_balance(777),
+                recipient: vec![0x02; 32],
+                message: "receive tokens".into(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![0x03; 16],
+                verification: VerificationType::StandardBilateral,
+                sender_state_hash: Some(vec![0x04; 32]),
+            });
+        }
+
+        #[test]
+        fn receive_without_sender_state_hash() {
+            roundtrip(&Operation::Receive {
+                token_id: b"TKN".to_vec(),
+                from_device_id: vec![0xAA; 32],
+                amount: test_balance(1),
+                recipient: vec![],
+                message: String::new(),
+                mode: TransactionMode::Unilateral,
+                nonce: vec![],
+                verification: VerificationType::Standard,
+                sender_state_hash: None,
+            });
+        }
+
+        #[test]
+        fn create_token_full() {
+            roundtrip(&Operation::CreateToken {
+                token_id: b"dBTC".to_vec(),
+                initial_supply: test_balance(21_000_000),
+                name: "Deterministic Bitcoin".into(),
+                symbol: "dBTC".into(),
+                decimals: 8,
+                metadata_uri: Some("https://example.com/dbtc".into()),
+                policy_anchor: Some(vec![0xAB; 32]),
+                signature: vec![0xCD; 64],
+            });
+        }
+
+        #[test]
+        fn create_token_minimal() {
+            roundtrip(&Operation::CreateToken {
+                token_id: b"T".to_vec(),
+                initial_supply: test_balance(0),
+                name: "Test".into(),
+                symbol: "T".into(),
+                decimals: 0,
+                metadata_uri: None,
+                policy_anchor: None,
+                signature: vec![],
+            });
+        }
+
+        #[test]
+        fn dlv_create() {
+            roundtrip(&Operation::DlvCreate {
+                vault_id: vec![0x01; 32],
+                creator_public_key: vec![0x02; 64],
+                parameters_hash: vec![0x03; 32],
+                fulfillment_condition: vec![0x04; 16],
+                intended_recipient: Some(vec![0x05; 64]),
+                token_id: Some(b"ERA".to_vec()),
+                locked_amount: Some(test_balance(999)),
+                signature: vec![0x06; 48],
+                mode: TransactionMode::Unilateral,
+            });
+        }
+
+        #[test]
+        fn dlv_create_no_optionals() {
+            roundtrip(&Operation::DlvCreate {
+                vault_id: vec![0x01; 32],
+                creator_public_key: vec![0x02; 64],
+                parameters_hash: vec![0x03; 32],
+                fulfillment_condition: vec![],
+                intended_recipient: None,
+                token_id: None,
+                locked_amount: None,
+                signature: vec![0x06; 48],
+                mode: TransactionMode::Bilateral,
+            });
+        }
+
+        #[test]
+        fn dlv_unlock() {
+            roundtrip(&Operation::DlvUnlock {
+                vault_id: vec![0x01; 32],
+                fulfillment_proof: vec![0x02; 128],
+                requester_public_key: vec![0x03; 64],
+                signature: vec![0x04; 48],
+                mode: TransactionMode::Unilateral,
+            });
+        }
+
+        #[test]
+        fn dlv_claim() {
+            roundtrip(&Operation::DlvClaim {
+                vault_id: vec![0x01; 32],
+                claim_proof: vec![0x02; 64],
+                claimant_public_key: vec![0x03; 64],
+                signature: vec![0x04; 48],
+                mode: TransactionMode::Bilateral,
+            });
+        }
+
+        #[test]
+        fn dlv_invalidate() {
+            roundtrip(&Operation::DlvInvalidate {
+                vault_id: vec![0x01; 32],
+                reason: "timeout expired".into(),
+                creator_public_key: vec![0x02; 64],
+                signature: vec![0x03; 48],
+                mode: TransactionMode::Unilateral,
+            });
+        }
+
+        #[test]
+        fn all_verification_types() {
+            let types = vec![
+                VerificationType::Standard,
+                VerificationType::Enhanced,
+                VerificationType::Bilateral,
+                VerificationType::Directory,
+                VerificationType::StandardBilateral,
+                VerificationType::PreCommitted,
+                VerificationType::UnilateralIdentityAnchor,
+                VerificationType::Custom(vec![0xCA, 0xFE]),
+            ];
+            for vt in types {
+                roundtrip(&Operation::Transfer {
+                    to_device_id: vec![0x01; 32],
+                    amount: test_balance(1),
+                    token_id: b"ERA".to_vec(),
+                    mode: TransactionMode::Bilateral,
+                    nonce: vec![],
+                    verification: vt,
+                    pre_commit: None,
+                    recipient: vec![],
+                    to: vec![],
+                    message: String::new(),
+                    signature: vec![],
+                });
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Ops trait tests
+    // ------------------------------------------------------------------ //
+    mod ops_trait {
+        use super::*;
+
+        #[test]
+        fn validate_transfer_zero_amount() {
+            let op = Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(0),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![],
+                to: vec![],
+                message: String::new(),
+                signature: vec![],
+            };
+            assert_eq!(Ops::validate(&op).unwrap(), false);
+        }
+
+        #[test]
+        fn validate_transfer_positive_amount() {
+            let op = Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(100),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![],
+                to: vec![],
+                message: String::new(),
+                signature: vec![],
+            };
+            assert_eq!(Ops::validate(&op).unwrap(), true);
+        }
+
+        #[test]
+        fn validate_genesis_is_true() {
+            assert_eq!(Ops::validate(&Operation::Genesis).unwrap(), true);
+        }
+
+        #[test]
+        fn validate_noop_is_true() {
+            assert_eq!(Ops::validate(&Operation::Noop).unwrap(), true);
+        }
+
+        #[test]
+        fn get_id_returns_correct_strings() {
+            let cases: Vec<(Operation, &str)> = vec![
+                (Operation::Genesis, "genesis"),
+                (Operation::Noop, "noop"),
+                (
+                    Operation::Create {
+                        message: String::new(),
+                        identity_data: vec![],
+                        public_key: vec![],
+                        metadata: vec![],
+                        commitment: vec![],
+                        proof: vec![],
+                        mode: TransactionMode::Bilateral,
+                    },
+                    "create",
+                ),
+                (
+                    Operation::Update {
+                        message: String::new(),
+                        identity_id: vec![],
+                        updated_data: vec![],
+                        proof: vec![],
+                        forward_link: None,
+                    },
+                    "update",
+                ),
+                (
+                    Operation::Delete {
+                        reason: String::new(),
+                        proof: vec![],
+                        mode: TransactionMode::Bilateral,
+                        id: vec![],
+                    },
+                    "delete",
+                ),
+                (
+                    Operation::Recovery {
+                        message: String::new(),
+                        state_number: 0,
+                        state_hash: vec![],
+                        state_entropy: vec![],
+                        invalidation_data: vec![],
+                        new_state_data: vec![],
+                        new_state_number: 0,
+                        new_state_hash: vec![],
+                        new_state_entropy: vec![],
+                        compromise_proof: vec![],
+                        authority_sigs: vec![],
+                    },
+                    "recovery",
+                ),
+                (
+                    Operation::DlvCreate {
+                        vault_id: vec![],
+                        creator_public_key: vec![],
+                        parameters_hash: vec![],
+                        fulfillment_condition: vec![],
+                        intended_recipient: None,
+                        token_id: None,
+                        locked_amount: None,
+                        signature: vec![],
+                        mode: TransactionMode::Unilateral,
+                    },
+                    "dlv_create",
+                ),
+            ];
+            for (op, expected) in cases {
+                assert_eq!(Ops::get_id(&op), expected);
+            }
+        }
+
+        #[test]
+        fn execute_returns_bytes() {
+            let op = Operation::Genesis;
+            let result = Ops::execute(&op).unwrap();
+            assert!(!result.is_empty());
+            assert_eq!(result, op.to_bytes());
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  get_operation_type tests
+    // ------------------------------------------------------------------ //
+    mod operation_type {
+        use super::*;
+
+        #[test]
+        fn returns_correct_type_strings() {
+            assert_eq!(Operation::Genesis.get_operation_type(), "genesis");
+            assert_eq!(Operation::Noop.get_operation_type(), "noop");
+
+            let transfer = Operation::Transfer {
+                to_device_id: vec![],
+                amount: test_balance(1),
+                token_id: vec![],
+                mode: TransactionMode::Bilateral,
+                nonce: vec![],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![],
+                to: vec![],
+                message: String::new(),
+                signature: vec![],
+            };
+            assert_eq!(transfer.get_operation_type(), "transfer");
+
+            let mint = Operation::Mint {
+                amount: test_balance(1),
+                token_id: vec![],
+                authorized_by: vec![],
+                proof_of_authorization: vec![],
+                message: String::new(),
+            };
+            assert_eq!(mint.get_operation_type(), "mint");
+
+            let burn = Operation::Burn {
+                amount: test_balance(1),
+                token_id: vec![],
+                proof_of_ownership: vec![],
+                message: String::new(),
+            };
+            assert_eq!(burn.get_operation_type(), "burn");
+
+            assert_eq!(
+                Operation::LockToken {
+                    token_id: vec![],
+                    amount: 0,
+                    purpose: vec![],
+                    mode: TransactionMode::Bilateral,
+                    signature: vec![],
+                }
+                .get_operation_type(),
+                "lock_token"
+            );
+
+            assert_eq!(
+                Operation::UnlockToken {
+                    token_id: vec![],
+                    amount: 0,
+                    purpose: vec![],
+                    mode: TransactionMode::Bilateral,
+                    signature: vec![],
+                }
+                .get_operation_type(),
+                "unlock_token"
+            );
+
+            assert_eq!(
+                Operation::DlvUnlock {
+                    vault_id: vec![],
+                    fulfillment_proof: vec![],
+                    requester_public_key: vec![],
+                    signature: vec![],
+                    mode: TransactionMode::Bilateral,
+                }
+                .get_operation_type(),
+                "dlv_unlock"
+            );
+
+            assert_eq!(
+                Operation::DlvClaim {
+                    vault_id: vec![],
+                    claim_proof: vec![],
+                    claimant_public_key: vec![],
+                    signature: vec![],
+                    mode: TransactionMode::Bilateral,
+                }
+                .get_operation_type(),
+                "dlv_claim"
+            );
+
+            assert_eq!(
+                Operation::DlvInvalidate {
+                    vault_id: vec![],
+                    reason: String::new(),
+                    creator_public_key: vec![],
+                    signature: vec![],
+                    mode: TransactionMode::Bilateral,
+                }
+                .get_operation_type(),
+                "dlv_invalidate"
+            );
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  with_cleared_signature tests
+    // ------------------------------------------------------------------ //
+    mod cleared_signature {
+        use super::*;
+
+        #[test]
+        fn clears_transfer_signature() {
+            let op = Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(100),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![0xFF; 16],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![],
+                to: vec![],
+                message: String::new(),
+                signature: vec![0xAA; 64],
+            };
+            let cleared = op.with_cleared_signature();
+            assert_eq!(cleared.get_signature(), None);
+        }
+
+        #[test]
+        fn clears_create_token_signature() {
+            let op = Operation::CreateToken {
+                token_id: b"T".to_vec(),
+                initial_supply: test_balance(0),
+                name: "T".into(),
+                symbol: "T".into(),
+                decimals: 0,
+                metadata_uri: None,
+                policy_anchor: None,
+                signature: vec![0xBB; 48],
+            };
+            let cleared = op.with_cleared_signature();
+            assert_eq!(cleared.get_signature(), None);
+        }
+
+        #[test]
+        fn clears_dlv_create_signature() {
+            let op = Operation::DlvCreate {
+                vault_id: vec![0x01; 32],
+                creator_public_key: vec![0x02; 64],
+                parameters_hash: vec![],
+                fulfillment_condition: vec![],
+                intended_recipient: None,
+                token_id: None,
+                locked_amount: None,
+                signature: vec![0xCC; 48],
+                mode: TransactionMode::Unilateral,
+            };
+            let cleared = op.with_cleared_signature();
+            assert_eq!(cleared.get_signature(), None);
+        }
+
+        #[test]
+        fn genesis_unchanged() {
+            let op = Operation::Genesis;
+            let cleared = op.with_cleared_signature();
+            assert_eq!(op, cleared);
+        }
+
+        #[test]
+        fn generic_signature_cleared() {
+            let op = Operation::Generic {
+                operation_type: b"test".to_vec(),
+                data: vec![1, 2, 3],
+                message: "msg".into(),
+                signature: vec![0xDD; 32],
+            };
+            let cleared = op.with_cleared_signature();
+            match &cleared {
+                Operation::Generic { signature, .. } => assert!(signature.is_empty()),
+                _ => panic!("wrong variant"),
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  from_bytes error cases
+    // ------------------------------------------------------------------ //
+    mod decode_errors {
+        use super::*;
+
+        #[test]
+        fn empty_input() {
+            assert!(Operation::from_bytes(&[]).is_err());
+        }
+
+        #[test]
+        fn invalid_tag_byte() {
+            assert!(Operation::from_bytes(&[254]).is_err());
+        }
+
+        #[test]
+        fn truncated_create() {
+            let bytes = Operation::Create {
+                message: "hello".into(),
+                identity_data: vec![1, 2, 3],
+                public_key: vec![4, 5],
+                metadata: vec![],
+                commitment: vec![],
+                proof: vec![],
+                mode: TransactionMode::Bilateral,
+            }
+            .to_bytes();
+            let truncated = &bytes[..bytes.len() / 2];
+            assert!(Operation::from_bytes(truncated).is_err());
+        }
+
+        #[test]
+        fn truncated_single_byte_tag() {
+            assert!(Operation::from_bytes(&[3]).is_err());
+        }
+
+        #[test]
+        fn bad_mode_byte() {
+            let mut bytes = Operation::Invalidate {
+                reason: "test".into(),
+                proof: vec![],
+                mode: TransactionMode::Bilateral,
+            }
+            .to_bytes();
+            *bytes.last_mut().unwrap() = 99;
+            assert!(Operation::from_bytes(&bytes).is_err());
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  TokenOps trait tests
+    // ------------------------------------------------------------------ //
+    mod token_ops {
+        use super::*;
+
+        #[test]
+        fn is_valid_transfer_positive() {
+            let op = Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(100),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![],
+                to: vec![],
+                message: String::new(),
+                signature: vec![],
+            };
+            assert!(TokenOps::is_valid(&op));
+        }
+
+        #[test]
+        fn is_valid_transfer_zero() {
+            let op = Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(0),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![],
+                to: vec![],
+                message: String::new(),
+                signature: vec![],
+            };
+            assert!(!TokenOps::is_valid(&op));
+        }
+
+        #[test]
+        fn is_valid_genesis_returns_false() {
+            assert!(!TokenOps::is_valid(&Operation::Genesis));
+        }
+
+        #[test]
+        fn is_valid_noop_returns_false() {
+            assert!(!TokenOps::is_valid(&Operation::Noop));
+        }
+
+        #[test]
+        fn is_valid_mint_positive() {
+            let op = Operation::Mint {
+                amount: test_balance(50),
+                token_id: b"ERA".to_vec(),
+                authorized_by: vec![],
+                proof_of_authorization: vec![],
+                message: String::new(),
+            };
+            assert!(TokenOps::is_valid(&op));
+        }
+
+        #[test]
+        fn is_valid_lock_positive() {
+            let op = Operation::Lock {
+                token_id: b"ERA".to_vec(),
+                amount: test_balance(10),
+                purpose: vec![],
+                owner: vec![],
+                message: String::new(),
+                signature: vec![],
+            };
+            assert!(TokenOps::is_valid(&op));
+        }
+
+        #[test]
+        fn has_expired_returns_false() {
+            assert!(!TokenOps::has_expired(&Operation::Genesis));
+            let transfer = Operation::Transfer {
+                to_device_id: vec![],
+                amount: test_balance(1),
+                token_id: vec![],
+                mode: TransactionMode::Bilateral,
+                nonce: vec![],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![],
+                to: vec![],
+                message: String::new(),
+                signature: vec![],
+            };
+            assert!(!TokenOps::has_expired(&transfer));
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  GenericOps trait tests
+    // ------------------------------------------------------------------ //
+    mod generic_ops {
+        use super::*;
+
+        #[test]
+        fn get_data_returns_data_for_generic() {
+            let op = Operation::Generic {
+                operation_type: b"test".to_vec(),
+                data: vec![10, 20, 30],
+                message: String::new(),
+                signature: vec![],
+            };
+            assert_eq!(GenericOps::get_data(&op), &[10, 20, 30]);
+        }
+
+        #[test]
+        fn get_data_returns_empty_for_non_generic() {
+            assert!(GenericOps::get_data(&Operation::Genesis).is_empty());
+            assert!(GenericOps::get_data(&Operation::Noop).is_empty());
+        }
+
+        #[test]
+        fn set_data_works_for_generic() {
+            let mut op = Operation::Generic {
+                operation_type: b"test".to_vec(),
+                data: vec![1],
+                message: String::new(),
+                signature: vec![],
+            };
+            GenericOps::set_data(&mut op, vec![99, 100]).unwrap();
+            assert_eq!(GenericOps::get_data(&op), &[99, 100]);
+        }
+
+        #[test]
+        fn set_data_errors_for_non_generic() {
+            let mut op = Operation::Genesis;
+            assert!(GenericOps::set_data(&mut op, vec![1]).is_err());
+        }
+
+        #[test]
+        fn merge_concatenates_data() {
+            let a = Operation::Generic {
+                operation_type: b"t".to_vec(),
+                data: vec![1, 2],
+                message: String::new(),
+                signature: vec![],
+            };
+            let b = Operation::Generic {
+                operation_type: b"t".to_vec(),
+                data: vec![3, 4],
+                message: String::new(),
+                signature: vec![],
+            };
+            let merged = GenericOps::merge(&a, &b).unwrap();
+            assert_eq!(merged, vec![1, 2, 3, 4]);
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Balance round-trip through Operation encoding
+    // ------------------------------------------------------------------ //
+    mod balance_encoding {
+        use super::*;
+
+        #[test]
+        fn balance_with_state_hash_roundtrips() {
+            let bal = Balance::from_parts(12345, 0, 99, Some([0xFE; 32]));
+            let op = Operation::Mint {
+                amount: bal.clone(),
+                token_id: b"T".to_vec(),
+                authorized_by: vec![],
+                proof_of_authorization: vec![],
+                message: String::new(),
+            };
+            let decoded = roundtrip(&op);
+            if let Operation::Mint { amount, .. } = decoded {
+                assert_eq!(amount.value(), bal.value());
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn balance_without_state_hash_roundtrips() {
+            let bal = Balance::from_parts(0, 0, 0, None);
+            let op = Operation::Burn {
+                amount: bal,
+                token_id: b"X".to_vec(),
+                proof_of_ownership: vec![],
+                message: String::new(),
+            };
+            roundtrip(&op);
+        }
+
+        #[test]
+        fn balance_with_locked_roundtrips() {
+            let bal = Balance::from_parts(1000, 200, 5, Some([0x01; 32]));
+            let op = Operation::Lock {
+                token_id: b"ERA".to_vec(),
+                amount: bal.clone(),
+                purpose: b"test".to_vec(),
+                owner: vec![0x01; 32],
+                message: "lock test".into(),
+                signature: vec![],
+            };
+            let decoded = roundtrip(&op);
+            if let Operation::Lock { amount, .. } = decoded {
+                assert_eq!(amount.value(), 1000);
+                assert_eq!(amount.locked(), 200);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Determinism / stability
+    // ------------------------------------------------------------------ //
+    mod determinism {
+        use super::*;
+
+        #[test]
+        fn encoding_is_deterministic() {
+            let op = Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(42),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Bilateral,
+                nonce: vec![0xAA; 16],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![0x02; 32],
+                to: vec![0x03; 32],
+                message: "test".into(),
+                signature: vec![0xBB; 64],
+            };
+            let b1 = op.to_bytes();
+            let b2 = op.to_bytes();
+            assert_eq!(b1, b2);
+        }
+
+        #[test]
+        fn precommit_map_order_independent() {
+            let make_op = |insert_order: &[(&str, Vec<u8>)]| {
+                let mut fixed = HashMap::new();
+                for (k, v) in insert_order {
+                    fixed.insert(k.to_string(), v.clone());
+                }
+                Operation::Transfer {
+                    to_device_id: vec![],
+                    amount: test_balance(1),
+                    token_id: vec![],
+                    mode: TransactionMode::Bilateral,
+                    nonce: vec![],
+                    verification: VerificationType::Standard,
+                    pre_commit: Some(PreCommitmentOp {
+                        fixed_parameters: fixed,
+                        variable_parameters: vec![],
+                        security_params: SecurityParameters::default(),
+                    }),
+                    recipient: vec![],
+                    to: vec![],
+                    message: String::new(),
+                    signature: vec![],
+                }
+            };
+            let a = make_op(&[("alpha", vec![1]), ("beta", vec![2])]);
+            let b = make_op(&[("beta", vec![2]), ("alpha", vec![1])]);
+            assert_eq!(a.to_bytes(), b.to_bytes());
+        }
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -2520,7 +2520,7 @@ mod tests {
                 message: String::new(),
                 signature: vec![],
             };
-            assert_eq!(Ops::validate(&op).unwrap(), false);
+            assert!(!Ops::validate(&op).unwrap());
         }
 
         #[test]
@@ -2538,17 +2538,17 @@ mod tests {
                 message: String::new(),
                 signature: vec![],
             };
-            assert_eq!(Ops::validate(&op).unwrap(), true);
+            assert!(Ops::validate(&op).unwrap());
         }
 
         #[test]
         fn validate_genesis_is_true() {
-            assert_eq!(Ops::validate(&Operation::Genesis).unwrap(), true);
+            assert!(Ops::validate(&Operation::Genesis).unwrap());
         }
 
         #[test]
         fn validate_noop_is_true() {
-            assert_eq!(Ops::validate(&Operation::Noop).unwrap(), true);
+            assert!(Ops::validate(&Operation::Noop).unwrap());
         }
 
         #[test]

--- a/dsm_client/deterministic_state_machine/dsm/src/types/policy_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/policy_types.rs
@@ -704,4 +704,196 @@ mod tests {
 
         assert_eq!(blake3::hash(&b1).as_bytes(), blake3::hash(&b2).as_bytes());
     }
+
+    #[test]
+    fn anchor_from_bytes_as_bytes_roundtrip() {
+        let raw = [0xABu8; 32];
+        let anchor = PolicyAnchor::from_bytes(raw);
+        assert_eq!(*anchor.as_bytes(), raw);
+    }
+
+    #[test]
+    fn anchor_base32_roundtrip() {
+        let raw = [0x42u8; 32];
+        let anchor = PolicyAnchor::from_bytes(raw);
+        let encoded = anchor.to_base32();
+        let decoded = PolicyAnchor::from_base32(&encoded).unwrap();
+        assert_eq!(anchor.0, decoded.0);
+    }
+
+    #[test]
+    fn anchor_from_base32_invalid_string() {
+        let result = PolicyAnchor::from_base32("!!invalid!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn anchor_from_base32_wrong_length() {
+        let short = base32::encode(base32::Alphabet::Crockford, &[1, 2, 3]);
+        let result = PolicyAnchor::from_base32(&short);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn anchor_path_component_roundtrip_no_special_bytes() {
+        let raw = [0x42u8; 32];
+        let anchor = PolicyAnchor::from_bytes(raw);
+        let encoded = anchor.to_path_component_bytes();
+        let decoded = PolicyAnchor::from_path_component_bytes(&encoded).unwrap();
+        assert_eq!(anchor.0, decoded.0);
+        assert_eq!(encoded.len(), 32, "No escaping needed for 0x42");
+    }
+
+    #[test]
+    fn anchor_path_component_roundtrip_with_special_bytes() {
+        let mut raw = [0u8; 32];
+        raw[0] = 0x00; // NUL — forbidden
+        raw[1] = 0x2F; // '/' — forbidden
+        raw[2] = 0xFF; // ESC sentinel
+        let anchor = PolicyAnchor::from_bytes(raw);
+        let encoded = anchor.to_path_component_bytes();
+        assert!(encoded.len() > 32, "Special bytes should be escaped");
+        let decoded = PolicyAnchor::from_path_component_bytes(&encoded).unwrap();
+        assert_eq!(anchor.0, decoded.0);
+    }
+
+    #[test]
+    fn from_path_component_bytes_truncated_escape() {
+        let bad = vec![0xFF]; // ESC with no following byte
+        assert!(PolicyAnchor::from_path_component_bytes(&bad).is_none());
+    }
+
+    #[test]
+    fn from_path_component_bytes_too_long() {
+        let too_long = vec![0x42u8; 33];
+        assert!(PolicyAnchor::from_path_component_bytes(&too_long).is_none());
+    }
+
+    #[test]
+    fn policy_file_builder_methods() {
+        let mut pf = PolicyFile::new("test", "v1", "alice");
+        pf.with_description("A test policy");
+        pf.add_metadata("key1", "val1");
+        pf.add_condition(PolicyCondition::LogicalTimeConstraint {
+            min_tick: 0,
+            max_tick: 100,
+        });
+        pf.add_role(PolicyRole {
+            id: "r1".into(),
+            name: "Role1".into(),
+            permissions: vec!["read".into()],
+        });
+
+        assert_eq!(pf.description.as_deref(), Some("A test policy"));
+        assert_eq!(pf.metadata.get("key1").unwrap(), "val1");
+        assert_eq!(pf.conditions.len(), 1);
+        assert_eq!(pf.roles.len(), 1);
+    }
+
+    #[test]
+    fn policy_file_to_bytes_from_bytes_roundtrip() {
+        let mut pf = PolicyFile::new("roundtrip", "v2", "bob");
+        pf.with_description("desc");
+        pf.add_metadata("k", "v");
+        pf.add_condition(PolicyCondition::IdentityConstraint {
+            allowed_identities: vec!["id1".into()],
+            allow_derived: true,
+        });
+        pf.add_role(PolicyRole {
+            id: "admin".into(),
+            name: "Admin".into(),
+            permissions: vec!["write".into(), "read".into()],
+        });
+
+        let bytes = pf.to_bytes().unwrap();
+        let restored = PolicyFile::from_bytes(&bytes).unwrap();
+        assert_eq!(restored.name, "roundtrip");
+        assert_eq!(restored.version, "v2");
+        assert_eq!(restored.author, "bob");
+        assert_eq!(restored.description.as_deref(), Some("desc"));
+        assert_eq!(restored.conditions.len(), 1);
+        assert_eq!(restored.roles.len(), 1);
+        assert_eq!(restored.roles[0].id, "admin");
+    }
+
+    #[test]
+    fn policy_file_canonical_bytes_from_canonical_bytes_roundtrip() {
+        let mut pf = PolicyFile::new("name", "v1", "carol");
+        pf.add_condition(PolicyCondition::EmissionsSchedule {
+            total_supply: 1_000_000,
+            shard_depth: 4,
+            schedule_steps: 10,
+            initial_step_emissions: 500,
+            initial_step_amount: 100,
+        });
+        let canonical = pf.canonical_bytes().unwrap();
+        let restored = PolicyFile::from_canonical_bytes(&canonical).unwrap();
+        assert_eq!(restored.author, "carol");
+        assert_eq!(restored.conditions.len(), 1);
+        assert!(restored.name.is_empty(), "name excluded from canonical");
+    }
+
+    #[test]
+    fn token_policy_new_and_mark_verified() {
+        let pf = PolicyFile::new("tp", "v1", "auth");
+        let mut tp = TokenPolicy::new(pf).unwrap();
+        assert!(!tp.verified);
+        tp.mark_verified();
+        assert!(tp.verified);
+    }
+
+    #[test]
+    fn token_policy_conditions_always_satisfied() {
+        let pf = PolicyFile::new("tp", "v1", "auth");
+        let tp = TokenPolicy::new(pf).unwrap();
+        let cond = PolicyCondition::LogicalTimeConstraint {
+            min_tick: 0,
+            max_tick: 100,
+        };
+        assert!(tp.is_condition_satisfied(&cond));
+        assert!(tp.are_time_conditions_satisfied());
+    }
+
+    #[test]
+    fn policy_verification_success_and_failure() {
+        let pv = PolicyVerification::new(VerificationType::Standard);
+        assert!(!pv.result);
+        assert!(pv.message.is_none());
+
+        let success = PolicyVerification::new(VerificationType::Standard)
+            .with_parameter("pk", vec![1, 2, 3])
+            .success(Some("ok".into()), Some(vec![9]));
+        assert!(success.result);
+        assert_eq!(success.message.as_deref(), Some("ok"));
+        assert_eq!(success.proof, Some(vec![9]));
+        assert_eq!(success.parameters.get("pk").unwrap(), &vec![1, 2, 3]);
+
+        let fail = PolicyVerification::new(VerificationType::Standard).failure("bad".into());
+        assert!(!fail.result);
+        assert_eq!(fail.message.as_deref(), Some("bad"));
+    }
+
+    #[test]
+    fn vault_condition_proto_roundtrip() {
+        let conditions = vec![
+            VaultCondition::Hash(vec![1, 2, 3]),
+            VaultCondition::MinimumBalance(1000),
+            VaultCondition::VaultType("standard".into()),
+            VaultCondition::SmartPolicy(vec![0xDE, 0xAD]),
+        ];
+        for cond in &conditions {
+            let proto: crate::types::proto::VaultConditionProto = cond.into();
+            let restored = VaultCondition::try_from(&proto).unwrap();
+            assert_eq!(&restored, cond);
+        }
+    }
+
+    #[test]
+    fn different_authors_produce_different_anchors() {
+        let p1 = PolicyFile::new("n", "v", "alice");
+        let p2 = PolicyFile::new("n", "v", "bob");
+        let a1 = p1.generate_anchor().unwrap();
+        let a2 = p2.generate_anchor().unwrap();
+        assert_ne!(a1.0, a2.0);
+    }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/receipt_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/receipt_types.rs
@@ -680,6 +680,250 @@ mod tests {
         // Should exceed 128 KiB cap
         assert!(receipt.validate_size_cap().is_err());
     }
+
+    // --- Additional tests ---
+
+    #[test]
+    fn receipt_is_fully_signed_both_present() {
+        let mut receipt = StitchedReceiptV2::new(
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+            [5; 32],
+            [6; 32],
+            vec![],
+            vec![],
+            vec![],
+        );
+        assert!(!receipt.is_fully_signed());
+
+        receipt.add_sig_a(vec![0xAA; 64]);
+        assert!(!receipt.is_fully_signed());
+
+        receipt.add_sig_b(vec![0xBB; 64]);
+        assert!(receipt.is_fully_signed());
+    }
+
+    #[test]
+    fn receipt_not_fully_signed_empty_sigs() {
+        let receipt = StitchedReceiptV2::new(
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+            [5; 32],
+            [6; 32],
+            vec![],
+            vec![],
+            vec![],
+        );
+        assert!(!receipt.is_fully_signed());
+    }
+
+    #[test]
+    fn receipt_id_accessors() {
+        let receipt = StitchedReceiptV2::new(
+            [0; 32],
+            [0x11; 32],
+            [0x22; 32],
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            vec![],
+            vec![],
+            vec![],
+        );
+        assert_eq!(receipt.id_a(), &[0x11; 32]);
+        assert_eq!(receipt.id_b(), &[0x22; 32]);
+    }
+
+    #[test]
+    fn receipt_t_extracts_sequence_from_parent_tip() {
+        let mut parent_tip = [0u8; 32];
+        parent_tip[24..32].copy_from_slice(&42u64.to_le_bytes());
+        let receipt = StitchedReceiptV2::new(
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            parent_tip,
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            vec![],
+            vec![],
+            vec![],
+        );
+        assert_eq!(receipt.t(), 42);
+    }
+
+    #[test]
+    fn receipt_serialized_size_grows_with_sigs() {
+        let mut receipt = StitchedReceiptV2::new(
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            [0; 32],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let base_size = receipt.serialized_size();
+
+        receipt.add_sig_a(vec![0xAA; 100]);
+        receipt.add_sig_b(vec![0xBB; 200]);
+        assert_eq!(receipt.serialized_size(), base_size + 300);
+    }
+
+    #[test]
+    fn receipt_canonical_commit_alias() {
+        let receipt = StitchedReceiptV2::new(
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+            [5; 32],
+            [6; 32],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let a = receipt.compute_commitment().unwrap();
+        let b = receipt.canonical_commit().unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn receipt_different_fields_produce_different_commitments() {
+        let r1 = StitchedReceiptV2::new(
+            [0; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+            [5; 32],
+            [6; 32],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let r2 = StitchedReceiptV2::new(
+            [0xFF; 32],
+            [1; 32],
+            [2; 32],
+            [3; 32],
+            [4; 32],
+            [5; 32],
+            [6; 32],
+            vec![],
+            vec![],
+            vec![],
+        );
+        assert_ne!(
+            r1.compute_commitment().unwrap(),
+            r2.compute_commitment().unwrap(),
+        );
+    }
+
+    // --- DeviceTreeAcceptanceCommitment ---
+
+    #[test]
+    fn device_tree_acceptance_from_root() {
+        let root = [0xAB; 32];
+        let c = DeviceTreeAcceptanceCommitment::from_root(root);
+        assert_eq!(c.root(), root);
+    }
+
+    #[test]
+    fn device_tree_acceptance_from_array() {
+        let root = [0xCD; 32];
+        let c: DeviceTreeAcceptanceCommitment = root.into();
+        assert_eq!(c.root(), root);
+    }
+
+    #[test]
+    fn device_tree_acceptance_copy_eq() {
+        let a = DeviceTreeAcceptanceCommitment::from_root([0; 32]);
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    // --- ReceiptAcceptance ---
+
+    #[test]
+    fn receipt_acceptance_accept() {
+        let commitment = [0xEE; 32];
+        let acc = ReceiptAcceptance::accept(commitment);
+        assert!(acc.valid);
+        assert!(acc.reason.is_none());
+        assert_eq!(acc.commitment, Some(commitment));
+    }
+
+    #[test]
+    fn receipt_acceptance_reject() {
+        let acc = ReceiptAcceptance::reject("bad signature");
+        assert!(!acc.valid);
+        assert_eq!(acc.reason.as_deref(), Some("bad signature"));
+        assert!(acc.commitment.is_none());
+    }
+
+    // --- ReceiptVerificationContext ---
+
+    #[test]
+    fn verification_context_mark_and_check_consumed() {
+        let mut ctx = ReceiptVerificationContext::new([0; 32], [1; 32], vec![2; 64], vec![3; 64]);
+        let tip = [0xAA; 32];
+        assert!(!ctx.is_consumed(&tip));
+        ctx.mark_consumed(tip);
+        assert!(ctx.is_consumed(&tip));
+    }
+
+    // --- ParentConsumptionTracker ---
+
+    #[test]
+    fn tracker_fresh_parent_not_consumed() {
+        let tracker = ParentConsumptionTracker::new();
+        assert!(!tracker.is_consumed(&[0; 32]));
+        assert!(tracker.get_child(&[0; 32]).is_none());
+    }
+
+    #[test]
+    fn tracker_with_capacity_behaves_like_new() {
+        let tracker = ParentConsumptionTracker::with_capacity(100);
+        assert!(!tracker.is_consumed(&[0xFF; 32]));
+    }
+
+    #[test]
+    fn tracker_multiple_distinct_parents() {
+        let mut tracker = ParentConsumptionTracker::new();
+        let p1 = [1u8; 32];
+        let p2 = [2u8; 32];
+        let c1 = [0xA0; 32];
+        let c2 = [0xB0; 32];
+
+        tracker.try_consume(p1, c1).unwrap();
+        tracker.try_consume(p2, c2).unwrap();
+
+        assert_eq!(tracker.get_child(&p1), Some(&c1));
+        assert_eq!(tracker.get_child(&p2), Some(&c2));
+    }
+
+    #[test]
+    fn tracker_replay_same_child_is_error() {
+        let mut tracker = ParentConsumptionTracker::new();
+        let parent = [0x10; 32];
+        let child = [0x20; 32];
+        tracker.try_consume(parent, child).unwrap();
+        let err = tracker.try_consume(parent, child).unwrap_err();
+        assert!(format!("{err}").contains("replay"));
+    }
 }
 
 #[cfg(test)]

--- a/dsm_client/deterministic_state_machine/dsm/src/types/serialization.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/serialization.rs
@@ -33,3 +33,114 @@ pub fn put_bytes(out: &mut Vec<u8>, b: &[u8]) {
 pub fn put_str(out: &mut Vec<u8>, s: &str) {
     put_bytes(out, s.as_bytes());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn put_u8_appends_single_byte() {
+        let mut buf = Vec::new();
+        put_u8(&mut buf, 0x42);
+        assert_eq!(buf, vec![0x42]);
+    }
+
+    #[test]
+    fn put_u8_zero_and_max() {
+        let mut buf = Vec::new();
+        put_u8(&mut buf, 0);
+        put_u8(&mut buf, 255);
+        assert_eq!(buf, vec![0, 255]);
+    }
+
+    #[test]
+    fn put_u32_little_endian() {
+        let mut buf = Vec::new();
+        put_u32(&mut buf, 0x0102_0304);
+        assert_eq!(buf, vec![0x04, 0x03, 0x02, 0x01]);
+    }
+
+    #[test]
+    fn put_u32_zero() {
+        let mut buf = Vec::new();
+        put_u32(&mut buf, 0);
+        assert_eq!(buf, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn put_u32_max() {
+        let mut buf = Vec::new();
+        put_u32(&mut buf, u32::MAX);
+        assert_eq!(buf, vec![0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn put_u64_little_endian() {
+        let mut buf = Vec::new();
+        put_u64(&mut buf, 0x0102_0304_0506_0708);
+        assert_eq!(buf, vec![0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]);
+    }
+
+    #[test]
+    fn put_u64_zero() {
+        let mut buf = Vec::new();
+        put_u64(&mut buf, 0);
+        assert_eq!(buf, vec![0; 8]);
+    }
+
+    #[test]
+    fn put_u64_max() {
+        let mut buf = Vec::new();
+        put_u64(&mut buf, u64::MAX);
+        assert_eq!(buf, vec![0xFF; 8]);
+    }
+
+    #[test]
+    fn put_bytes_prefixes_length_then_data() {
+        let mut buf = Vec::new();
+        put_bytes(&mut buf, &[0xAA, 0xBB, 0xCC]);
+        // length = 3 as u32 LE, then the bytes
+        assert_eq!(buf, vec![3, 0, 0, 0, 0xAA, 0xBB, 0xCC]);
+    }
+
+    #[test]
+    fn put_bytes_empty_slice() {
+        let mut buf = Vec::new();
+        put_bytes(&mut buf, &[]);
+        assert_eq!(buf, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn put_str_encodes_as_utf8_with_length() {
+        let mut buf = Vec::new();
+        put_str(&mut buf, "hi");
+        // length = 2 as u32 LE, then b"hi"
+        assert_eq!(buf, vec![2, 0, 0, 0, b'h', b'i']);
+    }
+
+    #[test]
+    fn put_str_empty() {
+        let mut buf = Vec::new();
+        put_str(&mut buf, "");
+        assert_eq!(buf, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn put_str_multibyte_utf8() {
+        let mut buf = Vec::new();
+        put_str(&mut buf, "\u{00E9}"); // é = 2 bytes in UTF-8
+        let bytes = "\u{00E9}".as_bytes();
+        assert_eq!(buf.len(), 4 + bytes.len());
+        assert_eq!(&buf[..4], &(bytes.len() as u32).to_le_bytes());
+        assert_eq!(&buf[4..], bytes);
+    }
+
+    #[test]
+    fn sequential_writes_concatenate() {
+        let mut buf = Vec::new();
+        put_u8(&mut buf, 1);
+        put_u32(&mut buf, 2);
+        put_u64(&mut buf, 3);
+        assert_eq!(buf.len(), 1 + 4 + 8);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/state_builder.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/state_builder.rs
@@ -327,3 +327,222 @@ impl StateBuilder {
         Ok(state)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::operations::Operation;
+    use crate::types::state_types::StateFlag;
+
+    fn valid_builder() -> StateBuilder {
+        StateBuilder::new()
+            .with_entropy(vec![0xAA; 32])
+            .with_device_id([0x11; 32])
+            .with_public_key(vec![0x22; 64])
+    }
+
+    // --- Successful builds ---
+
+    #[test]
+    fn build_minimal_valid_state() {
+        let state = valid_builder().build().unwrap();
+        assert_eq!(state.device_info.device_id, [0x11; 32]);
+        assert_eq!(state.device_info.public_key, vec![0x22; 64]);
+        assert_ne!(state.hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn build_with_state_number() {
+        let state = valid_builder().with_state_number(42).build().unwrap();
+        assert_eq!(state.state_number, 42);
+    }
+
+    #[test]
+    fn build_with_id() {
+        let state = valid_builder().with_id("my-state".into()).build().unwrap();
+        assert_eq!(state.id, "my-state");
+    }
+
+    #[test]
+    fn build_with_explicit_hash() {
+        let hash = [0xFF; 32];
+        let state = valid_builder().with_hash(hash).build().unwrap();
+        assert_eq!(state.hash, hash);
+    }
+
+    #[test]
+    fn build_auto_computed_hash_is_deterministic() {
+        let h1 = valid_builder().with_state_number(1).build().unwrap().hash;
+        let h2 = valid_builder().with_state_number(1).build().unwrap().hash;
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn build_different_state_numbers_produce_different_hashes() {
+        let h1 = valid_builder().with_state_number(1).build().unwrap().hash;
+        let h2 = valid_builder().with_state_number(2).build().unwrap().hash;
+        assert_ne!(h1, h2);
+    }
+
+    // --- Validation failures ---
+
+    #[test]
+    fn build_fails_without_entropy() {
+        let result = StateBuilder::new()
+            .with_device_id([0x11; 32])
+            .with_public_key(vec![0x22; 64])
+            .build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_fails_without_public_key() {
+        let result = StateBuilder::new()
+            .with_entropy(vec![0xAA; 32])
+            .with_device_id([0x11; 32])
+            .build();
+        assert!(result.is_err());
+    }
+
+    // --- Optional fields ---
+
+    #[test]
+    fn build_with_prev_state_hash() {
+        let prev = [0xBB; 32];
+        let state = valid_builder().with_prev_state_hash(prev).build().unwrap();
+        assert_eq!(state.prev_state_hash, prev);
+    }
+
+    #[test]
+    fn build_with_prev_hash_alias() {
+        let prev = [0xCC; 32];
+        let state = valid_builder().with_prev_hash(prev).build().unwrap();
+        assert_eq!(state.prev_state_hash, prev);
+    }
+
+    #[test]
+    fn build_with_operation() {
+        let state = valid_builder()
+            .with_operation(Operation::Genesis)
+            .build()
+            .unwrap();
+        assert!(matches!(state.operation, Operation::Genesis));
+    }
+
+    #[test]
+    fn build_with_flags() {
+        let mut flags = HashSet::new();
+        flags.insert(StateFlag::Recovered);
+        let state = valid_builder().with_flags(flags.clone()).build().unwrap();
+        assert!(state.flags.contains(&StateFlag::Recovered));
+    }
+
+    #[test]
+    fn build_with_single_flag() {
+        let state = valid_builder()
+            .with_flag(StateFlag::Synced)
+            .build()
+            .unwrap();
+        assert!(state.flags.contains(&StateFlag::Synced));
+    }
+
+    #[test]
+    fn build_with_token_balance() {
+        let balance = Balance::from_state(500, [0; 32], 1);
+        let state = valid_builder()
+            .with_token_balance("ERA".into(), balance)
+            .build()
+            .unwrap();
+        assert!(state.token_balances.contains_key("ERA"));
+        assert_eq!(state.token_balances["ERA"].value(), 500);
+    }
+
+    #[test]
+    fn build_with_token_balances_map() {
+        let mut balances = HashMap::new();
+        balances.insert("ERA".into(), Balance::from_state(100, [0; 32], 1));
+        balances.insert("TEST".into(), Balance::from_state(200, [0; 32], 1));
+        let state = valid_builder()
+            .with_token_balances(balances)
+            .build()
+            .unwrap();
+        assert_eq!(state.token_balances.len(), 2);
+    }
+
+    #[test]
+    fn build_with_encapsulated_entropy() {
+        let state = valid_builder()
+            .with_encapsulated_entropy(vec![0xDD; 32])
+            .build()
+            .unwrap();
+        assert_eq!(state.encapsulated_entropy, Some(vec![0xDD; 32]));
+    }
+
+    #[test]
+    fn build_with_relationship_context() {
+        let ctx = RelationshipContext::new([0x11; 32], [0x22; 32], vec![0x33; 64]);
+        let state = valid_builder()
+            .with_relationship_context(ctx)
+            .build()
+            .unwrap();
+        assert!(state.relationship_context.is_some());
+    }
+
+    #[test]
+    fn build_relationship_context_auto() {
+        let state = valid_builder()
+            .build_relationship_context()
+            .build()
+            .unwrap();
+        let ctx = state.relationship_context.unwrap();
+        assert_eq!(ctx.entity_id, [0x11; 32]);
+        assert!(ctx.active);
+    }
+
+    #[test]
+    fn build_relationship_context_with_chain_tip() {
+        let state = valid_builder()
+            .build_relationship_context_with_chain_tip([0x33; 32], "tip-1".into())
+            .build()
+            .unwrap();
+        let ctx = state.relationship_context.unwrap();
+        assert_eq!(ctx.counterparty_id, [0x33; 32]);
+        assert_eq!(ctx.chain_tip_id, Some("tip-1".into()));
+    }
+
+    #[test]
+    fn build_with_parameter() {
+        let state = valid_builder()
+            .with_parameter("key", vec![1, 2, 3])
+            .build()
+            .unwrap();
+        assert_eq!(state.get_parameter("key"), Some(&vec![1u8, 2, 3]));
+    }
+
+    #[test]
+    fn build_with_device_info() {
+        let info = crate::types::state_types::DeviceInfo {
+            device_id: [0xAA; 32],
+            public_key: vec![0xBB; 64],
+            metadata: vec![],
+        };
+        let state = valid_builder()
+            .with_device_info(info)
+            .with_entropy(vec![1; 32])
+            .build()
+            .unwrap();
+        assert_eq!(state.device_info.device_id, [0xAA; 32]);
+        assert_eq!(state.device_info.public_key, vec![0xBB; 64]);
+    }
+
+    // --- Default ---
+
+    #[test]
+    fn default_builder_matches_new() {
+        let a = StateBuilder::default();
+        let b = StateBuilder::new();
+        assert_eq!(a.state_number, b.state_number);
+        assert_eq!(a.entropy, b.entropy);
+        assert_eq!(a.device_id, b.device_id);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/state_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/state_types.rs
@@ -975,6 +975,799 @@ mod tests {
 
         assert_eq!(base_hash, dbrw_hash);
     }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    fn test_device_info() -> DeviceInfo {
+        DeviceInfo::new([0x11; 32], vec![0x22; 64])
+    }
+
+    fn test_state(n: u64) -> State {
+        State::new(StateParams::new(
+            n,
+            vec![0xAA; 16],
+            Operation::Noop,
+            test_device_info(),
+        ))
+    }
+
+    // ── DeviceInfo ──────────────────────────────────────────────────
+
+    #[test]
+    fn device_info_new_sets_fields() {
+        let di = DeviceInfo::new([0xFF; 32], vec![1, 2, 3]);
+        assert_eq!(di.device_id, [0xFF; 32]);
+        assert_eq!(di.public_key, vec![1, 2, 3]);
+        assert!(di.metadata.is_empty());
+    }
+
+    #[test]
+    fn device_info_from_hashed_label_deterministic() {
+        let a = DeviceInfo::from_hashed_label("alice", vec![10]);
+        let b = DeviceInfo::from_hashed_label("alice", vec![10]);
+        assert_eq!(a.device_id, b.device_id);
+    }
+
+    #[test]
+    fn device_info_from_hashed_label_different_labels_differ() {
+        let a = DeviceInfo::from_hashed_label("alice", vec![10]);
+        let b = DeviceInfo::from_hashed_label("bob", vec![10]);
+        assert_ne!(a.device_id, b.device_id);
+    }
+
+    #[test]
+    fn device_info_validate_ok() {
+        let di = DeviceInfo::new([0x01; 32], vec![0x99; 32]);
+        assert!(di.validate().unwrap());
+    }
+
+    #[test]
+    fn device_info_validate_empty_key_fails() {
+        let di = DeviceInfo::new([0x01; 32], vec![]);
+        assert!(di.validate().is_err());
+    }
+
+    #[test]
+    fn device_info_to_bytes_deterministic() {
+        let di = DeviceInfo::new([0xAB; 32], vec![1, 2, 3, 4]);
+        let b1 = di.to_bytes();
+        let b2 = di.to_bytes();
+        assert_eq!(b1, b2);
+        assert!(!b1.is_empty());
+    }
+
+    #[test]
+    fn device_info_to_bytes_contains_device_id_prefix() {
+        let di = DeviceInfo::new([0xCC; 32], vec![0xDD; 8]);
+        let bytes = di.to_bytes();
+        assert_eq!(&bytes[..32], &[0xCC; 32]);
+    }
+
+    // ── SparseIndex ─────────────────────────────────────────────────
+
+    use super::SparseIndex;
+
+    #[test]
+    fn sparse_index_new_stores_indices() {
+        let si = SparseIndex::new(vec![0, 3, 7]);
+        assert_eq!(si.indices, vec![0, 3, 7]);
+    }
+
+    #[test]
+    fn sparse_index_default_is_empty() {
+        let si = SparseIndex::default();
+        assert!(si.indices.is_empty());
+    }
+
+    #[test]
+    fn sparse_index_value_deterministic() {
+        let si = SparseIndex::new(vec![1, 5, 10]);
+        let v1 = si.value();
+        let v2 = si.value();
+        assert_eq!(v1, v2);
+    }
+
+    #[test]
+    fn sparse_index_value_order_independent() {
+        let a = SparseIndex::new(vec![1, 5, 10]);
+        let b = SparseIndex::new(vec![10, 1, 5]);
+        assert_eq!(a.value(), b.value());
+    }
+
+    #[test]
+    fn sparse_index_with_indices_replaces() {
+        let si = SparseIndex::new(vec![1]).with_indices(vec![9, 8, 7]);
+        assert_eq!(si.indices, vec![9, 8, 7]);
+    }
+
+    #[test]
+    fn sparse_index_calculate_sparse_indices_zero() {
+        let indices = SparseIndex::calculate_sparse_indices(0).unwrap();
+        assert!(indices.is_empty());
+    }
+
+    #[test]
+    fn sparse_index_calculate_sparse_indices_one() {
+        let indices = SparseIndex::calculate_sparse_indices(1).unwrap();
+        assert!(indices.contains(&0), "must include genesis");
+    }
+
+    #[test]
+    fn sparse_index_calculate_includes_genesis_and_predecessor() {
+        let indices = SparseIndex::calculate_sparse_indices(10).unwrap();
+        assert!(indices.contains(&0), "must include genesis");
+        assert!(indices.contains(&9), "must include predecessor");
+    }
+
+    #[test]
+    fn sparse_index_calculate_sorted_and_deduped() {
+        let indices = SparseIndex::calculate_sparse_indices(16).unwrap();
+        for w in indices.windows(2) {
+            assert!(w[0] < w[1], "indices must be sorted and unique");
+        }
+    }
+
+    #[test]
+    fn sparse_index_calculate_logarithmic_count() {
+        let indices = SparseIndex::calculate_sparse_indices(64).unwrap();
+        assert!(
+            indices.len() <= 10,
+            "should be logarithmic: got {}",
+            indices.len()
+        );
+    }
+
+    // ── State construction & basic properties ───────────────────────
+
+    #[test]
+    fn state_new_sets_id_and_number() {
+        let s = test_state(42);
+        assert_eq!(s.state_number, 42);
+        assert_eq!(s.id, "state_42");
+    }
+
+    #[test]
+    fn state_new_genesis_properties() {
+        let s = State::new_genesis([0xBB; 32], test_device_info());
+        assert_eq!(s.state_number, 0);
+        assert_eq!(s.id, "genesis");
+        assert!(s.is_genesis());
+        assert_eq!(s.entropy, vec![0xBB; 32]);
+    }
+
+    #[test]
+    fn state_compute_hash_nonzero() {
+        let s = test_state(1);
+        let h = s.compute_hash().unwrap();
+        assert_ne!(h, [0u8; 32]);
+    }
+
+    #[test]
+    fn state_compute_hash_deterministic() {
+        let a = test_state(5);
+        let b = test_state(5);
+        assert_eq!(a.compute_hash().unwrap(), b.compute_hash().unwrap());
+    }
+
+    #[test]
+    fn state_hash_returns_computed_when_zero() {
+        let s = test_state(3);
+        assert_eq!(s.hash, [0u8; 32]);
+        let h = s.hash().unwrap();
+        assert_ne!(h, [0u8; 32]);
+    }
+
+    #[test]
+    fn state_hash_returns_cached_when_set() {
+        let mut s = test_state(3);
+        s.hash = [0xDD; 32];
+        assert_eq!(s.hash().unwrap(), [0xDD; 32]);
+    }
+
+    #[test]
+    fn state_to_bytes_deterministic() {
+        let s = test_state(7);
+        let b1 = s.to_bytes().unwrap();
+        let b2 = s.to_bytes().unwrap();
+        assert_eq!(b1, b2);
+    }
+
+    #[test]
+    fn state_to_bytes_nonempty() {
+        let s = test_state(0);
+        let bytes = s.to_bytes().unwrap();
+        assert!(!bytes.is_empty());
+    }
+
+    // ── State flags ─────────────────────────────────────────────────
+
+    use super::StateFlag;
+
+    #[test]
+    fn state_is_genesis_false_by_default() {
+        let s = test_state(1);
+        assert!(!s.is_genesis());
+    }
+
+    #[test]
+    fn state_add_flag_invalidated() {
+        let mut s = test_state(2);
+        assert!(!s.is_invalidated());
+        s.add_flag(StateFlag::Invalidated);
+        assert!(s.is_invalidated());
+    }
+
+    #[test]
+    fn state_add_flag_custom() {
+        let mut s = test_state(3);
+        s.add_flag(StateFlag::Custom("test_flag".into()));
+        assert!(s.flags.contains(&StateFlag::Custom("test_flag".into())));
+    }
+
+    #[test]
+    fn state_has_pending_commitment_flag() {
+        let mut s = test_state(4);
+        assert!(!s.has_pending_commitment());
+        s.add_flag(StateFlag::Compromised);
+        assert!(s.has_pending_commitment());
+    }
+
+    // ── State metadata & parameters ─────────────────────────────────
+
+    #[test]
+    fn state_add_metadata_and_get_parameter() {
+        let mut s = test_state(5);
+        s.add_metadata("my_key", vec![1, 2, 3]).unwrap();
+        assert_eq!(s.get_parameter("my_key"), Some(&vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn state_get_parameter_missing_returns_none() {
+        let s = test_state(5);
+        assert_eq!(s.get_parameter("nonexistent"), None);
+    }
+
+    // ── State relationship context ──────────────────────────────────
+
+    #[test]
+    fn state_with_relationship_context() {
+        let s = test_state(10).with_relationship_context([0xCC; 32], 5, vec![0xDD; 32]);
+        let ctx = s.relationship_context.as_ref().unwrap();
+        assert_eq!(ctx.counterparty_id, [0xCC; 32]);
+        assert_eq!(ctx.counterparty_state_number, 5);
+        assert!(ctx.active);
+    }
+
+    #[test]
+    fn state_in_relationship_with_uses_hashed_label() {
+        let counterparty_id =
+            *crate::crypto::blake3::domain_hash("DSM/device-id", b"bob").as_bytes();
+        let s = test_state(10).with_relationship_context(counterparty_id, 3, vec![0xFF; 32]);
+        assert!(s.in_relationship_with("bob"));
+        assert!(!s.in_relationship_with("alice"));
+    }
+
+    #[test]
+    fn state_in_relationship_with_no_context() {
+        let s = test_state(10);
+        assert!(!s.in_relationship_with("anyone"));
+    }
+
+    // ── State hashing variants ──────────────────────────────────────
+
+    #[test]
+    fn state_pre_finalization_hash_deterministic() {
+        let s = test_state(8);
+        let h1 = s.pre_finalization_hash().unwrap();
+        let h2 = s.pre_finalization_hash().unwrap();
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 32);
+    }
+
+    #[test]
+    fn state_finalized_verification_hash_deterministic() {
+        let s = test_state(8);
+        let h1 = s.finalized_verification_hash().unwrap();
+        let h2 = s.finalized_verification_hash().unwrap();
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 32);
+    }
+
+    #[test]
+    fn state_finalized_hash_changes_with_token_balance() {
+        let mut s1 = test_state(9);
+        let h_no_tokens = s1.finalized_verification_hash().unwrap();
+
+        s1.token_balances.insert(
+            "owner:token".to_string(),
+            crate::types::token_types::Balance::zero(),
+        );
+        let h_with_tokens = s1.finalized_verification_hash().unwrap();
+
+        assert_ne!(h_no_tokens, h_with_tokens);
+    }
+
+    // ── State forward commitment ────────────────────────────────────
+
+    use super::PreCommitment;
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn state_forward_commitment_roundtrip() {
+        let mut s = test_state(11);
+        assert!(s.get_forward_commitment().is_none());
+
+        let pc = PreCommitment::new(
+            "transfer".into(),
+            HashMap::new(),
+            HashSet::new(),
+            5,
+            [0xAA; 32],
+        );
+        s.set_forward_commitment(Some(pc));
+        assert!(s.get_forward_commitment().is_some());
+        assert_eq!(
+            s.get_forward_commitment().unwrap().operation_type,
+            "transfer"
+        );
+
+        s.set_forward_commitment(None);
+        assert!(s.get_forward_commitment().is_none());
+    }
+
+    // ── State transition_count ───────────────────────────────────────
+
+    #[test]
+    fn state_transition_count() {
+        assert_eq!(test_state(0).transition_count(), 0);
+        assert_eq!(test_state(99).transition_count(), 99);
+    }
+
+    // ── State entity_signature ───────────────────────────────────────
+
+    #[test]
+    fn state_entity_signature_roundtrip() {
+        let mut s = test_state(12);
+        assert!(s.entity_signature().is_none());
+        s.set_entity_signature(Some(vec![0xEE; 64]));
+        assert_eq!(s.entity_signature(), Some(&vec![0xEE; 64]));
+    }
+
+    // ── State PartialEq (hash-based) ────────────────────────────────
+
+    #[test]
+    fn state_partial_eq_same_params() {
+        let a = test_state(20);
+        let b = test_state(20);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn state_partial_eq_different_state_number() {
+        let a = test_state(20);
+        let b = test_state(21);
+        assert_ne!(a, b);
+    }
+
+    // ── State value ─────────────────────────────────────────────────
+
+    #[test]
+    fn state_value_deterministic() {
+        let a = test_state(7);
+        let b = test_state(7);
+        assert_eq!(a.value(), b.value());
+    }
+
+    // ── State calculate_sparse_indices ───────────────────────────────
+
+    #[test]
+    fn state_calculate_sparse_indices_matches_sparse_index() {
+        let s_indices = State::calculate_sparse_indices(10).unwrap();
+        let si_indices = SparseIndex::calculate_sparse_indices(10).unwrap();
+        assert_eq!(s_indices, si_indices);
+    }
+
+    // ── PreCommitment ───────────────────────────────────────────────
+
+    #[test]
+    fn precommitment_new_defaults() {
+        let pc = PreCommitment::new(
+            "transfer".into(),
+            HashMap::new(),
+            HashSet::new(),
+            10,
+            [0x01; 32],
+        );
+        assert_eq!(pc.operation_type, "transfer");
+        assert_eq!(pc.min_state_number, 10);
+        assert_eq!(pc.counterparty_id, [0x01; 32]);
+        assert_eq!(pc.hash, [0u8; 32]);
+        assert!(pc.signatures.is_empty());
+        assert!(pc.entity_signature.is_none());
+        assert!(pc.counterparty_signature.is_none());
+    }
+
+    #[test]
+    fn precommitment_add_signature() {
+        let mut pc = PreCommitment::new(
+            "update".into(),
+            HashMap::new(),
+            HashSet::new(),
+            1,
+            [0x02; 32],
+        );
+        pc.add_signature(vec![0xAA; 32]);
+        pc.add_signature(vec![0xBB; 32]);
+        assert_eq!(pc.signatures.len(), 2);
+        assert_eq!(pc.signatures[0], vec![0xAA; 32]);
+    }
+
+    #[test]
+    fn precommitment_to_bytes_deterministic() {
+        let mut fixed = HashMap::new();
+        fixed.insert("param_a".to_string(), vec![1, 2, 3]);
+        let mut variable = HashSet::new();
+        variable.insert("var_x".to_string());
+
+        let pc = PreCommitment::new("op".into(), fixed, variable, 5, [0x03; 32]);
+        let b1 = pc.to_bytes();
+        let b2 = pc.to_bytes();
+        assert_eq!(b1, b2);
+        assert!(!b1.is_empty());
+    }
+
+    #[test]
+    fn precommitment_to_bytes_varies_with_content() {
+        let pc1 = PreCommitment::new("op_a".into(), HashMap::new(), HashSet::new(), 1, [0x04; 32]);
+        let pc2 = PreCommitment::new("op_b".into(), HashMap::new(), HashSet::new(), 1, [0x04; 32]);
+        assert_ne!(pc1.to_bytes(), pc2.to_bytes());
+    }
+
+    #[test]
+    fn precommitment_generate_hash_deterministic() {
+        let s = test_state(5);
+        let op = Operation::Noop;
+        let entropy = vec![0xFF; 16];
+        let h1 = PreCommitment::generate_hash(&s, &op, &entropy).unwrap();
+        let h2 = PreCommitment::generate_hash(&s, &op, &entropy).unwrap();
+        assert_eq!(h1, h2);
+        assert_ne!(h1, [0u8; 32]);
+    }
+
+    // ── SerializableHash ────────────────────────────────────────────
+
+    use super::SerializableHash;
+
+    #[test]
+    fn serializable_hash_default_is_zeroes() {
+        let sh = SerializableHash::default();
+        assert_eq!(sh.inner().as_bytes(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn serializable_hash_new_and_inner() {
+        let h = blake3::hash(b"test data");
+        let sh = SerializableHash::new(h);
+        assert_eq!(sh.inner(), &h);
+    }
+
+    #[test]
+    fn serializable_hash_into_inner() {
+        let h = blake3::hash(b"more data");
+        let sh = SerializableHash::new(h);
+        let recovered: blake3::Hash = sh.into_inner();
+        assert_eq!(recovered, h);
+    }
+
+    #[test]
+    fn serializable_hash_from_hash() {
+        let h = blake3::hash(b"from impl");
+        let sh: SerializableHash = h.into();
+        assert_eq!(*sh.inner(), h);
+    }
+
+    #[test]
+    fn serializable_hash_into_blake3_hash() {
+        let h = blake3::hash(b"into impl");
+        let sh = SerializableHash::new(h);
+        let back: blake3::Hash = sh.into();
+        assert_eq!(back, h);
+    }
+
+    #[test]
+    fn serializable_hash_eq() {
+        let h = blake3::hash(b"eq test");
+        let a = SerializableHash::new(h);
+        let b = SerializableHash::new(h);
+        assert_eq!(a, b);
+    }
+
+    // ── SerializableMerkleProof ─────────────────────────────────────
+
+    use super::SerializableMerkleProof;
+
+    #[test]
+    fn serializable_merkle_proof_new() {
+        let root = vec![0xAA; 32];
+        let proof = vec![vec![0xBB; 32], vec![0xCC; 32]];
+        let smp = SerializableMerkleProof::new(root.clone(), proof.clone());
+        assert_eq!(smp.root, root);
+        assert_eq!(smp.proof, proof);
+    }
+
+    #[test]
+    fn serializable_merkle_proof_serialize_from_bytes_roundtrip() {
+        let root = vec![1, 2, 3, 4, 5];
+        let proof = vec![vec![10, 20], vec![30, 40, 50]];
+        let smp = SerializableMerkleProof::new(root.clone(), proof.clone());
+
+        let bytes = smp.serialize();
+        let recovered = SerializableMerkleProof::from_bytes(&bytes).expect("roundtrip");
+        assert_eq!(recovered.root, root);
+        assert_eq!(recovered.proof, proof);
+    }
+
+    #[test]
+    fn serializable_merkle_proof_from_bytes_invalid() {
+        assert!(SerializableMerkleProof::from_bytes(&[]).is_none());
+        assert!(SerializableMerkleProof::from_bytes(&[0xFF; 3]).is_none());
+    }
+
+    #[test]
+    fn serializable_merkle_proof_verify_valid_path() {
+        use crate::crypto::blake3::dsm_domain_hasher;
+
+        let leaf = b"leaf_data";
+        let sibling = vec![0x11; 32];
+
+        let mut hasher = dsm_domain_hasher("DSM/merkle-path");
+        hasher.update(leaf);
+        hasher.update(&sibling);
+        let root = hasher.finalize().as_bytes().to_vec();
+
+        let smp = SerializableMerkleProof::new(root, vec![sibling]);
+        assert!(smp.verify(leaf));
+    }
+
+    #[test]
+    fn serializable_merkle_proof_verify_invalid_root() {
+        let smp = SerializableMerkleProof::new(vec![0x00; 32], vec![vec![0x11; 32]]);
+        assert!(!smp.verify(b"wrong"));
+    }
+
+    // ── PositionSequence ────────────────────────────────────────────
+
+    use super::PositionSequence;
+
+    #[test]
+    fn position_sequence_new() {
+        let ps = PositionSequence::new(vec![vec![1, 2], vec![3, 4]], vec![0xAA; 8]);
+        assert_eq!(ps.positions.len(), 2);
+        assert_eq!(ps.seed, vec![0xAA; 8]);
+    }
+
+    #[test]
+    fn position_sequence_verify_correct_seed() {
+        let seed = vec![0xBB; 16];
+        let ps = PositionSequence::new(vec![vec![1]], seed.clone());
+        assert!(ps.verify(&seed));
+    }
+
+    #[test]
+    fn position_sequence_verify_wrong_seed() {
+        let ps = PositionSequence::new(vec![], vec![0xCC; 16]);
+        assert!(!ps.verify(&[0xDD; 16]));
+    }
+
+    // ── IdentityAnchor ─────────────────────────────────────────────
+
+    use super::IdentityAnchor;
+
+    #[test]
+    fn identity_anchor_new() {
+        let ia = IdentityAnchor::new(
+            "alice".into(),
+            vec![0x01; 32],
+            vec![0x02; 64],
+            vec![0x03; 16],
+        );
+        assert_eq!(ia.id, "alice");
+        assert_eq!(ia.genesis_hash, vec![0x01; 32]);
+        assert_eq!(ia.public_key, vec![0x02; 64]);
+        assert_eq!(ia.commitment_proof, vec![0x03; 16]);
+    }
+
+    #[test]
+    fn identity_anchor_as_bytes_deterministic() {
+        let ia = IdentityAnchor::new("bob".into(), vec![0x10; 32], vec![0x20; 32], vec![0x30; 32]);
+        let b1 = ia.as_bytes();
+        let b2 = ia.as_bytes();
+        assert_eq!(b1, b2);
+    }
+
+    #[test]
+    fn identity_anchor_as_bytes_contains_all_fields() {
+        let ia = IdentityAnchor::new("x".into(), vec![1], vec![2], vec![3]);
+        let bytes = ia.as_bytes();
+        let expected_len = 1 + 1 + 1 + 1; // "x" + [1] + [2] + [3]
+        assert_eq!(bytes.len(), expected_len);
+    }
+
+    // ── RelationshipContext ─────────────────────────────────────────
+
+    use super::RelationshipContext;
+
+    #[test]
+    fn relationship_context_new() {
+        let ctx = RelationshipContext::new([0xAA; 32], [0xBB; 32], vec![0xCC; 64]);
+        assert_eq!(ctx.entity_id, [0xAA; 32]);
+        assert_eq!(ctx.counterparty_id, [0xBB; 32]);
+        assert_eq!(ctx.counterparty_public_key, vec![0xCC; 64]);
+        assert_eq!(ctx.entity_state_number, 0);
+        assert_eq!(ctx.counterparty_state_number, 0);
+        assert!(ctx.active);
+        assert!(ctx.chain_tip_id.is_none());
+        assert!(ctx.last_bilateral_state_hash.is_none());
+    }
+
+    #[test]
+    fn relationship_context_new_with_chain_tip() {
+        let ctx = RelationshipContext::new_with_chain_tip(
+            [0x01; 32],
+            [0x02; 32],
+            vec![0x03; 32],
+            "tip_42".into(),
+        );
+        assert_eq!(ctx.get_chain_tip_id(), Some(&"tip_42".to_string()));
+    }
+
+    #[test]
+    fn relationship_context_update_chain_tip() {
+        let mut ctx = RelationshipContext::new([0x01; 32], [0x02; 32], vec![]);
+        assert!(ctx.get_chain_tip_id().is_none());
+
+        ctx.update_chain_tip("new_tip".into(), vec![0xFF; 32]);
+        assert_eq!(ctx.get_chain_tip_id(), Some(&"new_tip".to_string()));
+        assert_eq!(ctx.last_bilateral_state_hash, Some(vec![0xFF; 32]));
+    }
+
+    #[test]
+    fn relationship_context_get_chain_tip_id_none_initially() {
+        let ctx = RelationshipContext::new([0; 32], [0; 32], vec![]);
+        assert!(ctx.get_chain_tip_id().is_none());
+    }
+
+    // ── StateParams builder methods ─────────────────────────────────
+
+    #[test]
+    fn state_params_new_defaults() {
+        let sp = StateParams::new(0, vec![1], Operation::Noop, test_device_info());
+        assert_eq!(sp.state_number, 0);
+        assert_eq!(sp.entropy, vec![1]);
+        assert!(sp.encapsulated_entropy.is_none());
+        assert_eq!(sp.prev_state_hash, [0u8; 32]);
+        assert!(sp.forward_commitment.is_none());
+        assert!(!sp.matches_parameters);
+        assert_eq!(sp.state_type, "standard");
+    }
+
+    #[test]
+    fn state_params_with_encapsulated_entropy() {
+        let sp = StateParams::new(1, vec![], Operation::Noop, test_device_info())
+            .with_encapsulated_entropy(vec![0xEE; 32]);
+        assert_eq!(sp.encapsulated_entropy, Some(vec![0xEE; 32]));
+    }
+
+    #[test]
+    fn state_params_with_prev_state_hash() {
+        let sp = StateParams::new(2, vec![], Operation::Noop, test_device_info())
+            .with_prev_state_hash([0xAA; 32]);
+        assert_eq!(sp.prev_state_hash, [0xAA; 32]);
+    }
+
+    #[test]
+    fn state_params_with_sparse_index() {
+        let si = SparseIndex::new(vec![1, 2, 3]);
+        let sp =
+            StateParams::new(3, vec![], Operation::Noop, test_device_info()).with_sparse_index(si);
+        assert_eq!(sp.sparse_index.indices, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn state_params_with_forward_commitment() {
+        let pc = PreCommitment::new("test".into(), HashMap::new(), HashSet::new(), 0, [0; 32]);
+        let sp = StateParams::new(4, vec![], Operation::Noop, test_device_info())
+            .with_forward_commitment(pc);
+        assert!(sp.forward_commitment.is_some());
+    }
+
+    #[test]
+    fn state_params_with_dbrw_summary_hash() {
+        let sp = StateParams::new(5, vec![], Operation::Noop, test_device_info())
+            .with_dbrw_summary_hash([0xDD; 32]);
+        assert_eq!(sp.dbrw_summary_hash, Some([0xDD; 32]));
+    }
+
+    // ── State hash varies with different inputs ─────────────────────
+
+    #[test]
+    fn state_hash_varies_with_entropy() {
+        let a = State::new(StateParams::new(
+            1,
+            vec![0x00; 16],
+            Operation::Noop,
+            test_device_info(),
+        ));
+        let b = State::new(StateParams::new(
+            1,
+            vec![0xFF; 16],
+            Operation::Noop,
+            test_device_info(),
+        ));
+        assert_ne!(a.compute_hash().unwrap(), b.compute_hash().unwrap());
+    }
+
+    #[test]
+    fn state_hash_varies_with_prev_state_hash() {
+        let a = State::new(
+            StateParams::new(1, vec![1], Operation::Noop, test_device_info())
+                .with_prev_state_hash([0x00; 32]),
+        );
+        let b = State::new(
+            StateParams::new(1, vec![1], Operation::Noop, test_device_info())
+                .with_prev_state_hash([0xFF; 32]),
+        );
+        assert_ne!(a.compute_hash().unwrap(), b.compute_hash().unwrap());
+    }
+
+    #[test]
+    fn state_hash_includes_forward_commitment() {
+        let without = test_state(5);
+
+        let pc = PreCommitment::new(
+            "commit_op".into(),
+            HashMap::new(),
+            HashSet::new(),
+            1,
+            [0xCC; 32],
+        );
+        let with = State::new(
+            StateParams::new(5, vec![0xAA; 16], Operation::Noop, test_device_info())
+                .with_forward_commitment(pc),
+        );
+
+        assert_ne!(
+            without.compute_hash().unwrap(),
+            with.compute_hash().unwrap()
+        );
+    }
+
+    // ── State with_relationship_context_and_chain_tip ───────────────
+
+    #[test]
+    fn state_with_relationship_context_and_chain_tip() {
+        let s = test_state(15).with_relationship_context_and_chain_tip(
+            [0xDD; 32],
+            8,
+            vec![0xEE; 32],
+            "chain_tip_99".into(),
+        );
+        let ctx = s.relationship_context.as_ref().unwrap();
+        assert_eq!(ctx.counterparty_state_number, 8);
+        assert_eq!(ctx.get_chain_tip_id(), Some(&"chain_tip_99".to_string()));
+    }
+
+    #[test]
+    fn state_get_counterparty_state() {
+        let s = test_state(10).with_relationship_context([0xCC; 32], 7, vec![]);
+        assert_eq!(s.get_counterparty_state(), Some(7));
+    }
+
+    #[test]
+    fn state_get_counterparty_state_none_without_context() {
+        let s = test_state(10);
+        assert_eq!(s.get_counterparty_state(), None);
+    }
 }
 
 /// SparseIndex represents a sparse index for efficient lookups

--- a/dsm_client/deterministic_state_machine/dsm/src/types/token_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/token_types.rs
@@ -1014,3 +1014,443 @@ pub enum TokenStatus {
     /// Token is temporarily locked
     Locked,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- TokenAmount ---
+
+    #[test]
+    fn token_amount_new_and_value() {
+        let a = TokenAmount::new(42);
+        assert_eq!(a.value(), 42);
+    }
+
+    #[test]
+    fn token_amount_default_is_zero() {
+        let a = TokenAmount::default();
+        assert_eq!(a.value(), 0);
+    }
+
+    #[test]
+    fn token_amount_checked_add_normal() {
+        let a = TokenAmount::new(10);
+        let b = TokenAmount::new(20);
+        let c = a.checked_add(b).unwrap();
+        assert_eq!(c.value(), 30);
+    }
+
+    #[test]
+    fn token_amount_checked_add_overflow() {
+        let a = TokenAmount::new(u64::MAX);
+        let b = TokenAmount::new(1);
+        assert!(a.checked_add(b).is_none());
+    }
+
+    #[test]
+    fn token_amount_checked_sub_normal() {
+        let a = TokenAmount::new(50);
+        let b = TokenAmount::new(20);
+        let c = a.checked_sub(b).unwrap();
+        assert_eq!(c.value(), 30);
+    }
+
+    #[test]
+    fn token_amount_checked_sub_underflow() {
+        let a = TokenAmount::new(5);
+        let b = TokenAmount::new(10);
+        assert!(a.checked_sub(b).is_none());
+    }
+
+    #[test]
+    fn token_amount_saturating_add() {
+        let a = TokenAmount::new(u64::MAX);
+        let b = TokenAmount::new(100);
+        assert_eq!(a.saturating_add(b).value(), u64::MAX);
+    }
+
+    #[test]
+    fn token_amount_saturating_sub() {
+        let a = TokenAmount::new(5);
+        let b = TokenAmount::new(100);
+        assert_eq!(a.saturating_sub(b).value(), 0);
+    }
+
+    #[test]
+    fn token_amount_ordering() {
+        let a = TokenAmount::new(10);
+        let b = TokenAmount::new(20);
+        assert!(a < b);
+        assert!(b > a);
+    }
+
+    // --- TokenSupply ---
+
+    #[test]
+    fn token_supply_fixed() {
+        let s = TokenSupply::fixed(1000);
+        assert!(s.is_fixed());
+        assert!(!s.is_unlimited());
+        assert_eq!(s.max_supply(), Some(1000));
+    }
+
+    #[test]
+    fn token_supply_unlimited() {
+        let s = TokenSupply::unlimited();
+        assert!(s.is_unlimited());
+        assert!(!s.is_fixed());
+        assert_eq!(s.max_supply(), None);
+    }
+
+    #[test]
+    fn token_supply_new_is_fixed() {
+        let s = TokenSupply::new(500);
+        assert!(s.is_fixed());
+    }
+
+    // --- TokenSupplyInfo ---
+
+    #[test]
+    fn token_supply_info_new() {
+        let info = TokenSupplyInfo::new(1_000_000);
+        assert_eq!(info.total_supply, 1_000_000);
+        assert_eq!(info.circulating_supply, 1_000_000);
+        assert_eq!(info.max_supply, Some(1_000_000));
+        assert_eq!(info.min_supply, Some(0));
+    }
+
+    #[test]
+    fn token_supply_info_with_limits() {
+        let info = TokenSupplyInfo::with_limits(500, Some(1000), Some(100));
+        assert_eq!(info.total_supply, 500);
+        assert_eq!(info.max_supply, Some(1000));
+        assert_eq!(info.min_supply, Some(100));
+    }
+
+    #[test]
+    fn supply_change_addition_within_max() {
+        let info = TokenSupplyInfo::with_limits(500, Some(1000), Some(0));
+        assert!(info.is_valid_supply_change(500, true));
+    }
+
+    #[test]
+    fn supply_change_addition_exceeds_max() {
+        let info = TokenSupplyInfo::with_limits(500, Some(1000), Some(0));
+        assert!(!info.is_valid_supply_change(501, true));
+    }
+
+    #[test]
+    fn supply_change_subtraction_within_min() {
+        let info = TokenSupplyInfo::with_limits(500, Some(1000), Some(100));
+        assert!(info.is_valid_supply_change(400, false));
+    }
+
+    #[test]
+    fn supply_change_subtraction_below_min() {
+        let info = TokenSupplyInfo::with_limits(500, Some(1000), Some(100));
+        assert!(!info.is_valid_supply_change(401, false));
+    }
+
+    #[test]
+    fn supply_change_subtraction_exceeds_circulating() {
+        let info = TokenSupplyInfo::new(100);
+        assert!(!info.is_valid_supply_change(101, false));
+    }
+
+    #[test]
+    fn supply_change_unlimited_max() {
+        let info = TokenSupplyInfo::with_limits(500, None, Some(0));
+        assert!(info.is_valid_supply_change(u64::MAX - 500, true));
+    }
+
+    #[test]
+    fn validate_supply_change_with_token_amount_mint() {
+        let info = TokenSupplyInfo::with_limits(500, Some(600), Some(0));
+        assert!(info.validate_supply_change(TokenAmount::new(100), true));
+        assert!(!info.validate_supply_change(TokenAmount::new(101), true));
+    }
+
+    #[test]
+    fn validate_supply_change_with_token_amount_burn() {
+        let info = TokenSupplyInfo::with_limits(500, Some(1000), Some(100));
+        assert!(info.validate_supply_change(TokenAmount::new(400), false));
+        assert!(!info.validate_supply_change(TokenAmount::new(401), false));
+    }
+
+    // --- Balance ---
+
+    #[test]
+    fn balance_zero() {
+        let b = Balance::zero();
+        assert_eq!(b.value(), 0);
+        assert_eq!(b.locked(), 0);
+    }
+
+    #[test]
+    fn balance_from_state() {
+        let b = Balance::from_state(1000, [0xAA; 32], 42);
+        assert_eq!(b.value(), 1000);
+        assert_eq!(b.available(), 1000);
+        assert_eq!(b.locked(), 0);
+    }
+
+    #[test]
+    fn balance_lock_and_unlock() {
+        let mut b = Balance::from_state(100, [0; 32], 1);
+        b.lock(30).unwrap();
+        assert_eq!(b.locked(), 30);
+
+        b.unlock(10).unwrap();
+        assert_eq!(b.locked(), 20);
+    }
+
+    #[test]
+    fn balance_lock_zero_fails() {
+        let mut b = Balance::from_state(100, [0; 32], 1);
+        assert!(b.lock(0).is_err());
+    }
+
+    #[test]
+    fn balance_lock_exceeds_available() {
+        let mut b = Balance::from_state(50, [0; 32], 1);
+        assert!(b.lock(51).is_err());
+    }
+
+    #[test]
+    fn balance_unlock_zero_fails() {
+        let mut b = Balance::from_state(100, [0; 32], 1);
+        b.lock(50).unwrap();
+        assert!(b.unlock(0).is_err());
+    }
+
+    #[test]
+    fn balance_unlock_exceeds_locked() {
+        let mut b = Balance::from_state(100, [0; 32], 1);
+        b.lock(30).unwrap();
+        assert!(b.unlock(31).is_err());
+    }
+
+    #[test]
+    fn balance_update_addition() {
+        let mut b = Balance::from_state(100, [0; 32], 1);
+        b.update(50, true);
+        assert_eq!(b.value(), 150);
+    }
+
+    #[test]
+    fn balance_update_subtraction() {
+        let mut b = Balance::from_state(100, [0; 32], 1);
+        b.update(30, false);
+        assert_eq!(b.value(), 70);
+    }
+
+    #[test]
+    fn balance_update_sub_saturates() {
+        let mut b = Balance::from_state(10, [0; 32], 1);
+        b.update(100, false);
+        assert_eq!(b.value(), 0);
+    }
+
+    #[test]
+    fn balance_update_with_amount_deduction_insufficient() {
+        let mut b = Balance::from_state(10, [0; 32], 1);
+        let result = b.update_with_amount(TokenAmount::new(20), false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn balance_update_add_and_sub() {
+        let mut b = Balance::from_state(100, [0; 32], 1);
+        b.update_add(50);
+        assert_eq!(b.value(), 150);
+        b.update_sub(30).unwrap();
+        assert_eq!(b.value(), 120);
+    }
+
+    #[test]
+    fn balance_update_sub_insufficient() {
+        let mut b = Balance::from_state(10, [0; 32], 1);
+        assert!(b.update_sub(11).is_err());
+    }
+
+    #[test]
+    fn balance_formatted() {
+        let b = Balance::from_state(1_500_000, [0; 32], 1);
+        let f = b.formatted(6);
+        assert_eq!(f, "1.500000");
+    }
+
+    #[test]
+    fn balance_with_state_hash() {
+        let b = Balance::from_state(100, [0; 32], 1).with_state_hash([0xFF; 32]);
+        let bytes = b.to_le_bytes();
+        assert!(bytes.len() > 24);
+    }
+
+    #[test]
+    fn balance_to_le_bytes_deterministic() {
+        let b = Balance::from_state(42, [0xAB; 32], 7);
+        assert_eq!(b.to_le_bytes(), b.to_le_bytes());
+    }
+
+    #[test]
+    fn balance_display() {
+        let b = Balance::from_state(12345, [0; 32], 1);
+        assert_eq!(format!("{b}"), "12345");
+    }
+
+    // --- StateContext ---
+
+    #[test]
+    fn state_context_thread_local_set_get_clear() {
+        StateContext::clear_current();
+        assert!(StateContext::get_current().is_none());
+
+        StateContext::set_current(StateContext::new([0xAA; 32], 10, [0xBB; 32]));
+        let ctx = StateContext::get_current().unwrap();
+        assert_eq!(ctx.state_hash, [0xAA; 32]);
+        assert_eq!(ctx.state_number, 10);
+
+        StateContext::clear_current();
+        assert!(StateContext::get_current().is_none());
+    }
+
+    // --- TokenMetadata ---
+
+    #[test]
+    fn token_metadata_builder_methods() {
+        let meta = TokenMetadata::new(
+            "TEST",
+            "Test Token",
+            "TST",
+            8,
+            TokenType::Created,
+            [0; 32],
+            1,
+            None,
+        )
+        .with_description("A test token")
+        .with_metadata_uri("https://example.com")
+        .with_icon_url("https://example.com/icon.png")
+        .with_field("website", "https://test.com");
+
+        assert_eq!(meta.description.as_deref(), Some("A test token"));
+        assert_eq!(meta.metadata_uri.as_deref(), Some("https://example.com"));
+        assert_eq!(
+            meta.icon_url.as_deref(),
+            Some("https://example.com/icon.png")
+        );
+        assert_eq!(
+            meta.fields.get("website").map(|s| s.as_str()),
+            Some("https://test.com")
+        );
+    }
+
+    #[test]
+    fn token_metadata_canonical_id() {
+        let meta = TokenMetadata::new(
+            "ERA",
+            "ERA",
+            "ERA",
+            18,
+            TokenType::Native,
+            [0xAA; 32],
+            0,
+            None,
+        );
+        let cid = meta.canonical_id();
+        assert!(cid.ends_with(".ERA"));
+    }
+
+    // --- TokenRegistry ---
+
+    #[test]
+    fn token_registry_new_has_era() {
+        let reg = TokenRegistry::new();
+        assert!(reg.get_token("ERA").is_some());
+        assert!(reg.get_supply("ERA").is_some());
+        assert!(reg.is_native_token("ERA"));
+        assert!(!reg.is_native_token("BTC"));
+    }
+
+    #[test]
+    fn token_registry_register_duplicate_fails() {
+        let mut reg = TokenRegistry::new();
+        let meta = TokenMetadata::new("ERA", "ERA", "ERA", 18, TokenType::Native, [0; 32], 0, None);
+        let supply = TokenSupplyInfo::new(100);
+        assert!(reg.register_token(meta, supply).is_err());
+    }
+
+    #[test]
+    fn token_registry_register_new_token() {
+        let mut reg = TokenRegistry::new();
+        let meta = TokenMetadata::new(
+            "TEST",
+            "Test",
+            "TST",
+            8,
+            TokenType::Created,
+            [0; 32],
+            1,
+            None,
+        );
+        let supply = TokenSupplyInfo::new(1000);
+        reg.register_token(meta, supply).unwrap();
+        assert!(reg.get_token("TEST").is_some());
+    }
+
+    // --- Token ---
+
+    #[test]
+    fn token_new_and_accessors() {
+        let balance = Balance::from_state(100, [0; 32], 1);
+        let t = Token::new("alice", vec![1, 2, 3], vec![4, 5], balance, [0xCC; 32]);
+
+        assert!(t.id().contains("alice"));
+        assert_eq!(t.owner_id(), "alice");
+        assert_eq!(t.token_data(), &[1, 2, 3]);
+        assert_eq!(t.metadata(), &[4, 5]);
+        assert!(!t.token_hash().is_empty());
+        assert_eq!(*t.status(), TokenStatus::Active);
+        assert!(t.is_valid());
+        assert_eq!(t.policy_anchor(), Some(&[0xCC; 32]));
+    }
+
+    #[test]
+    fn token_set_status_revoked() {
+        let balance = Balance::from_state(100, [0; 32], 1);
+        let mut t = Token::new("bob", vec![1], vec![], balance, [0; 32]);
+        t.set_status(TokenStatus::Revoked);
+        assert!(!t.is_valid());
+        assert_eq!(*t.status(), TokenStatus::Revoked);
+    }
+
+    #[test]
+    fn token_set_owner() {
+        let balance = Balance::from_state(100, [0; 32], 1);
+        let mut t = Token::new("bob", vec![1], vec![], balance, [0; 32]);
+        t.set_owner("charlie");
+        assert_eq!(t.owner_id(), "charlie");
+    }
+
+    #[test]
+    fn token_update_balance() {
+        let balance = Balance::from_state(100, [0; 32], 1);
+        let mut t = Token::new("bob", vec![1], vec![], balance, [0; 32]);
+        t.update_balance(50, true);
+        assert_eq!(t.balance().value(), 150);
+        t.update_balance(30, false);
+        assert_eq!(t.balance().value(), 120);
+    }
+
+    // --- TokenFactory ---
+
+    #[test]
+    fn token_factory_creation_fee() {
+        let mut f = TokenFactory::new(1000, vec![0; 32]);
+        assert_eq!(f.get_creation_fee(), 1000);
+        f.set_creation_fee(2000);
+        assert_eq!(f.get_creation_fee(), 2000);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/ui_error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/ui_error.rs
@@ -216,3 +216,168 @@ impl From<DsmCoreError> for DsmUiError {
         DsmUiError::Core(core_error)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_core_error() -> DsmCoreError {
+        DsmCoreError::StateMachine("test failure".into())
+    }
+
+    #[test]
+    fn core_variant_display_delegates() {
+        let err = DsmUiError::Core(sample_core_error());
+        let msg = err.to_string();
+        assert!(
+            msg.contains("State machine error: test failure"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_core_error() {
+        let ui: DsmUiError = sample_core_error().into();
+        assert!(matches!(ui, DsmUiError::Core(_)));
+    }
+
+    #[test]
+    fn browser_constructor_all_some() {
+        let err = DsmUiError::browser(
+            sample_core_error(),
+            Some("Mozilla/5.0".into()),
+            Some("https://example.com".into()),
+            Some("CORS blocked".into()),
+        );
+        let msg = err.to_string();
+        assert!(msg.starts_with("Browser error:"), "got: {msg}");
+        assert!(msg.contains("User-Agent: Mozilla/5.0"));
+        assert!(msg.contains("URL: https://example.com"));
+        assert!(msg.contains("Details: CORS blocked"));
+    }
+
+    #[test]
+    fn browser_constructor_all_none() {
+        let err = DsmUiError::browser(sample_core_error(), None, None, None);
+        let msg = err.to_string();
+        assert!(msg.starts_with("Browser error:"));
+        assert!(!msg.contains("User-Agent"));
+        assert!(!msg.contains("URL"));
+        assert!(!msg.contains("Details"));
+    }
+
+    #[test]
+    fn webview_display_with_fields() {
+        let err = DsmUiError::webview(
+            sample_core_error(),
+            Some("105.0".into()),
+            Some("Android 14".into()),
+        );
+        let msg = err.to_string();
+        assert!(msg.starts_with("WebView error:"));
+        assert!(msg.contains("WebView: 105.0"));
+        assert!(msg.contains("Platform: Android 14"));
+    }
+
+    #[test]
+    fn webview_display_no_fields() {
+        let err = DsmUiError::webview(sample_core_error(), None, None);
+        let msg = err.to_string();
+        assert!(msg.starts_with("WebView error:"));
+        assert!(!msg.contains("WebView:"));
+        assert!(!msg.contains("Platform:"));
+    }
+
+    #[test]
+    fn js_bridge_display_with_fields() {
+        let err = DsmUiError::js_bridge(
+            sample_core_error(),
+            Some("postMessage".into()),
+            Some("TypeError".into()),
+        );
+        let msg = err.to_string();
+        assert!(msg.starts_with("JavaScript bridge error:"));
+        assert!(msg.contains("Function: postMessage"));
+        assert!(msg.contains("JS Error: TypeError"));
+    }
+
+    #[test]
+    fn js_bridge_display_no_fields() {
+        let err = DsmUiError::js_bridge(sample_core_error(), None, None);
+        let msg = err.to_string();
+        assert!(msg.starts_with("JavaScript bridge error:"));
+        assert!(!msg.contains("Function:"));
+        assert!(!msg.contains("JS Error:"));
+    }
+
+    #[test]
+    fn ui_rendering_display_with_fields() {
+        let err = DsmUiError::ui_rendering(
+            sample_core_error(),
+            Some("WalletView".into()),
+            Some("React 18".into()),
+        );
+        let msg = err.to_string();
+        assert!(msg.starts_with("UI rendering error:"));
+        assert!(msg.contains("Component: WalletView"));
+        assert!(msg.contains("Framework: React 18"));
+    }
+
+    #[test]
+    fn ui_rendering_display_no_fields() {
+        let err = DsmUiError::ui_rendering(sample_core_error(), None, None);
+        let msg = err.to_string();
+        assert!(msg.starts_with("UI rendering error:"));
+        assert!(!msg.contains("Component:"));
+        assert!(!msg.contains("Framework:"));
+    }
+
+    #[test]
+    fn core_error_accessor_for_all_variants() {
+        let core = DsmUiError::Core(sample_core_error());
+        assert!(matches!(core.core_error(), DsmCoreError::StateMachine(_)));
+
+        let browser = DsmUiError::browser(sample_core_error(), None, None, None);
+        assert!(matches!(
+            browser.core_error(),
+            DsmCoreError::StateMachine(_)
+        ));
+
+        let wv = DsmUiError::webview(sample_core_error(), None, None);
+        assert!(matches!(wv.core_error(), DsmCoreError::StateMachine(_)));
+
+        let js = DsmUiError::js_bridge(sample_core_error(), None, None);
+        assert!(matches!(js.core_error(), DsmCoreError::StateMachine(_)));
+
+        let ui = DsmUiError::ui_rendering(sample_core_error(), None, None);
+        assert!(matches!(ui.core_error(), DsmCoreError::StateMachine(_)));
+    }
+
+    #[test]
+    fn is_recoverable_delegates_to_core() {
+        let recoverable = DsmUiError::Core(DsmCoreError::Network {
+            context: "timeout".into(),
+            source: None,
+            entity: String::new(),
+            details: None,
+        });
+        assert!(recoverable.is_recoverable());
+
+        let not_recoverable = DsmUiError::Core(DsmCoreError::InvalidPublicKey);
+        assert!(!not_recoverable.is_recoverable());
+    }
+
+    #[test]
+    fn error_trait_source_delegates() {
+        use std::error::Error;
+        let err = DsmUiError::Core(DsmCoreError::InvalidPublicKey);
+        assert!(err.source().is_none());
+    }
+
+    #[test]
+    fn debug_impl_exists() {
+        let err = DsmUiError::Core(sample_core_error());
+        let dbg = format!("{err:?}");
+        assert!(dbg.contains("Core"));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/unified_error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/unified_error.rs
@@ -427,3 +427,439 @@ impl From<std::io::Error> for UnifiedDsmError {
 
 /// Result type alias for DSM operations
 pub type DsmResult<T> = Result<T, UnifiedDsmError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Display tests ───────────────────────────────────────────────
+
+    #[test]
+    fn display_crypto_with_component() {
+        let e = UnifiedDsmError::Crypto {
+            context: "bad key".into(),
+            component: Some("ML-KEM".into()),
+            source: None,
+            recoverable: false,
+        };
+        assert_eq!(e.to_string(), "Crypto error in ML-KEM: bad key");
+    }
+
+    #[test]
+    fn display_crypto_without_component() {
+        let e = UnifiedDsmError::Crypto {
+            context: "bad key".into(),
+            component: None,
+            source: None,
+            recoverable: false,
+        };
+        assert_eq!(e.to_string(), "Crypto error: bad key");
+    }
+
+    #[test]
+    fn display_network_with_component() {
+        let e = UnifiedDsmError::Network {
+            context: "timeout".into(),
+            component: Some("BLE".into()),
+            source: None,
+            recoverable: true,
+        };
+        assert_eq!(e.to_string(), "Network error in BLE: timeout");
+    }
+
+    #[test]
+    fn display_network_without_component() {
+        let e = UnifiedDsmError::Network {
+            context: "timeout".into(),
+            component: None,
+            source: None,
+            recoverable: true,
+        };
+        assert_eq!(e.to_string(), "Network error: timeout");
+    }
+
+    #[test]
+    fn display_storage() {
+        let e = UnifiedDsmError::Storage {
+            context: "disk full".into(),
+            component: Some("kv".into()),
+            source: None,
+            recoverable: false,
+        };
+        assert_eq!(e.to_string(), "Storage error in kv: disk full");
+    }
+
+    #[test]
+    fn display_configuration() {
+        let e = UnifiedDsmError::Configuration {
+            context: "missing key".into(),
+            component: None,
+            source: None,
+            recoverable: false,
+        };
+        assert_eq!(e.to_string(), "Configuration error: missing key");
+    }
+
+    #[test]
+    fn display_internal() {
+        let e = UnifiedDsmError::Internal {
+            context: "invariant".into(),
+            component: Some("vault".into()),
+            source: None,
+            recoverable: false,
+        };
+        assert_eq!(e.to_string(), "Internal error in vault: invariant");
+    }
+
+    #[test]
+    fn display_validation_with_field() {
+        let e = UnifiedDsmError::Validation {
+            context: "too long".into(),
+            field: Some("name".into()),
+            recoverable: false,
+        };
+        assert_eq!(e.to_string(), "Validation error for field 'name': too long");
+    }
+
+    #[test]
+    fn display_validation_without_field() {
+        let e = UnifiedDsmError::Validation {
+            context: "too long".into(),
+            field: None,
+            recoverable: false,
+        };
+        assert_eq!(e.to_string(), "Validation error: too long");
+    }
+
+    #[test]
+    fn display_not_found() {
+        let e = UnifiedDsmError::NotFound {
+            resource_type: "vault".into(),
+            resource_id: "abc".into(),
+        };
+        assert_eq!(e.to_string(), "Resource not found: vault 'abc'");
+    }
+
+    #[test]
+    fn display_authentication() {
+        let e = UnifiedDsmError::Authentication {
+            context: "bad sig".into(),
+        };
+        assert_eq!(e.to_string(), "Authentication failed: bad sig");
+    }
+
+    #[test]
+    fn display_authorization() {
+        let e = UnifiedDsmError::Authorization {
+            context: "no perms".into(),
+        };
+        assert_eq!(e.to_string(), "Authorization failed: no perms");
+    }
+
+    #[test]
+    fn display_rate_limit() {
+        let e = UnifiedDsmError::RateLimit {
+            context: "too fast".into(),
+            retry_after_seconds: Some(30),
+        };
+        assert_eq!(e.to_string(), "Rate limit exceeded: too fast");
+    }
+
+    // ── is_recoverable ──────────────────────────────────────────────
+
+    #[test]
+    fn recoverable_respects_flag() {
+        let yes = UnifiedDsmError::Crypto {
+            context: "".into(),
+            component: None,
+            source: None,
+            recoverable: true,
+        };
+        assert!(yes.is_recoverable());
+
+        let no = UnifiedDsmError::Crypto {
+            context: "".into(),
+            component: None,
+            source: None,
+            recoverable: false,
+        };
+        assert!(!no.is_recoverable());
+    }
+
+    #[test]
+    fn not_found_never_recoverable() {
+        let e = UnifiedDsmError::not_found("x", "y");
+        assert!(!e.is_recoverable());
+    }
+
+    #[test]
+    fn authentication_never_recoverable() {
+        assert!(!UnifiedDsmError::authentication("x").is_recoverable());
+    }
+
+    #[test]
+    fn authorization_never_recoverable() {
+        assert!(!UnifiedDsmError::authorization("x").is_recoverable());
+    }
+
+    #[test]
+    fn rate_limit_always_recoverable() {
+        assert!(UnifiedDsmError::rate_limit("x", None).is_recoverable());
+    }
+
+    // ── error_type ──────────────────────────────────────────────────
+
+    #[test]
+    fn error_type_returns_correct_tag() {
+        assert_eq!(
+            UnifiedDsmError::Crypto {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .error_type(),
+            "crypto"
+        );
+        assert_eq!(
+            UnifiedDsmError::Network {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .error_type(),
+            "network"
+        );
+        assert_eq!(
+            UnifiedDsmError::Storage {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .error_type(),
+            "storage"
+        );
+        assert_eq!(
+            UnifiedDsmError::Configuration {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .error_type(),
+            "configuration"
+        );
+        assert_eq!(
+            UnifiedDsmError::new_internal("x".into()).error_type(),
+            "internal"
+        );
+        assert_eq!(UnifiedDsmError::validation("x").error_type(), "validation");
+        assert_eq!(
+            UnifiedDsmError::not_found("a", "b").error_type(),
+            "not_found"
+        );
+        assert_eq!(
+            UnifiedDsmError::authentication("x").error_type(),
+            "authentication"
+        );
+        assert_eq!(
+            UnifiedDsmError::authorization("x").error_type(),
+            "authorization"
+        );
+        assert_eq!(
+            UnifiedDsmError::rate_limit("x", None).error_type(),
+            "rate_limit"
+        );
+    }
+
+    // ── recovery_strategy ───────────────────────────────────────────
+
+    #[test]
+    fn recovery_strategy_mapping() {
+        assert!(matches!(
+            UnifiedDsmError::Crypto {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .recovery_strategy(),
+            RecoveryStrategy::RetryWithBackoff
+        ));
+        assert!(matches!(
+            UnifiedDsmError::Network {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .recovery_strategy(),
+            RecoveryStrategy::Reconnect
+        ));
+        assert!(matches!(
+            UnifiedDsmError::Storage {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .recovery_strategy(),
+            RecoveryStrategy::Reload
+        ));
+        assert!(matches!(
+            UnifiedDsmError::Configuration {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .recovery_strategy(),
+            RecoveryStrategy::Reconfigure
+        ));
+        assert!(matches!(
+            UnifiedDsmError::new_internal("x".into()).recovery_strategy(),
+            RecoveryStrategy::Restart
+        ));
+        assert!(matches!(
+            UnifiedDsmError::rate_limit("x", None).recovery_strategy(),
+            RecoveryStrategy::RetryWithBackoff
+        ));
+    }
+
+    // ── max_retries ─────────────────────────────────────────────────
+
+    #[test]
+    fn max_retries_values() {
+        assert_eq!(
+            UnifiedDsmError::Crypto {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .max_retries(),
+            0
+        );
+        assert_eq!(
+            UnifiedDsmError::Network {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .max_retries(),
+            3
+        );
+        assert_eq!(
+            UnifiedDsmError::Storage {
+                context: "".into(),
+                component: None,
+                source: None,
+                recoverable: false
+            }
+            .max_retries(),
+            2
+        );
+        assert_eq!(UnifiedDsmError::new_internal("x".into()).max_retries(), 1);
+        assert_eq!(UnifiedDsmError::validation("x").max_retries(), 0);
+        assert_eq!(UnifiedDsmError::not_found("a", "b").max_retries(), 0);
+        assert_eq!(UnifiedDsmError::rate_limit("x", None).max_retries(), 1);
+    }
+
+    // ── constructors ────────────────────────────────────────────────
+
+    #[test]
+    fn new_internal_sets_defaults() {
+        let e = UnifiedDsmError::new_internal("oops".into());
+        assert!(!e.is_recoverable());
+        assert_eq!(e.error_type(), "internal");
+        assert!(e.to_string().contains("oops"));
+    }
+
+    #[test]
+    fn internal_error_helper() {
+        let e = internal_error();
+        assert_eq!(e.to_string(), "Internal error: internal error");
+    }
+
+    #[test]
+    fn validation_field_constructor() {
+        let e = UnifiedDsmError::validation_field("too short", "password");
+        let msg = e.to_string();
+        assert!(msg.contains("password"), "got: {msg}");
+        assert!(msg.contains("too short"), "got: {msg}");
+    }
+
+    // ── to_error_response ───────────────────────────────────────────
+
+    #[test]
+    fn error_response_rate_limit_includes_retry_after() {
+        let e = UnifiedDsmError::rate_limit("quota hit", Some(60));
+        let resp = e.to_error_response();
+        assert_eq!(resp.error_type, "rate_limit");
+        assert_eq!(resp.code, "rate_limit");
+        let details = resp.details.unwrap();
+        assert_eq!(details.get("retry_after_seconds").unwrap(), "60");
+    }
+
+    #[test]
+    fn error_response_not_found_includes_resource() {
+        let e = UnifiedDsmError::not_found("vault", "v123");
+        let resp = e.to_error_response();
+        let details = resp.details.unwrap();
+        assert_eq!(details.get("resource_type").unwrap(), "vault");
+        assert_eq!(details.get("resource_id").unwrap(), "v123");
+    }
+
+    #[test]
+    fn error_response_validation_with_field() {
+        let e = UnifiedDsmError::validation_field("bad", "email");
+        let resp = e.to_error_response();
+        let details = resp.details.unwrap();
+        assert_eq!(details.get("field").unwrap(), "email");
+    }
+
+    #[test]
+    fn error_response_generic_has_no_details() {
+        let e = UnifiedDsmError::authentication("nope");
+        let resp = e.to_error_response();
+        assert!(resp.details.is_none());
+        assert!(resp.request_id.is_none());
+        assert!(resp.debug_b32.is_empty());
+    }
+
+    // ── Error trait source ──────────────────────────────────────────
+
+    #[test]
+    fn source_returns_inner_when_present() {
+        let inner = std::io::Error::new(std::io::ErrorKind::Other, "disk");
+        let e = UnifiedDsmError::Storage {
+            context: "write".into(),
+            component: None,
+            source: Some(Box::new(inner)),
+            recoverable: false,
+        };
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn source_returns_none_for_simple_variants() {
+        assert!(UnifiedDsmError::not_found("x", "y").source().is_none());
+        assert!(UnifiedDsmError::authentication("x").source().is_none());
+        assert!(UnifiedDsmError::authorization("x").source().is_none());
+        assert!(UnifiedDsmError::rate_limit("x", None).source().is_none());
+        assert!(UnifiedDsmError::validation("x").source().is_none());
+    }
+
+    // ── From<io::Error> ─────────────────────────────────────────────
+
+    #[test]
+    fn from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe");
+        let e: UnifiedDsmError = io_err.into();
+        assert_eq!(e.error_type(), "storage");
+        assert!(e.is_recoverable());
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/types/unified_error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/unified_error.rs
@@ -834,7 +834,7 @@ mod tests {
 
     #[test]
     fn source_returns_inner_when_present() {
-        let inner = std::io::Error::new(std::io::ErrorKind::Other, "disk");
+        let inner = std::io::Error::other("disk");
         let e = UnifiedDsmError::Storage {
             context: "write".into(),
             component: None,

--- a/dsm_client/deterministic_state_machine/dsm/src/utils/time.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/utils/time.rs
@@ -71,3 +71,135 @@ pub fn now() -> u64 {
     let (_hash, tick) = crate::utils::deterministic_time::peek();
     tick
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_duration_from_ticks() {
+        let d = Duration::from_ticks(42);
+        assert_eq!(d.as_ticks(), 42);
+    }
+
+    #[test]
+    fn test_duration_zero() {
+        let d = Duration::zero();
+        assert_eq!(d.as_ticks(), 0);
+        assert_eq!(d.as_secs(), 0);
+        assert_eq!(d.as_millis(), 0);
+    }
+
+    #[test]
+    fn test_duration_as_secs_equals_ticks() {
+        let d = Duration::from_ticks(100);
+        assert_eq!(d.as_secs(), d.as_ticks());
+    }
+
+    #[test]
+    fn test_duration_as_millis() {
+        let d = Duration::from_ticks(55);
+        assert_eq!(d.as_millis(), 55u128);
+    }
+
+    #[test]
+    fn test_duration_add() {
+        let a = Duration::from_ticks(10);
+        let b = Duration::from_ticks(20);
+        let c = a + b;
+        assert_eq!(c.as_ticks(), 30);
+    }
+
+    #[test]
+    fn test_duration_add_saturating() {
+        let a = Duration::from_ticks(u64::MAX);
+        let b = Duration::from_ticks(1);
+        let c = a + b;
+        assert_eq!(c.as_ticks(), u64::MAX);
+    }
+
+    #[test]
+    fn test_duration_add_assign() {
+        let mut a = Duration::from_ticks(5);
+        a += Duration::from_ticks(3);
+        assert_eq!(a.as_ticks(), 8);
+    }
+
+    #[test]
+    fn test_duration_add_assign_saturating() {
+        let mut a = Duration::from_ticks(u64::MAX);
+        a += Duration::from_ticks(10);
+        assert_eq!(a.as_ticks(), u64::MAX);
+    }
+
+    #[test]
+    fn test_duration_mul() {
+        let d = Duration::from_ticks(7);
+        let result = d * 3;
+        assert_eq!(result.as_ticks(), 21);
+    }
+
+    #[test]
+    fn test_duration_mul_saturating() {
+        let d = Duration::from_ticks(u64::MAX);
+        let result = d * 2;
+        assert_eq!(result.as_ticks(), u64::MAX);
+    }
+
+    #[test]
+    fn test_duration_min() {
+        let a = Duration::from_ticks(10);
+        let b = Duration::from_ticks(5);
+        assert_eq!(a.min(b).as_ticks(), 5);
+        assert_eq!(b.min(a).as_ticks(), 5);
+    }
+
+    #[test]
+    fn test_duration_min_equal() {
+        let a = Duration::from_ticks(7);
+        let b = Duration::from_ticks(7);
+        assert_eq!(a.min(b).as_ticks(), 7);
+    }
+
+    #[test]
+    fn test_duration_ord() {
+        let a = Duration::from_ticks(1);
+        let b = Duration::from_ticks(2);
+        assert!(a < b);
+        assert!(b > a);
+        assert_eq!(a, Duration::from_ticks(1));
+    }
+
+    #[test]
+    fn test_duration_clone_and_copy() {
+        let a = Duration::from_ticks(99);
+        let b = a;
+        let c = a.clone();
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn test_duration_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(Duration::from_ticks(1));
+        set.insert(Duration::from_ticks(2));
+        set.insert(Duration::from_ticks(1));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn test_now_returns_value() {
+        let tick = now();
+        // Should be some non-negative value; we just confirm it doesn't panic.
+        assert!(tick <= u64::MAX);
+    }
+
+    #[test]
+    fn test_duration_debug_format() {
+        let d = Duration::from_ticks(42);
+        let dbg = format!("{:?}", d);
+        assert!(dbg.contains("42"));
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/utils/time.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/utils/time.rs
@@ -174,7 +174,7 @@ mod tests {
     fn test_duration_clone_and_copy() {
         let a = Duration::from_ticks(99);
         let b = a;
-        let c = a.clone();
+        let c = a;
         assert_eq!(a, b);
         assert_eq!(a, c);
     }
@@ -191,9 +191,8 @@ mod tests {
 
     #[test]
     fn test_now_returns_value() {
-        let tick = now();
-        // Should be some non-negative value; we just confirm it doesn't panic.
-        assert!(tick <= u64::MAX);
+        // This test passes as long as the clock helper returns without panicking.
+        let _tick = now();
     }
 
     #[test]

--- a/dsm_client/deterministic_state_machine/dsm/src/utils/timeout.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/utils/timeout.rs
@@ -330,3 +330,210 @@ pub fn calculate_retry_delay(attempt: usize) -> Duration {
     let factor: u32 = 2_u32.pow(attempt as u32).min(4);
     (base_delay * factor).min(max_delay)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── OperationType::timeout tick values ──
+
+    #[test]
+    fn genesis_creation_timeout() {
+        assert_eq!(OperationType::GenesisCreation.timeout().as_ticks(), 50_000);
+    }
+
+    #[test]
+    fn identity_verification_timeout() {
+        assert_eq!(
+            OperationType::IdentityVerification.timeout().as_ticks(),
+            2_500
+        );
+    }
+
+    #[test]
+    fn storage_node_connectivity_timeout() {
+        assert_eq!(
+            OperationType::StorageNodeConnectivity.timeout().as_ticks(),
+            833
+        );
+    }
+
+    #[test]
+    fn mpc_contribution_timeout() {
+        assert_eq!(OperationType::MpcContribution.timeout().as_ticks(), 5_000);
+    }
+
+    #[test]
+    fn transaction_processing_timeout() {
+        assert_eq!(
+            OperationType::TransactionProcessing.timeout().as_ticks(),
+            2_500
+        );
+    }
+
+    #[test]
+    fn bilateral_transaction_timeout_with_default_calibration() {
+        let ticks = OperationType::BilateralTransaction.timeout().as_ticks();
+        // Default calibration: performance_factor = 1.0, base = 10_000
+        // scaled = 10_000 / 1.0 = 10_000, max = 50_000 → min(10_000, 50_000) = 10_000
+        assert_eq!(ticks, 10_000);
+    }
+
+    #[test]
+    fn crypto_operation_timeout() {
+        assert_eq!(OperationType::CryptoOperation.timeout().as_ticks(), 833);
+    }
+
+    #[test]
+    fn http_request_timeout() {
+        assert_eq!(OperationType::HttpRequest.timeout().as_ticks(), 416);
+    }
+
+    // ── OperationType::retry_count ──
+
+    #[test]
+    fn retry_counts() {
+        assert_eq!(OperationType::GenesisCreation.retry_count(), 1);
+        assert_eq!(OperationType::IdentityVerification.retry_count(), 3);
+        assert_eq!(OperationType::StorageNodeConnectivity.retry_count(), 3);
+        assert_eq!(OperationType::MpcContribution.retry_count(), 2);
+        assert_eq!(OperationType::TransactionProcessing.retry_count(), 3);
+        assert_eq!(OperationType::BilateralTransaction.retry_count(), 2);
+        assert_eq!(OperationType::CryptoOperation.retry_count(), 2);
+        assert_eq!(OperationType::HttpRequest.retry_count(), 3);
+    }
+
+    // ── OperationType::should_retry ──
+
+    #[test]
+    fn should_retry_true_variants() {
+        assert!(OperationType::IdentityVerification.should_retry());
+        assert!(OperationType::StorageNodeConnectivity.should_retry());
+        assert!(OperationType::TransactionProcessing.should_retry());
+        assert!(OperationType::HttpRequest.should_retry());
+    }
+
+    #[test]
+    fn should_retry_false_variants() {
+        assert!(!OperationType::GenesisCreation.should_retry());
+        assert!(!OperationType::MpcContribution.should_retry());
+        assert!(!OperationType::BilateralTransaction.should_retry());
+        assert!(!OperationType::CryptoOperation.should_retry());
+    }
+
+    // ── TimeoutConfig constants ──
+
+    #[test]
+    fn timeout_config_genesis() {
+        assert_eq!(TimeoutConfig::genesis_creation().as_ticks(), 50_000);
+    }
+
+    #[test]
+    fn timeout_config_identity() {
+        assert_eq!(TimeoutConfig::identity_verification().as_ticks(), 2_500);
+    }
+
+    #[test]
+    fn timeout_config_storage_node() {
+        assert_eq!(TimeoutConfig::storage_node_connectivity().as_ticks(), 833);
+    }
+
+    #[test]
+    fn timeout_config_mpc() {
+        assert_eq!(TimeoutConfig::mpc_contribution().as_ticks(), 5_000);
+    }
+
+    #[test]
+    fn timeout_config_transaction() {
+        assert_eq!(TimeoutConfig::transaction_processing().as_ticks(), 2_500);
+    }
+
+    #[test]
+    fn timeout_config_crypto() {
+        assert_eq!(TimeoutConfig::crypto_operation().as_ticks(), 833);
+    }
+
+    #[test]
+    fn timeout_config_http() {
+        assert_eq!(TimeoutConfig::http_request().as_ticks(), 416);
+    }
+
+    // ── calculate_retry_delay ──
+
+    #[test]
+    fn retry_delay_attempt_0() {
+        // 2^0 = 1, base * 1 = 2000
+        let d = calculate_retry_delay(0);
+        assert_eq!(d.as_ticks(), 2000);
+    }
+
+    #[test]
+    fn retry_delay_attempt_1() {
+        // 2^1 = 2, base * 2 = 4000
+        let d = calculate_retry_delay(1);
+        assert_eq!(d.as_ticks(), 4000);
+    }
+
+    #[test]
+    fn retry_delay_attempt_2() {
+        // 2^2 = 4, base * 4 = 8000, capped at max_delay 8000
+        let d = calculate_retry_delay(2);
+        assert_eq!(d.as_ticks(), 8000);
+    }
+
+    #[test]
+    fn retry_delay_attempt_3_capped() {
+        // 2^3 = 8 → min(8, 4) = 4, base * 4 = 8000, capped at 8000
+        let d = calculate_retry_delay(3);
+        assert_eq!(d.as_ticks(), 8000);
+    }
+
+    #[test]
+    fn retry_delay_attempt_4_still_capped() {
+        // 2^4 = 16 → min(16, 4) = 4, base * 4 = 8000
+        let d = calculate_retry_delay(4);
+        assert_eq!(d.as_ticks(), 8000);
+    }
+
+    #[test]
+    fn retry_delay_attempt_10_capped() {
+        // 2^10 = 1024 → min(1024, 4) = 4, base * 4 = 8000
+        let d = calculate_retry_delay(10);
+        assert_eq!(d.as_ticks(), 8000);
+    }
+
+    #[test]
+    fn retry_delay_monotonically_non_decreasing() {
+        let d0 = calculate_retry_delay(0).as_ticks();
+        let d1 = calculate_retry_delay(1).as_ticks();
+        let d2 = calculate_retry_delay(2).as_ticks();
+        assert!(d0 <= d1);
+        assert!(d1 <= d2);
+    }
+
+    // ── DeviceCalibration ──
+
+    #[test]
+    fn device_calibration_default() {
+        let cal = DeviceCalibration::default();
+        assert!((cal.ticks_per_second - 12.0).abs() < f64::EPSILON);
+        assert!((cal.performance_factor - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn get_device_calibration_returns_default_when_unset() {
+        let cal = get_device_calibration();
+        assert!((cal.performance_factor - 1.0).abs() < f64::EPSILON);
+    }
+
+    // ── OperationType is Clone + Copy + Debug ──
+
+    #[test]
+    fn operation_type_clone_copy_debug() {
+        let op = OperationType::HttpRequest;
+        let op2 = op;
+        let op3 = op.clone();
+        let _ = format!("{:?}", op2);
+        let _ = format!("{:?}", op3);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/utils/timeout.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/utils/timeout.rs
@@ -532,7 +532,7 @@ mod tests {
     fn operation_type_clone_copy_debug() {
         let op = OperationType::HttpRequest;
         let op2 = op;
-        let op3 = op.clone();
+        let op3 = op;
         let _ = format!("{:?}", op2);
         let _ = format!("{:?}", op3);
     }

--- a/dsm_client/deterministic_state_machine/dsm/src/vault/asset_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/vault/asset_manager.rs
@@ -229,3 +229,232 @@ impl Default for AssetManager {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_token(id: &str, balance: u64) -> DigitalAsset {
+        DigitalAsset::new(id.to_string(), AssetType::Token, vec![])
+            .with_metadata("balance", &balance.to_string())
+    }
+
+    #[test]
+    fn new_creates_empty_manager() {
+        let mgr = AssetManager::new();
+        let all = mgr.get_all_assets().unwrap();
+        assert!(all.is_empty());
+    }
+
+    #[test]
+    fn add_asset_and_retrieve() {
+        let mgr = AssetManager::new();
+        let asset = DigitalAsset::new("a1".into(), AssetType::BinaryData, vec![1, 2, 3]);
+        mgr.add_asset(asset).unwrap();
+
+        let fetched = mgr.get_asset("a1").unwrap().unwrap();
+        assert_eq!(fetched.id, "a1");
+        assert_eq!(fetched.data, vec![1, 2, 3]);
+        assert_eq!(fetched.asset_type, AssetType::BinaryData);
+    }
+
+    #[test]
+    fn add_asset_duplicate_id_fails() {
+        let mgr = AssetManager::new();
+        let a1 = DigitalAsset::new("dup".into(), AssetType::BinaryData, vec![]);
+        let a2 = DigitalAsset::new("dup".into(), AssetType::JsonData, vec![]);
+        mgr.add_asset(a1).unwrap();
+        let err = mgr.add_asset(a2).unwrap_err();
+        assert!(format!("{err}").contains("dup"));
+    }
+
+    #[test]
+    fn get_asset_returns_none_for_missing() {
+        let mgr = AssetManager::new();
+        assert!(mgr.get_asset("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn update_asset_returns_true_for_existing() {
+        let mgr = AssetManager::new();
+        mgr.add_asset(DigitalAsset::new(
+            "u1".into(),
+            AssetType::BinaryData,
+            vec![0],
+        ))
+        .unwrap();
+
+        let updated = mgr.update_asset("u1", |a| a.data = vec![9, 8, 7]).unwrap();
+        assert!(updated);
+
+        let fetched = mgr.get_asset("u1").unwrap().unwrap();
+        assert_eq!(fetched.data, vec![9, 8, 7]);
+    }
+
+    #[test]
+    fn update_asset_returns_false_for_missing() {
+        let mgr = AssetManager::new();
+        let updated = mgr.update_asset("ghost", |_| {}).unwrap();
+        assert!(!updated);
+    }
+
+    #[test]
+    fn remove_asset_returns_some() {
+        let mgr = AssetManager::new();
+        mgr.add_asset(DigitalAsset::new(
+            "rm1".into(),
+            AssetType::Credential,
+            vec![],
+        ))
+        .unwrap();
+
+        let removed = mgr.remove_asset("rm1").unwrap();
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().id, "rm1");
+        assert!(mgr.get_asset("rm1").unwrap().is_none());
+    }
+
+    #[test]
+    fn remove_asset_returns_none_for_missing() {
+        let mgr = AssetManager::new();
+        assert!(mgr.remove_asset("nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn get_all_assets_returns_all() {
+        let mgr = AssetManager::new();
+        mgr.add_asset(DigitalAsset::new("x".into(), AssetType::BinaryData, vec![]))
+            .unwrap();
+        mgr.add_asset(DigitalAsset::new("y".into(), AssetType::JsonData, vec![]))
+            .unwrap();
+        mgr.add_asset(DigitalAsset::new("z".into(), AssetType::Token, vec![]))
+            .unwrap();
+
+        let all = mgr.get_all_assets().unwrap();
+        assert_eq!(all.len(), 3);
+        assert!(all.contains_key("x"));
+        assert!(all.contains_key("y"));
+        assert!(all.contains_key("z"));
+    }
+
+    #[test]
+    fn get_assets_by_type_filters_correctly() {
+        let mgr = AssetManager::new();
+        mgr.add_asset(DigitalAsset::new("t1".into(), AssetType::Token, vec![]))
+            .unwrap();
+        mgr.add_asset(DigitalAsset::new("t2".into(), AssetType::Token, vec![]))
+            .unwrap();
+        mgr.add_asset(DigitalAsset::new(
+            "b1".into(),
+            AssetType::BinaryData,
+            vec![],
+        ))
+        .unwrap();
+
+        let tokens = mgr.get_assets_by_type(AssetType::Token).unwrap();
+        assert_eq!(tokens.len(), 2);
+        assert!(tokens.iter().all(|a| a.asset_type == AssetType::Token));
+
+        let binary = mgr.get_assets_by_type(AssetType::BinaryData).unwrap();
+        assert_eq!(binary.len(), 1);
+
+        let creds = mgr.get_assets_by_type(AssetType::Credential).unwrap();
+        assert!(creds.is_empty());
+    }
+
+    #[test]
+    fn update_asset_data_updates_existing() {
+        let mgr = AssetManager::new();
+        mgr.add_asset(DigitalAsset::new(
+            "d1".into(),
+            AssetType::BinaryData,
+            vec![0],
+        ))
+        .unwrap();
+
+        mgr.update_asset_data("d1", vec![5, 6, 7]).unwrap();
+        let fetched = mgr.get_asset("d1").unwrap().unwrap();
+        assert_eq!(fetched.data, vec![5, 6, 7]);
+    }
+
+    #[test]
+    fn update_asset_data_fails_for_missing() {
+        let mgr = AssetManager::new();
+        let err = mgr.update_asset_data("missing", vec![1]).unwrap_err();
+        assert!(format!("{err}").contains("missing"));
+    }
+
+    #[test]
+    fn validate_transfer_sufficient_balance_succeeds() {
+        let mgr = AssetManager::new();
+        mgr.add_asset(make_token("tok1", 1000)).unwrap();
+        mgr.validate_transfer("tok1", 500).unwrap();
+    }
+
+    #[test]
+    fn validate_transfer_insufficient_balance_fails() {
+        let mgr = AssetManager::new();
+        mgr.add_asset(make_token("tok2", 100)).unwrap();
+        let err = mgr.validate_transfer("tok2", 200).unwrap_err();
+        match err {
+            DsmError::InsufficientBalance {
+                token_id,
+                available,
+                requested,
+            } => {
+                assert_eq!(token_id, "tok2");
+                assert_eq!(available, 100);
+                assert_eq!(requested, 200);
+            }
+            other => panic!("Expected InsufficientBalance, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn validate_transfer_non_token_asset_fails() {
+        let mgr = AssetManager::new();
+        mgr.add_asset(DigitalAsset::new(
+            "notok".into(),
+            AssetType::BinaryData,
+            vec![],
+        ))
+        .unwrap();
+        let err = mgr.validate_transfer("notok", 1).unwrap_err();
+        assert!(format!("{err}").contains("not a token"));
+    }
+
+    #[test]
+    fn validate_transfer_missing_asset_fails() {
+        let mgr = AssetManager::new();
+        let err = mgr.validate_transfer("ghost", 1).unwrap_err();
+        match err {
+            DsmError::NotFound { .. } => {}
+            other => panic!("Expected NotFound, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn digital_asset_new_sets_fields() {
+        let asset = DigitalAsset::new("id1".into(), AssetType::KeyMaterial, vec![10, 20]);
+        assert_eq!(asset.id, "id1");
+        assert_eq!(asset.asset_type, AssetType::KeyMaterial);
+        assert_eq!(asset.data, vec![10, 20]);
+        assert!(asset.metadata.is_empty());
+    }
+
+    #[test]
+    fn digital_asset_with_metadata_adds_metadata() {
+        let asset = DigitalAsset::new("id2".into(), AssetType::JsonData, vec![])
+            .with_metadata("key1", "val1")
+            .with_metadata("key2", "val2");
+        assert_eq!(asset.metadata.len(), 2);
+        assert_eq!(asset.metadata.get("key1").unwrap(), "val1");
+        assert_eq!(asset.metadata.get("key2").unwrap(), "val2");
+    }
+
+    #[test]
+    fn default_asset_manager_is_empty() {
+        let mgr = AssetManager::default();
+        assert!(mgr.get_all_assets().unwrap().is_empty());
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/vault/dlv_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/vault/dlv_manager.rs
@@ -264,3 +264,185 @@ impl Default for DLVManager {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::pedersen::{PedersenCommitment, PedersenParams, SecurityLevel};
+    use crate::vault::limbo_vault::{EncryptedContent, VaultState as VS};
+
+    fn dummy_vault(id: &str, state: VS) -> LimboVault {
+        let params = PedersenParams::new(SecurityLevel::Standard128).expect("pedersen params");
+        let commitment =
+            PedersenCommitment::commit(b"test_content", &params).expect("pedersen commit");
+        LimboVault {
+            id: id.to_string(),
+            created_at_state: 0,
+            creator_public_key: vec![0x01; 32],
+            fulfillment_condition: FulfillmentMechanism::CryptoCondition {
+                condition_hash: vec![0x02; 32],
+                public_params: vec![0x03; 16],
+            },
+            intended_recipient: None,
+            state,
+            content_type: "application/octet-stream".into(),
+            encrypted_content: EncryptedContent {
+                encapsulated_key: vec![],
+                encrypted_data: vec![],
+                nonce: vec![],
+                aad: vec![],
+            },
+            content_commitment: commitment,
+            parameters_hash: vec![0xAA; 32],
+            creator_signature: vec![0xBB; 64],
+            verification_positions: vec![],
+            reference_state_hash: [0xCC; 32],
+            entry_header: None,
+        }
+    }
+
+    // ── Construction ────────────────────────────────────────────────
+
+    #[test]
+    fn dlv_manager_default() {
+        let mgr = DLVManager::default();
+        let dbg = format!("{:?}", mgr.vaults);
+        assert!(dbg.contains("RwLock"));
+    }
+
+    // ── add_vault + get_vault ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn add_and_get_vault() {
+        let mgr = DLVManager::new();
+        let vault = dummy_vault("vault_1", VS::Limbo);
+
+        let id = mgr.add_vault(vault).await.unwrap();
+        assert_eq!(id, "vault_1");
+
+        let lock = mgr.get_vault("vault_1").await.unwrap();
+        let v = lock.lock().await;
+        assert_eq!(v.id, "vault_1");
+        assert_eq!(v.state, VS::Limbo);
+    }
+
+    #[tokio::test]
+    async fn get_vault_not_found() {
+        let mgr = DLVManager::new();
+        let result = mgr.get_vault("nonexistent").await;
+        assert!(result.is_err());
+    }
+
+    // ── list_vaults ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_vaults_empty() {
+        let mgr = DLVManager::new();
+        let ids = mgr.list_vaults().await.unwrap();
+        assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_vaults_after_adds() {
+        let mgr = DLVManager::new();
+        mgr.add_vault(dummy_vault("v1", VS::Limbo)).await.unwrap();
+        mgr.add_vault(dummy_vault("v2", VS::Limbo)).await.unwrap();
+
+        let mut ids = mgr.list_vaults().await.unwrap();
+        ids.sort();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&"v1".to_string()));
+        assert!(ids.contains(&"v2".to_string()));
+    }
+
+    // ── get_vaults_by_status ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_vaults_by_status_empty() {
+        let mgr = DLVManager::new();
+        let result = mgr.get_vaults_by_status(VS::Limbo).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_vaults_by_status_filters() {
+        let mgr = DLVManager::new();
+        mgr.add_vault(dummy_vault("limbo_1", VS::Limbo))
+            .await
+            .unwrap();
+        mgr.add_vault(dummy_vault("limbo_2", VS::Limbo))
+            .await
+            .unwrap();
+        mgr.add_vault(dummy_vault(
+            "active_1",
+            VS::Active {
+                activated_state_number: 10,
+            },
+        ))
+        .await
+        .unwrap();
+
+        let limbo = mgr.get_vaults_by_status(VS::Limbo).await.unwrap();
+        assert_eq!(limbo.len(), 2);
+
+        let active = mgr
+            .get_vaults_by_status(VS::Active {
+                activated_state_number: 10,
+            })
+            .await
+            .unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0], "active_1");
+    }
+
+    // ── add_vault overwrites existing ───────────────────────────────
+
+    #[tokio::test]
+    async fn add_vault_overwrites_same_id() {
+        let mgr = DLVManager::new();
+        mgr.add_vault(dummy_vault("dup", VS::Limbo)).await.unwrap();
+        mgr.add_vault(dummy_vault(
+            "dup",
+            VS::Active {
+                activated_state_number: 5,
+            },
+        ))
+        .await
+        .unwrap();
+
+        let ids = mgr.list_vaults().await.unwrap();
+        assert_eq!(ids.len(), 1);
+
+        let lock = mgr.get_vault("dup").await.unwrap();
+        let v = lock.lock().await;
+        assert_eq!(
+            v.state,
+            VS::Active {
+                activated_state_number: 5
+            }
+        );
+    }
+
+    // ── concurrent access safety ────────────────────────────────────
+
+    #[tokio::test]
+    async fn concurrent_add_and_list() {
+        let mgr = std::sync::Arc::new(DLVManager::new());
+        let mut handles = Vec::new();
+
+        for i in 0..10 {
+            let mgr = mgr.clone();
+            handles.push(tokio::spawn(async move {
+                let vault = dummy_vault(&format!("v_{i}"), VS::Limbo);
+                mgr.add_vault(vault).await.unwrap();
+            }));
+        }
+
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        let ids = mgr.list_vaults().await.unwrap();
+        assert_eq!(ids.len(), 10);
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/vault/fulfillment.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/vault/fulfillment.rs
@@ -121,3 +121,197 @@ impl fmt::Display for FulfillmentMechanism {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_payment() -> FulfillmentMechanism {
+        FulfillmentMechanism::Payment {
+            amount: 500,
+            token_id: "dBTC".into(),
+            recipient: "alice".into(),
+            verification_state: vec![1, 2, 3],
+        }
+    }
+
+    fn sample_crypto_condition() -> FulfillmentMechanism {
+        FulfillmentMechanism::CryptoCondition {
+            condition_hash: vec![0xAA; 32],
+            public_params: vec![0xBB; 16],
+        }
+    }
+
+    fn sample_multisig(threshold: usize) -> FulfillmentMechanism {
+        FulfillmentMechanism::MultiSignature {
+            public_keys: vec![vec![1], vec![2], vec![3]],
+            threshold,
+        }
+    }
+
+    fn sample_state_reference() -> FulfillmentMechanism {
+        FulfillmentMechanism::StateReference {
+            reference_states: vec![vec![0xCC; 32]],
+            parameters: vec![0xDD],
+        }
+    }
+
+    fn sample_random_walk() -> FulfillmentMechanism {
+        FulfillmentMechanism::RandomWalkVerification {
+            verification_key: vec![0xEE; 32],
+            statement: "test-stmt".into(),
+        }
+    }
+
+    fn sample_bitcoin_htlc() -> FulfillmentMechanism {
+        FulfillmentMechanism::BitcoinHTLC {
+            hash_lock: [0xAA; 32],
+            refund_hash_lock: [0xBB; 32],
+            refund_iterations: 100,
+            bitcoin_pubkey: vec![0x02; 33],
+            expected_btc_amount_sats: 100_000,
+            network: 0,
+            min_confirmations: 6,
+        }
+    }
+
+    #[test]
+    fn display_payment() {
+        assert_eq!(sample_payment().to_string(), "Payment of 500 dBTC");
+    }
+
+    #[test]
+    fn display_crypto_condition() {
+        assert_eq!(
+            sample_crypto_condition().to_string(),
+            "Cryptographic Condition"
+        );
+    }
+
+    #[test]
+    fn display_multisig() {
+        assert_eq!(sample_multisig(2).to_string(), "2-of-n MultiSignature");
+    }
+
+    #[test]
+    fn display_state_reference() {
+        assert_eq!(sample_state_reference().to_string(), "State Reference");
+    }
+
+    #[test]
+    fn display_random_walk() {
+        assert_eq!(sample_random_walk().to_string(), "RandomWalk: test-stmt");
+    }
+
+    #[test]
+    fn display_bitcoin_htlc() {
+        assert_eq!(
+            sample_bitcoin_htlc().to_string(),
+            "Bitcoin HTLC (100000 sats)"
+        );
+    }
+
+    #[test]
+    fn display_and_condition() {
+        let and = FulfillmentMechanism::And(vec![sample_payment(), sample_crypto_condition()]);
+        assert_eq!(and.to_string(), "AND(2 conditions)");
+    }
+
+    #[test]
+    fn display_or_condition() {
+        let or = FulfillmentMechanism::Or(vec![
+            sample_payment(),
+            sample_multisig(3),
+            sample_state_reference(),
+        ]);
+        assert_eq!(or.to_string(), "OR(3 conditions)");
+    }
+
+    #[test]
+    fn equality_same_payment() {
+        let a = sample_payment();
+        let b = sample_payment();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn inequality_different_variants() {
+        assert_ne!(sample_payment(), sample_crypto_condition());
+        assert_ne!(sample_multisig(2), sample_state_reference());
+        assert_ne!(sample_random_walk(), sample_bitcoin_htlc());
+    }
+
+    #[test]
+    fn inequality_same_variant_different_fields() {
+        let a = FulfillmentMechanism::Payment {
+            amount: 100,
+            token_id: "dBTC".into(),
+            recipient: "alice".into(),
+            verification_state: vec![],
+        };
+        let b = FulfillmentMechanism::Payment {
+            amount: 200,
+            token_id: "dBTC".into(),
+            recipient: "alice".into(),
+            verification_state: vec![],
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn clone_payment() {
+        let orig = sample_payment();
+        let cloned = orig.clone();
+        assert_eq!(orig, cloned);
+    }
+
+    #[test]
+    fn clone_crypto_condition() {
+        let orig = sample_crypto_condition();
+        let cloned = orig.clone();
+        assert_eq!(orig, cloned);
+    }
+
+    #[test]
+    fn clone_multisig() {
+        let orig = sample_multisig(2);
+        let cloned = orig.clone();
+        assert_eq!(orig, cloned);
+    }
+
+    #[test]
+    fn clone_bitcoin_htlc() {
+        let orig = sample_bitcoin_htlc();
+        let cloned = orig.clone();
+        assert_eq!(orig, cloned);
+    }
+
+    #[test]
+    fn and_compound_nesting() {
+        let inner_or = FulfillmentMechanism::Or(vec![sample_payment(), sample_multisig(2)]);
+        let outer = FulfillmentMechanism::And(vec![inner_or.clone(), sample_crypto_condition()]);
+        assert_eq!(outer.to_string(), "AND(2 conditions)");
+
+        if let FulfillmentMechanism::And(conditions) = &outer {
+            assert_eq!(conditions.len(), 2);
+            assert_eq!(conditions[0], inner_or);
+        } else {
+            panic!("Expected And variant");
+        }
+    }
+
+    #[test]
+    fn or_compound_nesting() {
+        let inner_and =
+            FulfillmentMechanism::And(vec![sample_crypto_condition(), sample_state_reference()]);
+        let outer = FulfillmentMechanism::Or(vec![inner_and.clone(), sample_payment()]);
+        assert_eq!(outer.to_string(), "OR(2 conditions)");
+
+        if let FulfillmentMechanism::Or(conditions) = &outer {
+            assert_eq!(conditions.len(), 2);
+            assert_eq!(conditions[0], inner_and);
+        } else {
+            panic!("Expected Or variant");
+        }
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm/src/vault/limbo_vault.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/vault/limbo_vault.rs
@@ -1979,9 +1979,781 @@ impl Default for LimboVault {
 
 #[cfg(test)]
 mod tests {
-    // use super::*;
-    // use crate::crypto::{sphincs, kyber};
-    // use crate::types::state_types::{DeviceInfo, State};
+    use super::*;
+    use crate::core::state_machine::random_walk::algorithms::Position;
+    use crate::types::policy_types::VaultCondition;
+
+    // ───────── secure_eq ─────────
+
+    #[test]
+    fn secure_eq_equal_slices() {
+        assert!(secure_eq(b"hello", b"hello"));
+    }
+
+    #[test]
+    fn secure_eq_different_slices() {
+        assert!(!secure_eq(b"hello", b"world"));
+    }
+
+    #[test]
+    fn secure_eq_different_lengths() {
+        assert!(!secure_eq(b"short", b"longer_slice"));
+    }
+
+    #[test]
+    fn secure_eq_empty_slices() {
+        assert!(secure_eq(b"", b""));
+    }
+
+    #[test]
+    fn secure_eq_one_empty() {
+        assert!(!secure_eq(b"", b"x"));
+    }
+
+    #[test]
+    fn secure_eq_single_bit_diff() {
+        let a = [0xFFu8; 32];
+        let mut b = [0xFFu8; 32];
+        b[31] = 0xFE;
+        assert!(!secure_eq(&a, &b));
+    }
+
+    // ───────── concat_bytes ─────────
+
+    #[test]
+    fn concat_bytes_multiple() {
+        let result = concat_bytes(&[b"ab", b"cd", b"ef"]);
+        assert_eq!(result, b"abcdef");
+    }
+
+    #[test]
+    fn concat_bytes_with_empty() {
+        let result = concat_bytes(&[b"a", b"", b"b"]);
+        assert_eq!(result, b"ab");
+    }
+
+    #[test]
+    fn concat_bytes_all_empty() {
+        let result = concat_bytes(&[b"", b"", b""]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn concat_bytes_no_parts() {
+        let result = concat_bytes(&[]);
+        assert!(result.is_empty());
+    }
+
+    // ───────── decimal_label ─────────
+
+    #[test]
+    fn decimal_label_deterministic() {
+        let l1 = decimal_label("pfx-", b"material");
+        let l2 = decimal_label("pfx-", b"material");
+        assert_eq!(l1, l2);
+    }
+
+    #[test]
+    fn decimal_label_different_prefix() {
+        let l1 = decimal_label("a-", b"mat");
+        let l2 = decimal_label("b-", b"mat");
+        assert!(l1.starts_with("a-"));
+        assert!(l2.starts_with("b-"));
+        let num1 = &l1[2..];
+        let num2 = &l2[2..];
+        assert_eq!(num1, num2);
+    }
+
+    #[test]
+    fn decimal_label_different_material() {
+        let l1 = decimal_label("x-", b"aaa");
+        let l2 = decimal_label("x-", b"bbb");
+        assert_ne!(l1, l2);
+    }
+
+    // ───────── encode_position / decode_position roundtrip ─────────
+
+    #[test]
+    fn position_roundtrip_basic() {
+        let pos = Position(vec![1, -2, 3, 0]);
+        let bytes = encode_position(&pos);
+        let decoded = decode_position(&bytes).unwrap();
+        assert_eq!(pos.0, decoded.0);
+    }
+
+    #[test]
+    fn position_roundtrip_empty() {
+        let pos = Position(vec![]);
+        let bytes = encode_position(&pos);
+        assert_eq!(bytes.len(), 4); // only the length prefix
+        let decoded = decode_position(&bytes).unwrap();
+        assert!(decoded.0.is_empty());
+    }
+
+    #[test]
+    fn position_roundtrip_single_coord() {
+        let pos = Position(vec![i32::MAX]);
+        let bytes = encode_position(&pos);
+        let decoded = decode_position(&bytes).unwrap();
+        assert_eq!(decoded.0, vec![i32::MAX]);
+    }
+
+    #[test]
+    fn position_roundtrip_many_coords() {
+        let coords: Vec<i32> = (0..100).collect();
+        let pos = Position(coords.clone());
+        let bytes = encode_position(&pos);
+        let decoded = decode_position(&bytes).unwrap();
+        assert_eq!(decoded.0, coords);
+    }
+
+    #[test]
+    fn decode_position_short_input() {
+        let result = decode_position(&[0, 1]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_position_wrong_length() {
+        // Header says 2 coords (8 extra bytes needed) but only 4 provided
+        let mut bytes = vec![2, 0, 0, 0]; // len=2
+        bytes.extend_from_slice(&1i32.to_le_bytes());
+        let result = decode_position(&bytes);
+        assert!(result.is_err());
+    }
+
+    // ───────── FulfillmentProof::to_bytes ─────────
+
+    #[test]
+    fn payment_proof_to_bytes_no_sigma() {
+        let proof = FulfillmentProof::PaymentProof {
+            state_transition: vec![1, 2, 3],
+            merkle_proof: vec![4, 5],
+            stitched_receipt_sigma: None,
+        };
+        let bytes = proof.to_bytes();
+        assert_eq!(bytes[0], 1); // variant tag
+        assert!(!bytes.is_empty());
+        // last byte should be 0x00 (no sigma)
+        assert_eq!(*bytes.last().unwrap(), 0x00);
+    }
+
+    #[test]
+    fn payment_proof_to_bytes_with_sigma() {
+        let sigma = [0xABu8; 32];
+        let proof = FulfillmentProof::PaymentProof {
+            state_transition: vec![10],
+            merkle_proof: vec![20],
+            stitched_receipt_sigma: Some(sigma),
+        };
+        let bytes = proof.to_bytes();
+        assert_eq!(bytes[0], 1);
+        // sigma present: ..., 0x01, <32 bytes of 0xAB>
+        let tail = &bytes[bytes.len() - 33..];
+        assert_eq!(tail[0], 0x01);
+        assert_eq!(&tail[1..], &sigma);
+    }
+
+    #[test]
+    fn crypto_condition_proof_to_bytes() {
+        let proof = FulfillmentProof::CryptoConditionProof {
+            solution: vec![0xFF; 5],
+            proof: vec![0xEE; 3],
+            stitched_receipt_sigma: None,
+        };
+        let bytes = proof.to_bytes();
+        assert_eq!(bytes[0], 2);
+    }
+
+    #[test]
+    fn multi_signature_proof_to_bytes() {
+        let proof = FulfillmentProof::MultiSignatureProof {
+            signatures: vec![(vec![1], vec![2]), (vec![3], vec![4])],
+            signed_data: vec![5, 6],
+            stitched_receipt_sigma: None,
+        };
+        let bytes = proof.to_bytes();
+        assert_eq!(bytes[0], 3);
+    }
+
+    #[test]
+    fn random_walk_proof_to_bytes() {
+        let proof = FulfillmentProof::RandomWalkProof {
+            positions: vec![Position(vec![1, 2]), Position(vec![3, 4])],
+            hash_chain_proof: vec![0xCC; 8],
+            stitched_receipt_sigma: None,
+        };
+        let bytes = proof.to_bytes();
+        assert_eq!(bytes[0], 4);
+    }
+
+    #[test]
+    fn compound_proof_to_bytes() {
+        let inner = FulfillmentProof::PaymentProof {
+            state_transition: vec![1],
+            merkle_proof: vec![2],
+            stitched_receipt_sigma: None,
+        };
+        let proof = FulfillmentProof::CompoundProof(vec![inner]);
+        let bytes = proof.to_bytes();
+        assert_eq!(bytes[0], 5);
+    }
+
+    #[test]
+    fn bitcoin_htlc_proof_to_bytes() {
+        let proof = FulfillmentProof::BitcoinHTLCProof {
+            preimage: vec![0x01; 32],
+            bitcoin_txid: [0x02; 32],
+            bitcoin_tx_raw: vec![0x03; 10],
+            spv_proof: vec![0x04; 8],
+            expected_script_pubkey: vec![0x05; 4],
+            block_header: Box::new([0x06; 80]),
+            header_chain: vec![],
+            stitched_receipt: None,
+            stitched_receipt_sigma: None,
+        };
+        let bytes = proof.to_bytes();
+        assert_eq!(bytes[0], 6);
+    }
+
+    #[test]
+    fn to_bytes_deterministic() {
+        let proof = FulfillmentProof::PaymentProof {
+            state_transition: vec![9, 8, 7],
+            merkle_proof: vec![6, 5],
+            stitched_receipt_sigma: Some([0x42; 32]),
+        };
+        let b1 = proof.to_bytes();
+        let b2 = proof.to_bytes();
+        assert_eq!(b1, b2);
+    }
+
+    // ───────── extract_sigma_from_proof ─────────
+
+    #[test]
+    fn extract_sigma_payment_some() {
+        let sigma = [0x11u8; 32];
+        let proof = FulfillmentProof::PaymentProof {
+            state_transition: vec![],
+            merkle_proof: vec![],
+            stitched_receipt_sigma: Some(sigma),
+        };
+        assert_eq!(extract_sigma_from_proof(&proof), Some(sigma));
+    }
+
+    #[test]
+    fn extract_sigma_payment_none() {
+        let proof = FulfillmentProof::PaymentProof {
+            state_transition: vec![],
+            merkle_proof: vec![],
+            stitched_receipt_sigma: None,
+        };
+        assert_eq!(extract_sigma_from_proof(&proof), None);
+    }
+
+    #[test]
+    fn extract_sigma_crypto_condition() {
+        let sigma = [0x22u8; 32];
+        let proof = FulfillmentProof::CryptoConditionProof {
+            solution: vec![],
+            proof: vec![],
+            stitched_receipt_sigma: Some(sigma),
+        };
+        assert_eq!(extract_sigma_from_proof(&proof), Some(sigma));
+    }
+
+    #[test]
+    fn extract_sigma_multi_sig() {
+        let sigma = [0x33u8; 32];
+        let proof = FulfillmentProof::MultiSignatureProof {
+            signatures: vec![],
+            signed_data: vec![],
+            stitched_receipt_sigma: Some(sigma),
+        };
+        assert_eq!(extract_sigma_from_proof(&proof), Some(sigma));
+    }
+
+    #[test]
+    fn extract_sigma_random_walk() {
+        let sigma = [0x44u8; 32];
+        let proof = FulfillmentProof::RandomWalkProof {
+            positions: vec![],
+            hash_chain_proof: vec![],
+            stitched_receipt_sigma: Some(sigma),
+        };
+        assert_eq!(extract_sigma_from_proof(&proof), Some(sigma));
+    }
+
+    #[test]
+    fn extract_sigma_bitcoin_htlc() {
+        let sigma = [0x55u8; 32];
+        let proof = FulfillmentProof::BitcoinHTLCProof {
+            preimage: vec![],
+            bitcoin_txid: [0; 32],
+            bitcoin_tx_raw: vec![],
+            spv_proof: vec![],
+            expected_script_pubkey: vec![],
+            block_header: Box::new([0; 80]),
+            header_chain: vec![],
+            stitched_receipt: None,
+            stitched_receipt_sigma: Some(sigma),
+        };
+        assert_eq!(extract_sigma_from_proof(&proof), Some(sigma));
+    }
+
+    #[test]
+    fn extract_sigma_compound_returns_none() {
+        let proof = FulfillmentProof::CompoundProof(vec![]);
+        assert_eq!(extract_sigma_from_proof(&proof), None);
+    }
+
+    // ───────── VaultState ─────────
+
+    #[test]
+    fn vault_state_limbo_equality() {
+        assert_eq!(VaultState::Limbo, VaultState::Limbo);
+    }
+
+    #[test]
+    fn vault_state_active_equality() {
+        let a = VaultState::Active {
+            activated_state_number: 42,
+        };
+        let b = VaultState::Active {
+            activated_state_number: 42,
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn vault_state_active_inequality() {
+        let a = VaultState::Active {
+            activated_state_number: 1,
+        };
+        let b = VaultState::Active {
+            activated_state_number: 2,
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn vault_state_limbo_ne_active() {
+        assert_ne!(
+            VaultState::Limbo,
+            VaultState::Active {
+                activated_state_number: 0
+            }
+        );
+    }
+
+    // ───────── DeterministicLimboVault ─────────
+
+    #[test]
+    fn dlv_new_and_getters() {
+        let cond = VaultCondition::Hash(b"test".to_vec());
+        let v = DeterministicLimboVault::new("alice", "bob", vec![1, 2, 3], cond);
+
+        assert!(v.id().starts_with("dlv-"));
+        assert_eq!(v.creator_id(), "alice");
+        assert_eq!(v.recipient_id(), "bob");
+        assert_eq!(v.data(), &[1, 2, 3]);
+        assert_eq!(*v.status(), VaultStatus::Active);
+    }
+
+    #[test]
+    fn dlv_set_status() {
+        let cond = VaultCondition::Hash(vec![]);
+        let mut v = DeterministicLimboVault::new("c", "r", vec![], cond);
+
+        v.set_status(VaultStatus::Claimed);
+        assert_eq!(*v.status(), VaultStatus::Claimed);
+
+        v.set_status(VaultStatus::Revoked);
+        assert_eq!(*v.status(), VaultStatus::Revoked);
+
+        v.set_status(VaultStatus::Expired);
+        assert_eq!(*v.status(), VaultStatus::Expired);
+    }
+
+    #[test]
+    fn dlv_id_is_deterministic() {
+        let cond1 = VaultCondition::Hash(b"h".to_vec());
+        let cond2 = VaultCondition::Hash(b"h".to_vec());
+        let v1 = DeterministicLimboVault::new("alice", "bob", vec![42], cond1);
+        let v2 = DeterministicLimboVault::new("alice", "bob", vec![42], cond2);
+        assert_eq!(v1.id(), v2.id());
+    }
+
+    #[test]
+    fn dlv_different_data_different_id() {
+        let cond1 = VaultCondition::Hash(vec![]);
+        let cond2 = VaultCondition::Hash(vec![]);
+        let v1 = DeterministicLimboVault::new("a", "b", vec![1], cond1);
+        let v2 = DeterministicLimboVault::new("a", "b", vec![2], cond2);
+        assert_ne!(v1.id(), v2.id());
+    }
+
+    // ───────── factory functions ─────────
+
+    #[test]
+    fn create_deterministic_limbo_vault_basic() {
+        let v = create_deterministic_limbo_vault(
+            "creator1",
+            vec![10, 20],
+            VaultCondition::MinimumBalance(100),
+        );
+        assert!(v.id().starts_with("dlv-"));
+        assert_eq!(v.creator_id(), "creator1");
+        assert_eq!(v.recipient_id(), "");
+        assert_eq!(v.data(), &[10, 20]);
+    }
+
+    #[test]
+    fn create_deterministic_limbo_vault_with_timeout_basic() {
+        let v = create_deterministic_limbo_vault_with_timeout("creator2", vec![30], 999);
+        assert!(v.id().starts_with("dlv-"));
+        assert_eq!(v.creator_id(), "creator2");
+        assert_eq!(v.recipient_id(), "");
+    }
+
+    #[test]
+    fn create_deterministic_limbo_vault_with_timeout_and_recipient_basic() {
+        let v = create_deterministic_limbo_vault_with_timeout_and_recipient(
+            "creator3",
+            "recip3",
+            vec![40],
+            500,
+        );
+        assert!(v.id().starts_with("dlv-"));
+        assert_eq!(v.creator_id(), "creator3");
+        assert_eq!(v.recipient_id(), "recip3");
+    }
+
+    // ───────── VaultPost from LimboVault (proto conversion) ─────────
+
+    #[test]
+    fn vault_post_proto_metadata_sorted() {
+        let mut metadata = HashMap::new();
+        metadata.insert("zebra".to_string(), "z_val".to_string());
+        metadata.insert("alpha".to_string(), "a_val".to_string());
+        metadata.insert("mid".to_string(), "m_val".to_string());
+
+        let post = VaultPost {
+            vault_id: "v1".to_string(),
+            lock_description: "test".to_string(),
+            creator_id: "c1".to_string(),
+            commitment_hash: vec![],
+            status: "unresolved".to_string(),
+            metadata,
+            vault_data: vec![],
+        };
+
+        let proto: crate::types::proto::VaultPostProto = (&post).into();
+        let keys: Vec<&str> = proto.metadata.iter().map(|kv| kv.key.as_str()).collect();
+        assert_eq!(keys, vec!["alpha", "mid", "zebra"]);
+    }
+
+    #[test]
+    fn vault_post_proto_fields_match() {
+        let post = VaultPost {
+            vault_id: "vid".to_string(),
+            lock_description: "lock".to_string(),
+            creator_id: "cid".to_string(),
+            commitment_hash: vec![99],
+            status: "active".to_string(),
+            metadata: HashMap::new(),
+            vault_data: vec![1, 2, 3],
+        };
+
+        let proto: crate::types::proto::VaultPostProto = (&post).into();
+        assert_eq!(proto.vault_id, "vid");
+        assert_eq!(proto.lock_description, "lock");
+        assert_eq!(proto.creator_id, "cid");
+        assert_eq!(proto.commitment_hash, vec![99]);
+        assert_eq!(proto.status, "active");
+        assert_eq!(proto.vault_data, vec![1, 2, 3]);
+    }
+
+    // ───────── LimboVault::new_minimal ─────────
+
+    #[test]
+    fn new_minimal_fields() {
+        let cond = FulfillmentMechanism::CryptoCondition {
+            condition_hash: vec![1],
+            public_params: vec![2],
+        };
+        let ref_hash = [0xAAu8; 32];
+        let v = LimboVault::new_minimal("test-vault".to_string(), cond, ref_hash);
+
+        assert_eq!(v.id, "test-vault");
+        assert_eq!(v.created_at_state, 0);
+        assert!(v.creator_public_key.is_empty());
+        assert!(v.intended_recipient.is_none());
+        assert_eq!(v.state, VaultState::Limbo);
+        assert_eq!(v.content_type, "application/dsm-dbtc-mint");
+        assert!(v.encrypted_content.encapsulated_key.is_empty());
+        assert!(v.encrypted_content.encrypted_data.is_empty());
+        assert!(v.encrypted_content.nonce.is_empty());
+        assert!(v.encrypted_content.aad.is_empty());
+        assert!(v.parameters_hash.is_empty());
+        assert!(v.creator_signature.is_empty());
+        assert!(v.verification_positions.is_empty());
+        assert_eq!(v.reference_state_hash, ref_hash);
+        assert!(v.entry_header.is_none());
+    }
+
+    // ───────── LimboVault::default ─────────
+
+    #[test]
+    fn limbo_vault_default() {
+        let v = LimboVault::default();
+
+        assert!(v.id.is_empty());
+        assert_eq!(v.created_at_state, 0);
+        assert!(v.creator_public_key.is_empty());
+        assert!(v.intended_recipient.is_none());
+        assert_eq!(v.state, VaultState::Limbo);
+        assert_eq!(v.content_type, "application/octet-stream");
+        assert!(v.parameters_hash.is_empty());
+        assert!(v.creator_signature.is_empty());
+        assert!(v.verification_positions.is_empty());
+        assert_eq!(v.reference_state_hash, [0u8; 32]);
+        assert!(v.entry_header.is_none());
+    }
+
+    #[test]
+    fn limbo_vault_default_fulfillment_is_crypto_condition() {
+        let v = LimboVault::default();
+        assert!(matches!(
+            v.fulfillment_condition,
+            FulfillmentMechanism::CryptoCondition { .. }
+        ));
+    }
+
+    // ───────── VaultStatus Display ─────────
+
+    #[test]
+    fn vault_status_display_active() {
+        assert_eq!(format!("{}", VaultStatus::Active), "active");
+    }
+
+    #[test]
+    fn vault_status_display_claimed() {
+        assert_eq!(format!("{}", VaultStatus::Claimed), "claimed");
+    }
+
+    #[test]
+    fn vault_status_display_revoked() {
+        assert_eq!(format!("{}", VaultStatus::Revoked), "revoked");
+    }
+
+    #[test]
+    fn vault_status_display_expired() {
+        assert_eq!(format!("{}", VaultStatus::Expired), "expired");
+    }
+
+    // ───────── to_vault_post lock descriptions ─────────
+
+    fn make_minimal_vault_with_condition(cond: FulfillmentMechanism) -> LimboVault {
+        LimboVault {
+            fulfillment_condition: cond,
+            ..LimboVault::default()
+        }
+    }
+
+    #[test]
+    fn to_vault_post_payment_description() {
+        let v = make_minimal_vault_with_condition(FulfillmentMechanism::Payment {
+            amount: 100,
+            token_id: "DSM".to_string(),
+            recipient: "alice".to_string(),
+            verification_state: vec![],
+        });
+        let post = v.to_vault_post("test", None).unwrap();
+        assert_eq!(post.lock_description, "Payment of 100 DSM to alice");
+        assert_eq!(post.status, "unresolved");
+    }
+
+    #[test]
+    fn to_vault_post_multi_sig_description() {
+        let v = make_minimal_vault_with_condition(FulfillmentMechanism::MultiSignature {
+            public_keys: vec![vec![1], vec![2], vec![3]],
+            threshold: 2,
+        });
+        let post = v.to_vault_post("governance", None).unwrap();
+        assert_eq!(post.lock_description, "Requires 2 of 3 signatures");
+    }
+
+    #[test]
+    fn to_vault_post_crypto_condition_description() {
+        let v = make_minimal_vault_with_condition(FulfillmentMechanism::CryptoCondition {
+            condition_hash: vec![],
+            public_params: vec![],
+        });
+        let post = v.to_vault_post("cond", None).unwrap();
+        assert_eq!(post.lock_description, "Cryptographic condition");
+    }
+
+    #[test]
+    fn to_vault_post_state_reference_description() {
+        let v = make_minimal_vault_with_condition(FulfillmentMechanism::StateReference {
+            reference_states: vec![],
+            parameters: vec![],
+        });
+        let post = v.to_vault_post("ref", None).unwrap();
+        assert_eq!(post.lock_description, "Reference state verification");
+    }
+
+    #[test]
+    fn to_vault_post_random_walk_description() {
+        let v = make_minimal_vault_with_condition(FulfillmentMechanism::RandomWalkVerification {
+            verification_key: vec![],
+            statement: "prove-it".to_string(),
+        });
+        let post = v.to_vault_post("rw", None).unwrap();
+        assert_eq!(post.lock_description, "Random walk verification: prove-it");
+    }
+
+    #[test]
+    fn to_vault_post_bitcoin_htlc_description() {
+        let v = make_minimal_vault_with_condition(FulfillmentMechanism::BitcoinHTLC {
+            hash_lock: [0; 32],
+            refund_hash_lock: [0; 32],
+            refund_iterations: 0,
+            bitcoin_pubkey: vec![],
+            expected_btc_amount_sats: 50_000,
+            network: 0,
+            min_confirmations: 6,
+        });
+        let post = v.to_vault_post("btc", None).unwrap();
+        assert_eq!(post.lock_description, "Bitcoin HTLC vault (50000 sats)");
+    }
+
+    #[test]
+    fn to_vault_post_and_description() {
+        let v = make_minimal_vault_with_condition(FulfillmentMechanism::And(vec![
+            FulfillmentMechanism::CryptoCondition {
+                condition_hash: vec![],
+                public_params: vec![],
+            },
+            FulfillmentMechanism::CryptoCondition {
+                condition_hash: vec![],
+                public_params: vec![],
+            },
+        ]));
+        let post = v.to_vault_post("compound", None).unwrap();
+        assert_eq!(post.lock_description, "All of 2 conditions must be met");
+    }
+
+    #[test]
+    fn to_vault_post_or_description() {
+        let v = make_minimal_vault_with_condition(FulfillmentMechanism::Or(vec![
+            FulfillmentMechanism::CryptoCondition {
+                condition_hash: vec![],
+                public_params: vec![],
+            },
+        ]));
+        let post = v.to_vault_post("compound", None).unwrap();
+        assert_eq!(post.lock_description, "Any of 1 conditions must be met");
+    }
+
+    #[test]
+    fn to_vault_post_with_timeout_metadata() {
+        let v = LimboVault::default();
+        let post = v.to_vault_post("op", Some(3600)).unwrap();
+        assert_eq!(post.metadata.get("purpose").unwrap(), "op");
+        assert_eq!(post.metadata.get("timeout").unwrap(), "3600");
+    }
+
+    #[test]
+    fn to_vault_post_no_timeout_metadata() {
+        let v = LimboVault::default();
+        let post = v.to_vault_post("op", None).unwrap();
+        assert_eq!(post.metadata.get("purpose").unwrap(), "op");
+        assert!(post.metadata.get("timeout").is_none());
+    }
+
+    #[test]
+    fn to_vault_post_status_reflects_vault_state() {
+        let mut v = LimboVault::default();
+        assert_eq!(v.to_vault_post("t", None).unwrap().status, "unresolved");
+
+        v.state = VaultState::Active {
+            activated_state_number: 1,
+        };
+        assert_eq!(v.to_vault_post("t", None).unwrap().status, "active");
+
+        v.state = VaultState::Unlocked {
+            unlocked_state_number: 2,
+            fulfillment_proof: Box::new(FulfillmentProof::CompoundProof(vec![])),
+        };
+        assert_eq!(v.to_vault_post("t", None).unwrap().status, "unlocked");
+
+        v.state = VaultState::Claimed {
+            claimed_state_number: 3,
+            claimant: vec![],
+            claim_proof: vec![],
+        };
+        assert_eq!(v.to_vault_post("t", None).unwrap().status, "claimed");
+
+        v.state = VaultState::Invalidated {
+            invalidated_state_number: 4,
+            reason: "gone".to_string(),
+            creator_signature: vec![],
+        };
+        assert_eq!(v.to_vault_post("t", None).unwrap().status, "invalidated");
+    }
+
+    // ───────── from_limbo_vault status mapping ─────────
+
+    #[test]
+    fn from_limbo_vault_status_mapping() {
+        let cond = VaultCondition::Hash(vec![]);
+
+        let mut v = LimboVault::default();
+        v.state = VaultState::Limbo;
+        let dlv = DeterministicLimboVault::from_limbo_vault(&v, cond.clone()).unwrap();
+        assert_eq!(*dlv.status(), VaultStatus::Active);
+
+        v.state = VaultState::Active {
+            activated_state_number: 1,
+        };
+        let dlv = DeterministicLimboVault::from_limbo_vault(&v, cond.clone()).unwrap();
+        assert_eq!(*dlv.status(), VaultStatus::Active);
+
+        v.state = VaultState::Claimed {
+            claimed_state_number: 2,
+            claimant: vec![],
+            claim_proof: vec![],
+        };
+        let dlv = DeterministicLimboVault::from_limbo_vault(&v, cond.clone()).unwrap();
+        assert_eq!(*dlv.status(), VaultStatus::Claimed);
+
+        v.state = VaultState::Invalidated {
+            invalidated_state_number: 3,
+            reason: "test".to_string(),
+            creator_signature: vec![],
+        };
+        let dlv = DeterministicLimboVault::from_limbo_vault(&v, cond).unwrap();
+        assert_eq!(*dlv.status(), VaultStatus::Revoked);
+    }
+
+    // ───────── EncryptedContent struct ─────────
+
+    #[test]
+    fn encrypted_content_clone() {
+        let ec = EncryptedContent {
+            encapsulated_key: vec![1, 2],
+            encrypted_data: vec![3, 4],
+            nonce: vec![5],
+            aad: vec![6],
+        };
+        let ec2 = ec.clone();
+        assert_eq!(ec.encapsulated_key, ec2.encapsulated_key);
+        assert_eq!(ec.encrypted_data, ec2.encrypted_data);
+        assert_eq!(ec.nonce, ec2.nonce);
+        assert_eq!(ec.aad, ec2.aad);
+    }
 }
 
 /* ------------------- Optional Deterministic Limbo (lightweight) -------------- */

--- a/dsm_client/deterministic_state_machine/dsm/src/vault/limbo_vault.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/vault/limbo_vault.rs
@@ -2670,7 +2670,7 @@ mod tests {
         let v = LimboVault::default();
         let post = v.to_vault_post("op", None).unwrap();
         assert_eq!(post.metadata.get("purpose").unwrap(), "op");
-        assert!(post.metadata.get("timeout").is_none());
+        assert!(!post.metadata.contains_key("timeout"));
     }
 
     #[test]
@@ -2710,8 +2710,10 @@ mod tests {
     fn from_limbo_vault_status_mapping() {
         let cond = VaultCondition::Hash(vec![]);
 
-        let mut v = LimboVault::default();
-        v.state = VaultState::Limbo;
+        let mut v = LimboVault {
+            state: VaultState::Limbo,
+            ..Default::default()
+        };
         let dlv = DeterministicLimboVault::from_limbo_vault(&v, cond.clone()).unwrap();
         assert_eq!(*dlv.status(), VaultStatus::Active);
 

--- a/dsm_client/deterministic_state_machine/dsm/tests/dsm_end_to_end_test.rs
+++ b/dsm_client/deterministic_state_machine/dsm/tests/dsm_end_to_end_test.rs
@@ -230,8 +230,8 @@ fn create_next_state(
 }
 
 #[test]
-#[ignore] // Skip due to batch manager access issues
 fn test_random_walk_verification() -> Result<(), DsmError> {
+    // Pre-commitment random-walk positions via StateMachine (no external batch service).
     // This test focuses solely on random walk verification which appears to be working correctly
     // initialize() removed; core has no global init.
 


### PR DESCRIPTION
## Summary

This PR adds broad unit-test coverage across the DSM core crate, including canonical encoding, error handling, security, verification, state-machine behavior, token flows, emissions, serialization, and vault logic.

## What Changed

- adds tests for common encoding and domain-tag behavior
- adds coverage for core error types and unified error surfaces
- adds tests for bilateral control, manipulation resistance, and verification flows
- adds coverage for checkpoint, bilateral, token, policy, and registry logic
- adds tests for serialization, telemetry, identifiers, operations, and state builders
- adds vault and fulfillment coverage, including limbo-vault behavior
- includes a minimal end-to-end test adjustment

## Why

Core DSM logic spans a large number of deterministic and security-sensitive paths. This PR raises confidence in those paths with direct unit coverage, reducing the risk that changes in policy, state, serialization, or vault code regress behavior silently.

## Reviewer Focus

- error and type-heavy files where coverage additions are large
- bilateral and checkpoint state-machine behavior
- token and policy logic
- vault flows, especially limbo-vault coverage
- any production code touched only to make tests possible

## Validation

- branch adds coverage across 49 files
- majority of changes are new tests embedded alongside the covered modules
- net effect is a large increase in core crate unit coverage