### PR TITLE
test(android): add JVM unit coverage for bridge, BLE, and security

### DIFF
--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/BridgeEncodingTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/BridgeEncodingTest.kt
@@ -1,0 +1,149 @@
+package com.dsm.wallet.bridge
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class BridgeEncodingTest {
+
+    // ── base32CrockfordEncode ──────────────────────────────────────────────
+
+    @Test
+    fun encode_emptyByteArray_returnsEmptyString() {
+        assertEquals("", BridgeEncoding.base32CrockfordEncode(byteArrayOf()))
+    }
+
+    @Test
+    fun encode_singleByte_zero() {
+        // 0x00 → 00000 000(pad) → "00"
+        assertEquals("00", BridgeEncoding.base32CrockfordEncode(byteArrayOf(0)))
+    }
+
+    @Test
+    fun encode_singleByte_0xFF() {
+        // 0xFF = 11111111 → 11111 111(pad 00) → 31,28 → "ZW"
+        assertEquals("ZW", BridgeEncoding.base32CrockfordEncode(byteArrayOf(0xFF.toByte())))
+    }
+
+    @Test
+    fun encode_helloBytes() {
+        val input = "Hello".toByteArray(Charsets.US_ASCII)
+        val encoded = BridgeEncoding.base32CrockfordEncode(input)
+        // Round-trip check: decode must reproduce input
+        assertArrayEquals(input, BridgeEncoding.base32CrockfordDecode(encoded))
+    }
+
+    @Test
+    fun encode_fiveByteAlignedInput() {
+        // 5 bytes = 40 bits, divisible by 5 → no padding bits
+        val input = byteArrayOf(0x48, 0x65, 0x6C, 0x6C, 0x6F) // "Hello"
+        val encoded = BridgeEncoding.base32CrockfordEncode(input)
+        assertEquals(8, encoded.length) // 40 bits / 5 = 8 chars
+    }
+
+    @Test
+    fun encode_usesOnlyCrockfordAlphabet() {
+        val crockfordChars = "0123456789ABCDEFGHJKMNPQRSTVWXYZ".toSet()
+        val input = ByteArray(256) { it.toByte() }
+        val encoded = BridgeEncoding.base32CrockfordEncode(input)
+        for (c in encoded) {
+            assert(c in crockfordChars) { "Unexpected char '$c' in encoded output" }
+        }
+    }
+
+    @Test
+    fun encode_excludesConfusableLetters() {
+        val input = ByteArray(256) { it.toByte() }
+        val encoded = BridgeEncoding.base32CrockfordEncode(input)
+        // Crockford base32 excludes I, L, O, U
+        assert('I' !in encoded)
+        assert('L' !in encoded)
+        assert('O' !in encoded)
+        assert('U' !in encoded)
+    }
+
+    // ── base32CrockfordDecode ──────────────────────────────────────────────
+
+    @Test
+    fun decode_emptyString_returnsEmptyArray() {
+        assertArrayEquals(byteArrayOf(), BridgeEncoding.base32CrockfordDecode(""))
+    }
+
+    @Test
+    fun decode_caseInsensitive() {
+        val upper = BridgeEncoding.base32CrockfordDecode("ABCD")
+        val lower = BridgeEncoding.base32CrockfordDecode("abcd")
+        assertArrayEquals(upper, lower)
+    }
+
+    @Test
+    fun decode_skipsInvalidCharacters() {
+        // Characters outside the lookup table (e.g. spaces, punctuation) are ignored
+        val clean = BridgeEncoding.base32CrockfordDecode("91")
+        val withGarbage = BridgeEncoding.base32CrockfordDecode("9 -!1")
+        assertArrayEquals(clean, withGarbage)
+    }
+
+    @Test
+    fun decode_highAsciiCharsIgnored() {
+        // Chars with code >= 128 are outside lookup bounds and skipped
+        val normal = BridgeEncoding.base32CrockfordDecode("AA")
+        val withUnicode = BridgeEncoding.base32CrockfordDecode("A\u00FFA")
+        assertArrayEquals(normal, withUnicode)
+    }
+
+    // ── Round-trip ─────────────────────────────────────────────────────────
+
+    @Test
+    fun roundTrip_allSingleBytes() {
+        for (b in 0..255) {
+            val input = byteArrayOf(b.toByte())
+            val encoded = BridgeEncoding.base32CrockfordEncode(input)
+            val decoded = BridgeEncoding.base32CrockfordDecode(encoded)
+            assertArrayEquals("Round-trip failed for byte $b", input, decoded)
+        }
+    }
+
+    @Test
+    fun roundTrip_variousLengths() {
+        for (len in 0..20) {
+            val input = ByteArray(len) { (it * 37 + 13).toByte() }
+            val encoded = BridgeEncoding.base32CrockfordEncode(input)
+            val decoded = BridgeEncoding.base32CrockfordDecode(encoded)
+            assertArrayEquals("Round-trip failed for length $len", input, decoded)
+        }
+    }
+
+    @Test
+    fun roundTrip_32Bytes_typicalDeviceId() {
+        val deviceId = ByteArray(32) { (it * 7 + 0xAB).toByte() }
+        val encoded = BridgeEncoding.base32CrockfordEncode(deviceId)
+        val decoded = BridgeEncoding.base32CrockfordDecode(encoded)
+        assertArrayEquals(deviceId, decoded)
+    }
+
+    @Test
+    fun roundTrip_largePayload() {
+        val payload = ByteArray(1024) { (it xor 0x5A).toByte() }
+        val decoded = BridgeEncoding.base32CrockfordDecode(
+            BridgeEncoding.base32CrockfordEncode(payload)
+        )
+        assertArrayEquals(payload, decoded)
+    }
+
+    // ── Encoding length ───────────────────────────────────────────────────
+
+    @Test
+    fun encode_outputLengthIsCorrect() {
+        // ceil(n * 8 / 5) characters
+        for (n in 0..20) {
+            val input = ByteArray(n) { 0x42 }
+            val encoded = BridgeEncoding.base32CrockfordEncode(input)
+            val expectedLen = if (n == 0) 0 else ((n * 8) + 4) / 5
+            assertEquals("Wrong encoded length for $n bytes", expectedLen, encoded.length)
+        }
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/BridgeEnvelopeCodecTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/BridgeEnvelopeCodecTest.kt
@@ -1,0 +1,587 @@
+package com.dsm.wallet.bridge
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+@RunWith(JUnit4::class)
+class BridgeEnvelopeCodecTest {
+
+    // ── Protobuf wire-format helpers ───────────────────────────────────────
+
+    private fun encodeVarint(valueIn: Int): ByteArray {
+        var v = valueIn
+        val out = mutableListOf<Byte>()
+        while (true) {
+            if (v and 0x7F.inv() == 0) {
+                out.add(v.toByte())
+                break
+            } else {
+                out.add(((v and 0x7F) or 0x80).toByte())
+                v = v ushr 7
+            }
+        }
+        return out.toByteArray()
+    }
+
+    private fun encodeLenField(fieldNumber: Int, value: ByteArray): ByteArray {
+        val tag = (fieldNumber shl 3) or 2
+        return encodeVarint(tag) + encodeVarint(value.size) + value
+    }
+
+    private fun encodeVarintField(fieldNumber: Int, value: Int): ByteArray {
+        val tag = (fieldNumber shl 3) or 0
+        return encodeVarint(tag) + encodeVarint(value)
+    }
+
+    private fun encodeFixed64Field(fieldNumber: Int, value: Long): ByteArray {
+        val tag = (fieldNumber shl 3) or 1
+        val buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array()
+        return encodeVarint(tag) + buf
+    }
+
+    private fun encodeFixed32Field(fieldNumber: Int, value: Int): ByteArray {
+        val tag = (fieldNumber shl 3) or 5
+        val buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).array()
+        return encodeVarint(tag) + buf
+    }
+
+    private fun makeRequest(
+        method: String,
+        payloadFieldNumber: Int? = null,
+        payloadBytes: ByteArray? = null
+    ): ByteArray {
+        val methodField = encodeLenField(1, method.toByteArray(Charsets.UTF_8))
+        return if (payloadFieldNumber != null && payloadBytes != null) {
+            methodField + encodeLenField(payloadFieldNumber, payloadBytes)
+        } else {
+            methodField
+        }
+    }
+
+    // ── parseBridgeRequest: happy paths ────────────────────────────────────
+
+    @Test
+    fun parseBridgeRequest_methodOnly() {
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("hello"))
+        assertEquals("hello", req.method)
+        assertEquals(0, req.payload.size)
+    }
+
+    @Test
+    fun parseBridgeRequest_methodWithDots() {
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("app.router.call"))
+        assertEquals("app.router.call", req.method)
+    }
+
+    @Test
+    fun parseBridgeRequest_methodWithUnderscoresAndHyphens() {
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("get_status-v2"))
+        assertEquals("get_status-v2", req.method)
+    }
+
+    @Test
+    fun parseBridgeRequest_methodExactly128Bytes() {
+        val method128 = "a".repeat(128)
+        val bytes = encodeLenField(1, method128.toByteArray(Charsets.UTF_8))
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(bytes)
+        assertEquals(method128, req.method)
+    }
+
+    @Test
+    fun parseBridgeRequest_emptyInput_defaultValues() {
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(ByteArray(0))
+        assertEquals("", req.method)
+        assertEquals(0, req.payload.size)
+    }
+
+    @Test
+    fun parseBridgeRequest_emptyPayloadType() {
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("test", 2, ByteArray(0)))
+        assertEquals("test", req.method)
+        assertEquals(0, req.payload.size)
+    }
+
+    @Test
+    fun parseBridgeRequest_bytesPayload() {
+        val innerData = byteArrayOf(0x01, 0x02, 0x03)
+        val innerProto = encodeLenField(1, innerData)
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("getData", 3, innerProto))
+        assertEquals("getData", req.method)
+        assertArrayEquals(innerData, req.payload)
+    }
+
+    @Test
+    fun parseBridgeRequest_stringPayload() {
+        val innerStr = "hello world".toByteArray(Charsets.UTF_8)
+        val innerProto = encodeLenField(1, innerStr)
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("getString", 4, innerProto))
+        assertEquals("getString", req.method)
+        assertArrayEquals(innerStr, req.payload)
+    }
+
+    @Test
+    fun parseBridgeRequest_preferencePayloadPassthrough() {
+        val prefProto = encodeLenField(1, "theme".toByteArray()) +
+            encodeLenField(2, "dark".toByteArray())
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("setPref", 5, prefProto))
+        assertArrayEquals(prefProto, req.payload)
+    }
+
+    @Test
+    fun parseBridgeRequest_appRouterPayloadPassthrough() {
+        val routerProto = encodeLenField(1, "doThing".toByteArray()) +
+            encodeLenField(2, byteArrayOf(0x42))
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("route", 6, routerProto))
+        assertArrayEquals(routerProto, req.payload)
+    }
+
+    @Test
+    fun parseBridgeRequest_singleBytesPayloadField8() {
+        val innerData = byteArrayOf(0xAA.toByte(), 0xBB.toByte())
+        val innerProto = encodeLenField(1, innerData)
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("f8", 8, innerProto))
+        assertArrayEquals(innerData, req.payload)
+    }
+
+    @Test
+    fun parseBridgeRequest_singleBytesPayloadField9() {
+        val innerData = byteArrayOf(0xCC.toByte())
+        val innerProto = encodeLenField(1, innerData)
+        val req = BridgeEnvelopeCodec.parseBridgeRequest(makeRequest("f9", 9, innerProto))
+        assertArrayEquals(innerData, req.payload)
+    }
+
+    // ── parseBridgeRequest: unknown field skipping ─────────────────────────
+
+    @Test
+    fun parseBridgeRequest_unknownVarintFieldSkipped() {
+        val bytes = makeRequest("test") + encodeVarintField(99, 999)
+        assertEquals("test", BridgeEnvelopeCodec.parseBridgeRequest(bytes).method)
+    }
+
+    @Test
+    fun parseBridgeRequest_unknownLenFieldSkipped() {
+        val bytes = makeRequest("test") + encodeLenField(50, byteArrayOf(0x01, 0x02))
+        assertEquals("test", BridgeEnvelopeCodec.parseBridgeRequest(bytes).method)
+    }
+
+    @Test
+    fun parseBridgeRequest_unknownFixed64FieldSkipped() {
+        val bytes = makeRequest("test") + encodeFixed64Field(55, 0x1234567890ABCDEFL)
+        assertEquals("test", BridgeEnvelopeCodec.parseBridgeRequest(bytes).method)
+    }
+
+    @Test
+    fun parseBridgeRequest_unknownFixed32FieldSkipped() {
+        val bytes = makeRequest("test") + encodeFixed32Field(55, 0x12345678)
+        assertEquals("test", BridgeEnvelopeCodec.parseBridgeRequest(bytes).method)
+    }
+
+    // ── parseBridgeRequest: error cases ────────────────────────────────────
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_methodTooLong() {
+        val longMethod = "a".repeat(129)
+        BridgeEnvelopeCodec.parseBridgeRequest(
+            encodeLenField(1, longMethod.toByteArray(Charsets.UTF_8))
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_methodEmpty() {
+        BridgeEnvelopeCodec.parseBridgeRequest(encodeLenField(1, ByteArray(0)))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_methodInvalidChars() {
+        BridgeEnvelopeCodec.parseBridgeRequest(
+            encodeLenField(1, "hello world".toByteArray(Charsets.UTF_8))
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_methodWrongWireType() {
+        BridgeEnvelopeCodec.parseBridgeRequest(encodeVarintField(1, 42))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_payloadWrongWireType() {
+        val bytes = encodeLenField(1, "test".toByteArray()) + encodeVarintField(5, 42)
+        BridgeEnvelopeCodec.parseBridgeRequest(bytes)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_duplicatePayloads() {
+        val methodField = encodeLenField(1, "test".toByteArray())
+        val payload1 = encodeLenField(3, encodeLenField(1, byteArrayOf(1)))
+        val payload2 = encodeLenField(4, encodeLenField(1, byteArrayOf(2)))
+        BridgeEnvelopeCodec.parseBridgeRequest(methodField + payload1 + payload2)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_truncatedVarint() {
+        BridgeEnvelopeCodec.parseBridgeRequest(byteArrayOf(0x80.toByte()))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_truncatedLengthDelimited() {
+        BridgeEnvelopeCodec.parseBridgeRequest(byteArrayOf(0x0A, 0x0A, 0x41, 0x42))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_varintTooLong() {
+        val bytes = ByteArray(11) { 0x80.toByte() }.also { it[10] = 0x01 }
+        BridgeEnvelopeCodec.parseBridgeRequest(bytes)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseBridgeRequest_unsupportedWireType3() {
+        val tag = (99 shl 3) or 3 // start-group, not supported by skipField
+        BridgeEnvelopeCodec.parseBridgeRequest(encodeVarint(tag))
+    }
+
+    // ── decodeBridgeRpcError ──────────────────────────────────────────────
+
+    @Test
+    fun decodeBridgeRpcError_allFields() {
+        val bytes = encodeVarintField(1, 404) +
+            encodeLenField(2, "not found".toByteArray()) +
+            encodeLenField(3, "ABC123".toByteArray())
+        val err = BridgeEnvelopeCodec.decodeBridgeRpcError(bytes)!!
+        assertEquals(404, err.errorCode)
+        assertEquals("not found", err.message)
+        assertEquals("ABC123", err.debugB32)
+    }
+
+    @Test
+    fun decodeBridgeRpcError_codeOnly() {
+        val err = BridgeEnvelopeCodec.decodeBridgeRpcError(encodeVarintField(1, 500))!!
+        assertEquals(500, err.errorCode)
+        assertEquals("", err.message)
+        assertNull(err.debugB32)
+    }
+
+    @Test
+    fun decodeBridgeRpcError_messageOnly() {
+        val err = BridgeEnvelopeCodec.decodeBridgeRpcError(
+            encodeLenField(2, "server error".toByteArray())
+        )!!
+        assertEquals(0, err.errorCode)
+        assertEquals("server error", err.message)
+    }
+
+    @Test
+    fun decodeBridgeRpcError_debugOnly() {
+        val err = BridgeEnvelopeCodec.decodeBridgeRpcError(
+            encodeLenField(3, "DEBUG".toByteArray())
+        )!!
+        assertEquals("DEBUG", err.debugB32)
+    }
+
+    @Test
+    fun decodeBridgeRpcError_emptyInput_returnsNull() {
+        assertNull(BridgeEnvelopeCodec.decodeBridgeRpcError(ByteArray(0)))
+    }
+
+    @Test
+    fun decodeBridgeRpcError_allDefaultValues_returnsNull() {
+        assertNull(BridgeEnvelopeCodec.decodeBridgeRpcError(encodeVarintField(1, 0)))
+    }
+
+    @Test
+    fun decodeBridgeRpcError_wrongWireTypeForCode_returnsNull() {
+        assertNull(BridgeEnvelopeCodec.decodeBridgeRpcError(encodeLenField(1, byteArrayOf(1))))
+    }
+
+    @Test
+    fun decodeBridgeRpcError_wrongWireTypeForMessage_returnsNull() {
+        val bytes = encodeVarintField(1, 1) + encodeVarintField(2, 42)
+        assertNull(BridgeEnvelopeCodec.decodeBridgeRpcError(bytes))
+    }
+
+    @Test
+    fun decodeBridgeRpcError_unknownFieldsSkipped() {
+        val bytes = encodeVarintField(1, 1) +
+            encodeLenField(2, "err".toByteArray()) +
+            encodeVarintField(99, 42)
+        val err = BridgeEnvelopeCodec.decodeBridgeRpcError(bytes)!!
+        assertEquals(1, err.errorCode)
+        assertEquals("err", err.message)
+    }
+
+    // ── parseEnvelopeResponse ─────────────────────────────────────────────
+
+    @Test
+    fun parseEnvelopeResponse_success() {
+        val data = byteArrayOf(0x0A, 0x0B, 0x0C)
+        val (isSuccess, payload) = BridgeEnvelopeCodec.parseEnvelopeResponse(
+            BridgeEnvelopeCodec.createSuccessResponse(data)
+        )
+        assertTrue(isSuccess)
+        assertArrayEquals(data, payload)
+    }
+
+    @Test
+    fun parseEnvelopeResponse_successEmptyData() {
+        val (isSuccess, payload) = BridgeEnvelopeCodec.parseEnvelopeResponse(
+            BridgeEnvelopeCodec.createSuccessResponse(ByteArray(0))
+        )
+        assertTrue(isSuccess)
+        assertEquals(0, payload.size)
+    }
+
+    @Test
+    fun parseEnvelopeResponse_error() {
+        val (isSuccess, _) = BridgeEnvelopeCodec.parseEnvelopeResponse(
+            BridgeEnvelopeCodec.createErrorResponse(500, "fail") { "" }
+        )
+        assertFalse(isSuccess)
+    }
+
+    @Test
+    fun parseEnvelopeResponse_errorRoundTrip() {
+        val responseBytes = BridgeEnvelopeCodec.createErrorResponse(404, "not found") {
+            BridgeEncoding.base32CrockfordEncode(it)
+        }
+        val (isSuccess, errorPayload) = BridgeEnvelopeCodec.parseEnvelopeResponse(responseBytes)
+        assertFalse(isSuccess)
+
+        val err = BridgeEnvelopeCodec.decodeBridgeRpcError(errorPayload)!!
+        assertEquals(404, err.errorCode)
+        assertEquals("not found", err.message)
+        assertNotNull(err.debugB32)
+        assertTrue(err.debugB32!!.isNotEmpty())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseEnvelopeResponse_missingResult() {
+        BridgeEnvelopeCodec.parseEnvelopeResponse(ByteArray(0))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseEnvelopeResponse_multipleResults() {
+        val successInner = encodeLenField(1, byteArrayOf(0x01))
+        val success = encodeLenField(1, successInner)
+        val error = encodeLenField(2, byteArrayOf(0x08, 0x01))
+        BridgeEnvelopeCodec.parseEnvelopeResponse(success + error)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun parseEnvelopeResponse_successWrongWireType() {
+        BridgeEnvelopeCodec.parseEnvelopeResponse(encodeVarintField(1, 42))
+    }
+
+    @Test
+    fun parseEnvelopeResponse_unknownFieldsSkipped() {
+        val data = byteArrayOf(0x0A, 0x0B)
+        val responseBytes = BridgeEnvelopeCodec.createSuccessResponse(data) +
+            encodeVarintField(99, 42)
+        val (isSuccess, payload) = BridgeEnvelopeCodec.parseEnvelopeResponse(responseBytes)
+        assertTrue(isSuccess)
+        assertArrayEquals(data, payload)
+    }
+
+    // ── createSuccessResponse / createErrorResponse ──────────────────────
+
+    @Test
+    fun createSuccessResponse_largePayloadRoundTrip() {
+        val data = ByteArray(10_000) { (it % 256).toByte() }
+        val (isSuccess, payload) = BridgeEnvelopeCodec.parseEnvelopeResponse(
+            BridgeEnvelopeCodec.createSuccessResponse(data)
+        )
+        assertTrue(isSuccess)
+        assertArrayEquals(data, payload)
+    }
+
+    @Test
+    fun createErrorResponse_debugEncoderIsCalled() {
+        var debugInput: ByteArray? = null
+        BridgeEnvelopeCodec.createErrorResponse(1, "test") { bytes ->
+            debugInput = bytes
+            "encoded"
+        }
+        assertNotNull(debugInput)
+        assertTrue(debugInput!!.isNotEmpty())
+    }
+
+    @Test
+    fun createErrorResponse_debugEncoderThrows_emptyDebug() {
+        val response = BridgeEnvelopeCodec.createErrorResponse(1, "test") {
+            throw RuntimeException("encoder broke")
+        }
+        val (isSuccess, errorPayload) = BridgeEnvelopeCodec.parseEnvelopeResponse(response)
+        assertFalse(isSuccess)
+        val err = BridgeEnvelopeCodec.decodeBridgeRpcError(errorPayload)!!
+        assertEquals("", err.debugB32)
+    }
+
+    // ── encodeAppRouterPayload / decodeAppRouterPayload ──────────────────
+
+    @Test
+    fun appRouterPayload_roundTrip() {
+        val args = byteArrayOf(0x01, 0x02, 0x03)
+        val decoded = BridgeEnvelopeCodec.decodeAppRouterPayload(
+            BridgeEnvelopeCodec.encodeAppRouterPayload("doSomething", args)
+        )!!
+        assertEquals("doSomething", decoded.methodName)
+        assertArrayEquals(args, decoded.args)
+    }
+
+    @Test
+    fun appRouterPayload_emptyArgs() {
+        val decoded = BridgeEnvelopeCodec.decodeAppRouterPayload(
+            BridgeEnvelopeCodec.encodeAppRouterPayload("ping", ByteArray(0))
+        )!!
+        assertEquals("ping", decoded.methodName)
+        assertEquals(0, decoded.args.size)
+    }
+
+    @Test
+    fun decodeAppRouterPayload_blankMethodName_returnsNull() {
+        val encoded = encodeLenField(1, "   ".toByteArray()) + encodeLenField(2, byteArrayOf(1))
+        assertNull(BridgeEnvelopeCodec.decodeAppRouterPayload(encoded))
+    }
+
+    @Test
+    fun decodeAppRouterPayload_emptyInput_returnsNull() {
+        assertNull(BridgeEnvelopeCodec.decodeAppRouterPayload(ByteArray(0)))
+    }
+
+    @Test
+    fun decodeAppRouterPayload_wrongWireType_returnsNull() {
+        assertNull(BridgeEnvelopeCodec.decodeAppRouterPayload(encodeVarintField(1, 42)))
+    }
+
+    @Test
+    fun decodeAppRouterPayload_unknownFieldsSkipped() {
+        val encoded = BridgeEnvelopeCodec.encodeAppRouterPayload("test", byteArrayOf(0x42)) +
+            encodeVarintField(99, 42)
+        assertEquals("test", BridgeEnvelopeCodec.decodeAppRouterPayload(encoded)!!.methodName)
+    }
+
+    // ── decodePreferencePayload ──────────────────────────────────────────
+
+    @Test
+    fun decodePreferencePayload_keyAndValue() {
+        val bytes = encodeLenField(1, "theme".toByteArray()) +
+            encodeLenField(2, "dark".toByteArray())
+        val pref = BridgeEnvelopeCodec.decodePreferencePayload(bytes)!!
+        assertEquals("theme", pref.key)
+        assertEquals("dark", pref.value)
+    }
+
+    @Test
+    fun decodePreferencePayload_keyOnly() {
+        val pref = BridgeEnvelopeCodec.decodePreferencePayload(
+            encodeLenField(1, "theme".toByteArray())
+        )!!
+        assertEquals("theme", pref.key)
+        assertNull(pref.value)
+    }
+
+    @Test
+    fun decodePreferencePayload_blankKey_returnsNull() {
+        assertNull(
+            BridgeEnvelopeCodec.decodePreferencePayload(encodeLenField(1, "   ".toByteArray()))
+        )
+    }
+
+    @Test
+    fun decodePreferencePayload_emptyInput_returnsNull() {
+        assertNull(BridgeEnvelopeCodec.decodePreferencePayload(ByteArray(0)))
+    }
+
+    // ── decodeBilateralPayload ───────────────────────────────────────────
+
+    @Test
+    fun decodeBilateralPayload_commitmentAndReason() {
+        val commitment = ByteArray(32) { (it * 7).toByte() }
+        val bytes = encodeLenField(1, commitment) +
+            encodeLenField(2, "reason text".toByteArray())
+        val req = BridgeEnvelopeCodec.decodeBilateralPayload(bytes)!!
+        assertArrayEquals(commitment, req.commitment)
+        assertEquals("reason text", req.reason)
+    }
+
+    @Test
+    fun decodeBilateralPayload_commitmentOnly() {
+        val commitment = ByteArray(32) { 0xFF.toByte() }
+        val req = BridgeEnvelopeCodec.decodeBilateralPayload(encodeLenField(1, commitment))!!
+        assertArrayEquals(commitment, req.commitment)
+        assertNull(req.reason)
+    }
+
+    @Test
+    fun decodeBilateralPayload_wrongCommitmentSize_returnsNull() {
+        assertNull(
+            BridgeEnvelopeCodec.decodeBilateralPayload(encodeLenField(1, ByteArray(16) { 1 }))
+        )
+    }
+
+    @Test
+    fun decodeBilateralPayload_emptyInput_returnsNull() {
+        assertNull(BridgeEnvelopeCodec.decodeBilateralPayload(ByteArray(0)))
+    }
+
+    // ── extractDeterministicSafetyMessageFromEnvelope ─────────────────────
+
+    @Test
+    fun extractSafetyMessage_emptyEnvelope_returnsNull() {
+        assertNull(
+            BridgeEnvelopeCodec.extractDeterministicSafetyMessageFromEnvelope(ByteArray(0))
+        )
+    }
+
+    @Test
+    fun extractSafetyMessage_noErrorInfo_returnsNull() {
+        assertNull(
+            BridgeEnvelopeCodec.extractDeterministicSafetyMessageFromEnvelope(
+                encodeVarintField(1, 42)
+            )
+        )
+    }
+
+    @Test
+    fun extractSafetyMessage_field99_sourceTag11_returnsMessage() {
+        val errorInfo = encodeLenField(2, "safety violation".toByteArray()) +
+            encodeVarintField(4, 11)
+        val envelope = encodeLenField(99, errorInfo)
+        assertEquals(
+            "safety violation",
+            BridgeEnvelopeCodec.extractDeterministicSafetyMessageFromEnvelope(envelope)
+        )
+    }
+
+    @Test
+    fun extractSafetyMessage_field99_differentSourceTag_returnsNull() {
+        val errorInfo = encodeLenField(2, "other error".toByteArray()) +
+            encodeVarintField(4, 5)
+        assertNull(
+            BridgeEnvelopeCodec.extractDeterministicSafetyMessageFromEnvelope(
+                encodeLenField(99, errorInfo)
+            )
+        )
+    }
+
+    @Test
+    fun extractSafetyMessage_field11_nestedPath_returnsMessage() {
+        val errorInfo = encodeLenField(2, "deep error".toByteArray()) +
+            encodeVarintField(4, 11)
+        val opResult = encodeLenField(5, errorInfo)
+        val universalRx = encodeLenField(1, opResult)
+        val envelope = encodeLenField(11, universalRx)
+        assertEquals(
+            "deep error",
+            BridgeEnvelopeCodec.extractDeterministicSafetyMessageFromEnvelope(envelope)
+        )
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/BridgeLoggerTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/BridgeLoggerTest.kt
@@ -1,0 +1,131 @@
+package com.dsm.wallet.bridge
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Tests for [BridgeLogger] file I/O and log formatting.
+ *
+ * Uses Robolectric because appendLine calls SystemClock.elapsedRealtime()
+ * and logBridgeCall calls android.util.Log in debug builds.
+ *
+ * Note: BridgeLogger is a singleton. Each test sets its own temp file via
+ * setLogFile, but we cannot reset logFile to null through the public API.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class BridgeLoggerTest {
+
+    private lateinit var tempFile: File
+
+    @Before
+    fun setUp() {
+        tempFile = File.createTempFile("bridge_log_test_", ".log")
+        tempFile.deleteOnExit()
+        BridgeLogger.setLogFile(tempFile)
+    }
+
+    @After
+    fun tearDown() {
+        tempFile.delete()
+    }
+
+    // ── readLogBytes ──────────────────────────────────────────────────────
+
+    @Test
+    fun readLogBytes_nonExistentFile_returnsEmpty() {
+        val missing = File(tempFile.parent, "does_not_exist.log")
+        BridgeLogger.setLogFile(missing)
+        assertEquals(0, BridgeLogger.readLogBytes().size)
+        BridgeLogger.setLogFile(tempFile)
+    }
+
+    @Test
+    fun readLogBytes_emptyFile_returnsEmpty() {
+        assertEquals(0, BridgeLogger.readLogBytes().size)
+    }
+
+    @Test
+    fun readLogBytes_readsWrittenContent() {
+        tempFile.writeText("hello\n")
+        val bytes = BridgeLogger.readLogBytes()
+        assertEquals("hello\n", String(bytes, Charsets.UTF_8))
+    }
+
+    @Test
+    fun readLogBytes_maxBytesTruncation() {
+        tempFile.writeBytes(ByteArray(200) { 0x41 })
+        val bytes = BridgeLogger.readLogBytes(maxBytes = 50)
+        assertEquals(50, bytes.size)
+        assertTrue("Should read from end of file", bytes.all { it == 0x41.toByte() })
+    }
+
+    // ── logBridgeCall round-trip ──────────────────────────────────────────
+
+    @Test
+    fun logBridgeCall_writesMethodToFile() {
+        BridgeLogger.logBridgeCall(
+            method = "testMethod",
+            payload = byteArrayOf(0x01, 0x02),
+            response = byteArrayOf(0x03),
+            error = null
+        )
+        val content = String(BridgeLogger.readLogBytes(), Charsets.UTF_8)
+        assertTrue("Log should contain method name", content.contains("testMethod"))
+        assertTrue("Log should contain BRIDGE prefix", content.contains("BRIDGE:"))
+    }
+
+    @Test
+    fun logBridgeCall_shortPayload_notTruncated() {
+        val payload = byteArrayOf(0x01, 0x02, 0x03)
+        val b32 = BridgeEncoding.base32CrockfordEncode(payload)
+        BridgeLogger.logBridgeCall("m", payload, null, null)
+        val content = String(BridgeLogger.readLogBytes(), Charsets.UTF_8)
+        assertTrue("Short payload b32 should appear in full", content.contains(b32))
+    }
+
+    @Test
+    fun logBridgeCall_longPayload_truncated() {
+        val payload = ByteArray(100) { it.toByte() }
+        BridgeLogger.logBridgeCall("m", payload, null, null)
+        val content = String(BridgeLogger.readLogBytes(), Charsets.UTF_8)
+        assertTrue("Long payload should be truncated with ...", content.contains("..."))
+    }
+
+    @Test
+    fun logBridgeCall_error_showsErrorMessage() {
+        BridgeLogger.logBridgeCall(
+            method = "failing",
+            payload = ByteArray(0),
+            response = null,
+            error = RuntimeException("boom")
+        )
+        val content = String(BridgeLogger.readLogBytes(), Charsets.UTF_8)
+        assertTrue("Error message should appear", content.contains("boom"))
+    }
+
+    // ── logDiagnosticsPayload ─────────────────────────────────────────────
+
+    @Test
+    fun logDiagnosticsPayload_writesToFile() {
+        BridgeLogger.logDiagnosticsPayload(byteArrayOf(0x01, 0x02))
+        val content = String(BridgeLogger.readLogBytes(), Charsets.UTF_8)
+        assertTrue(content.contains("DIAGNOSTICS:"))
+        assertTrue(content.contains("payload=2b"))
+    }
+
+    @Test
+    fun logDiagnosticsPayload_longPayload_truncated() {
+        val payload = ByteArray(100) { it.toByte() }
+        BridgeLogger.logDiagnosticsPayload(payload)
+        val content = String(BridgeLogger.readLogBytes(), Charsets.UTF_8)
+        assertTrue(content.contains("..."))
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleConstantsTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleConstantsTest.kt
@@ -1,0 +1,203 @@
+package com.dsm.wallet.bridge.ble
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.UUID
+
+@RunWith(JUnit4::class)
+class BleConstantsTest {
+
+    // ── UUID validity ──────────────────────────────────────────────────────
+
+    @Test
+    fun serviceUuid_isNotNull() {
+        assertTrue(BleConstants.DSM_SERVICE_UUID_V2 is UUID)
+    }
+
+    @Test
+    fun characteristicUuids_areDistinct() {
+        val uuids = listOf(
+            BleConstants.TX_REQUEST_UUID,
+            BleConstants.TX_RESPONSE_UUID,
+            BleConstants.IDENTITY_UUID,
+            BleConstants.PAIRING_UUID,
+            BleConstants.PAIRING_ACK_UUID,
+        )
+        assertEquals(uuids.size, uuids.toSet().size)
+    }
+
+    @Test
+    fun characteristicUuids_differFromServiceUuid() {
+        val chars = listOf(
+            BleConstants.TX_REQUEST_UUID,
+            BleConstants.TX_RESPONSE_UUID,
+            BleConstants.IDENTITY_UUID,
+            BleConstants.PAIRING_UUID,
+            BleConstants.PAIRING_ACK_UUID,
+        )
+        for (c in chars) {
+            assertNotEquals(BleConstants.DSM_SERVICE_UUID_V2, c)
+        }
+    }
+
+    @Test
+    fun cccdUuid_isStandardBluetooth() {
+        assertEquals(
+            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"),
+            BleConstants.CCCD_UUID
+        )
+    }
+
+    @Test
+    fun allUuids_shareBaseSuffix() {
+        val suffix = "7c07-4f3f-9b32-7bf3ba6c2a01"
+        val uuids = listOf(
+            BleConstants.DSM_SERVICE_UUID_V2,
+            BleConstants.TX_REQUEST_UUID,
+            BleConstants.TX_RESPONSE_UUID,
+            BleConstants.IDENTITY_UUID,
+            BleConstants.PAIRING_UUID,
+            BleConstants.PAIRING_ACK_UUID,
+        )
+        for (uuid in uuids) {
+            assertTrue(
+                "UUID $uuid doesn't end with DSM base suffix",
+                uuid.toString().endsWith(suffix)
+            )
+        }
+    }
+
+    // ── Manufacturer data ──────────────────────────────────────────────────
+
+    @Test
+    fun manufacturerId_isExperimentalReserved() {
+        assertEquals(0xFFFF, BleConstants.DSM_MANUFACTURER_ID)
+    }
+
+    @Test
+    fun manufacturerMagic_isDSM01() {
+        assertArrayEquals(
+            byteArrayOf(0x44, 0x53, 0x4D, 0x01),
+            BleConstants.DSM_MANUFACTURER_MAGIC
+        )
+    }
+
+    @Test
+    fun manufacturerMagic_startsWithDSM() {
+        val magic = BleConstants.DSM_MANUFACTURER_MAGIC
+        assertEquals('D'.code.toByte(), magic[0])
+        assertEquals('S'.code.toByte(), magic[1])
+        assertEquals('M'.code.toByte(), magic[2])
+    }
+
+    @Test
+    fun manufacturerMagic_has4Bytes() {
+        assertEquals(4, BleConstants.DSM_MANUFACTURER_MAGIC.size)
+    }
+
+    // ── MTU settings ───────────────────────────────────────────────────────
+
+    @Test
+    fun mtuSize_is517() {
+        assertEquals(517, BleConstants.MTU_SIZE)
+    }
+
+    @Test
+    fun identityMtuRequest_is512() {
+        assertEquals(512, BleConstants.IDENTITY_MTU_REQUEST)
+    }
+
+    @Test
+    fun minIdentityMtu_is67() {
+        assertEquals(67, BleConstants.MIN_IDENTITY_MTU)
+    }
+
+    @Test
+    fun mtuOrdering_minLessThanIdentityLessThanMax() {
+        assertTrue(BleConstants.MIN_IDENTITY_MTU < BleConstants.IDENTITY_MTU_REQUEST)
+        assertTrue(BleConstants.IDENTITY_MTU_REQUEST <= BleConstants.MTU_SIZE)
+    }
+
+    // ── Reconnection backoff ───────────────────────────────────────────────
+
+    @Test
+    fun reconnectInitialDelay_is1Second() {
+        assertEquals(1_000L, BleConstants.RECONNECT_INITIAL_DELAY_MS)
+    }
+
+    @Test
+    fun reconnectMaxDelay_is30Seconds() {
+        assertEquals(30_000L, BleConstants.RECONNECT_MAX_DELAY_MS)
+    }
+
+    @Test
+    fun reconnectMaxAttempts_is8() {
+        assertEquals(8, BleConstants.RECONNECT_MAX_ATTEMPTS)
+    }
+
+    @Test
+    fun reconnectBackoff_maxDelayGreaterThanInitial() {
+        assertTrue(BleConstants.RECONNECT_MAX_DELAY_MS > BleConstants.RECONNECT_INITIAL_DELAY_MS)
+    }
+
+    // ── Scan duration ──────────────────────────────────────────────────────
+
+    @Test
+    fun scanLowLatencyDuration_is12Seconds() {
+        assertEquals(12_000L, BleConstants.SCAN_LOW_LATENCY_DURATION_MS)
+    }
+
+    // ── GATT error retry ───────────────────────────────────────────────────
+
+    @Test
+    fun gattErrorStatus_is133() {
+        assertEquals(133, BleConstants.GATT_ERROR_STATUS)
+    }
+
+    @Test
+    fun gattRetryDelay_is300ms() {
+        assertEquals(300L, BleConstants.GATT_RETRY_DELAY_MS)
+    }
+
+    @Test
+    fun gattRetryMaxAttempts_is3() {
+        assertEquals(3, BleConstants.GATT_RETRY_MAX_ATTEMPTS)
+    }
+
+    // ── Connection priority ────────────────────────────────────────────────
+
+    @Test
+    fun connectionPriorityResetDelay_is500ms() {
+        assertEquals(500L, BleConstants.CONNECTION_PRIORITY_RESET_DELAY_MS)
+    }
+
+    // ── MTU fallback ───────────────────────────────────────────────────────
+
+    @Test
+    fun mtuFallbackDelay_is2Seconds() {
+        assertEquals(2_000L, BleConstants.MTU_FALLBACK_DELAY_MS)
+    }
+
+    // ── Constant immutability ──────────────────────────────────────────────
+
+    @Test
+    fun allNumericConstants_arePositive() {
+        assertTrue(BleConstants.MTU_SIZE > 0)
+        assertTrue(BleConstants.IDENTITY_MTU_REQUEST > 0)
+        assertTrue(BleConstants.MIN_IDENTITY_MTU > 0)
+        assertTrue(BleConstants.RECONNECT_INITIAL_DELAY_MS > 0)
+        assertTrue(BleConstants.RECONNECT_MAX_DELAY_MS > 0)
+        assertTrue(BleConstants.RECONNECT_MAX_ATTEMPTS > 0)
+        assertTrue(BleConstants.SCAN_LOW_LATENCY_DURATION_MS > 0)
+        assertTrue(BleConstants.GATT_ERROR_STATUS > 0)
+        assertTrue(BleConstants.GATT_RETRY_DELAY_MS > 0)
+        assertTrue(BleConstants.GATT_RETRY_MAX_ATTEMPTS > 0)
+        assertTrue(BleConstants.CONNECTION_PRIORITY_RESET_DELAY_MS > 0)
+        assertTrue(BleConstants.MTU_FALLBACK_DELAY_MS > 0)
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleDiagnosticsTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleDiagnosticsTest.kt
@@ -1,0 +1,179 @@
+package com.dsm.wallet.bridge.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class BleDiagnosticsTest {
+
+    // ── recordEvent ───────────────────────────────────────────────────────
+
+    @Test
+    fun recordEvent_addsEventToLog() {
+        val diag = BleDiagnostics()
+        diag.recordEvent(BleDiagEvent(phase = "connect", device = "AA:BB"))
+
+        val log = diag.getEventsLog()
+        assertTrue(log.contains("connect"))
+        assertTrue(log.contains("AA:BB"))
+    }
+
+    @Test
+    fun recordEvent_assignsIncrementingSequenceNumbers() {
+        val diag = BleDiagnostics()
+        diag.recordEvent(BleDiagEvent(phase = "first"))
+        diag.recordEvent(BleDiagEvent(phase = "second"))
+
+        val lines = diag.getEventsLog().lines()
+        assertEquals(2, lines.size)
+        val ts1 = lines[0].substringBefore('|').toLong()
+        val ts2 = lines[1].substringBefore('|').toLong()
+        assertTrue("Second event ts ($ts2) should be > first ($ts1)", ts2 > ts1)
+    }
+
+    @Test
+    fun recordEvent_disabledDoesNotRecord() {
+        val diag = BleDiagnostics()
+        diag.setDebugEnabled(false)
+        diag.recordEvent(BleDiagEvent(phase = "invisible"))
+        assertEquals("", diag.getEventsLog())
+    }
+
+    @Test
+    fun recordEvent_capsAt1000() {
+        val diag = BleDiagnostics()
+        repeat(1100) { diag.recordEvent(BleDiagEvent(phase = "evt$it")) }
+        assertEquals(1000, diag.getEventsLog().lines().size)
+    }
+
+    @Test
+    fun recordEvent_reEnableAfterDisable() {
+        val diag = BleDiagnostics()
+        diag.setDebugEnabled(false)
+        diag.recordEvent(BleDiagEvent(phase = "hidden"))
+        diag.setDebugEnabled(true)
+        diag.recordEvent(BleDiagEvent(phase = "visible"))
+
+        val log = diag.getEventsLog()
+        assertFalse(log.contains("hidden"))
+        assertTrue(log.contains("visible"))
+    }
+
+    // ── recordError ───────────────────────────────────────────────────────
+
+    @Test
+    fun recordError_incrementsCountAndCreatesEvent() {
+        val diag = BleDiagnostics()
+        diag.recordError(BleErrorCategory.CONNECTION_FAILED, "scan", device = "XX:YY")
+
+        val guidance = diag.getErrorGuidance()
+        assertNotNull(guidance)
+        assertEquals("CONNECTION_FAILED", guidance!!["category"])
+        assertEquals(1, guidance["frequency"])
+
+        val log = diag.getEventsLog()
+        assertTrue(log.contains("CONNECTION_FAILED"))
+    }
+
+    @Test
+    fun recordError_multipleCategories_dominantReturned() {
+        val diag = BleDiagnostics()
+        diag.recordError(BleErrorCategory.CONNECTION_FAILED, "scan")
+        diag.recordError(BleErrorCategory.CONNECTION_FAILED, "scan")
+        diag.recordError(BleErrorCategory.MTU_TOO_SMALL, "mtu")
+
+        val guidance = diag.getErrorGuidance()!!
+        assertEquals("CONNECTION_FAILED", guidance["category"])
+        assertEquals(2, guidance["frequency"])
+    }
+
+    @Test
+    fun recordError_guidanceContainsUserMessageAndSteps() {
+        val diag = BleDiagnostics()
+        diag.recordError(BleErrorCategory.BLUETOOTH_DISABLED, "init")
+
+        val guidance = diag.getErrorGuidance()!!
+        val message = guidance["message"] as String
+        assertTrue(message.contains("Bluetooth"))
+        @Suppress("UNCHECKED_CAST")
+        val steps = guidance["troubleshooting"] as List<String>
+        assertTrue(steps.isNotEmpty())
+    }
+
+    // ── getErrorGuidance ──────────────────────────────────────────────────
+
+    @Test
+    fun getErrorGuidance_noErrors_returnsNull() {
+        assertNull(BleDiagnostics().getErrorGuidance())
+    }
+
+    // ── hasPersistentIssues ───────────────────────────────────────────────
+
+    @Test
+    fun hasPersistentIssues_belowThreshold() {
+        val diag = BleDiagnostics()
+        repeat(10) { diag.recordError(BleErrorCategory.CONNECTION_FAILED, "test") }
+        assertFalse(diag.hasPersistentIssues())
+    }
+
+    @Test
+    fun hasPersistentIssues_aboveThreshold() {
+        val diag = BleDiagnostics()
+        repeat(11) { diag.recordError(BleErrorCategory.CONNECTION_FAILED, "test") }
+        assertTrue(diag.hasPersistentIssues())
+    }
+
+    @Test
+    fun hasPersistentIssues_sumsAcrossCategories() {
+        val diag = BleDiagnostics()
+        repeat(6) { diag.recordError(BleErrorCategory.CONNECTION_FAILED, "a") }
+        repeat(6) { diag.recordError(BleErrorCategory.MTU_TOO_SMALL, "b") }
+        assertTrue(diag.hasPersistentIssues())
+    }
+
+    // ── clearEvents ───────────────────────────────────────────────────────
+
+    @Test
+    fun clearEvents_resetsAllState() {
+        val diag = BleDiagnostics()
+        diag.recordEvent(BleDiagEvent(phase = "evt"))
+        diag.recordError(BleErrorCategory.UNKNOWN, "test")
+        diag.clearEvents()
+
+        assertEquals("", diag.getEventsLog())
+        assertNull(diag.getErrorGuidance())
+        assertFalse(diag.hasPersistentIssues())
+    }
+
+    // ── getEventsLog ──────────────────────────────────────────────────────
+
+    @Test
+    fun getEventsLog_pipeDelimitedFormat() {
+        val diag = BleDiagnostics()
+        diag.recordEvent(BleDiagEvent(phase = "scan", device = "DD:EE", status = 0))
+
+        val log = diag.getEventsLog()
+        val parts = log.split("|")
+        assertTrue("Expected pipe-delimited fields, got: $log", parts.size >= 3)
+        assertEquals("scan", parts[1])
+        assertEquals("DD:EE", parts[2])
+    }
+
+    @Test
+    fun getEventsLog_pipesInDeviceNameEscaped() {
+        val diag = BleDiagnostics()
+        diag.recordEvent(BleDiagEvent(phase = "scan", device = "AA|BB"))
+
+        val log = diag.getEventsLog()
+        assertFalse("Pipe in device name should be escaped", log.contains("AA|BB"))
+        assertTrue(log.contains("AA/BB"))
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleErrorCategoryTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleErrorCategoryTest.kt
@@ -1,0 +1,187 @@
+package com.dsm.wallet.bridge.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class BleErrorCategoryTest {
+
+    // ── Enum completeness ──────────────────────────────────────────────────
+
+    @Test
+    fun enumHasExpected14Values() {
+        assertEquals(14, BleErrorCategory.entries.size)
+    }
+
+    @Test
+    fun allExpectedEntriesExist() {
+        val expected = setOf(
+            "BLUETOOTH_DISABLED",
+            "PERMISSION_DENIED",
+            "HARDWARE_UNAVAILABLE",
+            "MTU_TOO_SMALL",
+            "MTU_NEGOTIATION_FAILED",
+            "CONNECTION_FAILED",
+            "SERVICE_DISCOVERY_FAILED",
+            "CHARACTERISTIC_READ_FAILED",
+            "CHARACTERISTIC_WRITE_FAILED",
+            "CHARACTERISTIC_ERROR",
+            "ADVERTISING_FAILED",
+            "SCANNING_FAILED",
+            "PROTOCOL_TIMEOUT",
+            "UNKNOWN",
+        )
+        assertEquals(expected, BleErrorCategory.entries.map { it.name }.toSet())
+    }
+
+    @Test
+    fun valueOfRoundTrips() {
+        for (entry in BleErrorCategory.entries) {
+            assertEquals(entry, BleErrorCategory.valueOf(entry.name))
+        }
+    }
+
+    // ── getUserMessage() ───────────────────────────────────────────────────
+
+    @Test
+    fun everyEntryReturnsNonBlankUserMessage() {
+        for (entry in BleErrorCategory.entries) {
+            val msg = entry.getUserMessage()
+            assertTrue("$entry has blank user message", msg.isNotBlank())
+        }
+    }
+
+    @Test
+    fun bluetoothDisabled_userMessageMentionsBluetooth() {
+        assertTrue(
+            BleErrorCategory.BLUETOOTH_DISABLED.getUserMessage().contains("Bluetooth", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun permissionDenied_userMessageMentionsPermission() {
+        assertTrue(
+            BleErrorCategory.PERMISSION_DENIED.getUserMessage().contains("permission", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun mtuTooSmall_userMessageMentionsAndroid8() {
+        assertTrue(
+            BleErrorCategory.MTU_TOO_SMALL.getUserMessage().contains("Android 8.0")
+        )
+    }
+
+    @Test
+    fun connectionFailed_userMessageMentionsDistance() {
+        assertTrue(
+            BleErrorCategory.CONNECTION_FAILED.getUserMessage().contains("10 meters")
+        )
+    }
+
+    @Test
+    fun unknown_userMessageSuggestsRestart() {
+        assertTrue(
+            BleErrorCategory.UNKNOWN.getUserMessage().contains("Restart", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun userMessages_areDistinctPerCategory() {
+        val messages = BleErrorCategory.entries.map { it.getUserMessage() }
+        assertEquals(messages.size, messages.toSet().size)
+    }
+
+    // ── getTroubleshootingSteps() ──────────────────────────────────────────
+
+    @Test
+    fun everyEntryReturnsNonEmptyTroubleshootingSteps() {
+        for (entry in BleErrorCategory.entries) {
+            val steps = entry.getTroubleshootingSteps()
+            assertTrue("$entry returned empty troubleshooting steps", steps.isNotEmpty())
+        }
+    }
+
+    @Test
+    fun troubleshootingStepsContainNoBlankEntries() {
+        for (entry in BleErrorCategory.entries) {
+            for (step in entry.getTroubleshootingSteps()) {
+                assertTrue("$entry has blank step", step.isNotBlank())
+            }
+        }
+    }
+
+    @Test
+    fun bluetoothDisabled_stepsReferenceSettings() {
+        val steps = BleErrorCategory.BLUETOOTH_DISABLED.getTroubleshootingSteps()
+        assertTrue(steps.any { it.contains("Settings", ignoreCase = true) })
+    }
+
+    @Test
+    fun permissionDenied_stepsReferencePermissions() {
+        val steps = BleErrorCategory.PERMISSION_DENIED.getTroubleshootingSteps()
+        assertTrue(steps.any { it.contains("Permission", ignoreCase = true) })
+    }
+
+    @Test
+    fun connectionFailed_hasAtLeast3Steps() {
+        assertTrue(BleErrorCategory.CONNECTION_FAILED.getTroubleshootingSteps().size >= 3)
+    }
+
+    @Test
+    fun unknown_stepsSuggestContactSupport() {
+        val steps = BleErrorCategory.UNKNOWN.getTroubleshootingSteps()
+        assertTrue(steps.any { it.contains("support", ignoreCase = true) })
+    }
+
+    @Test
+    fun scanningFailed_stepsMentionWiFi() {
+        val steps = BleErrorCategory.SCANNING_FAILED.getTroubleshootingSteps()
+        assertTrue(steps.any { it.contains("WiFi", ignoreCase = true) })
+    }
+
+    @Test
+    fun advertisingFailed_stepsMentionOtherApps() {
+        val steps = BleErrorCategory.ADVERTISING_FAILED.getTroubleshootingSteps()
+        assertTrue(steps.any { it.contains("other apps", ignoreCase = true) })
+    }
+
+    // ── Specific step counts ───────────────────────────────────────────────
+
+    @Test
+    fun bluetoothDisabled_hasExactly3Steps() {
+        assertEquals(3, BleErrorCategory.BLUETOOTH_DISABLED.getTroubleshootingSteps().size)
+    }
+
+    @Test
+    fun connectionFailed_has4Steps() {
+        assertEquals(4, BleErrorCategory.CONNECTION_FAILED.getTroubleshootingSteps().size)
+    }
+
+    @Test
+    fun unknown_has4Steps() {
+        assertEquals(4, BleErrorCategory.UNKNOWN.getTroubleshootingSteps().size)
+    }
+
+    // ── Cross-cutting consistency ──────────────────────────────────────────
+
+    @Test
+    fun readAndWriteFailed_haveIdenticalSteps() {
+        assertEquals(
+            BleErrorCategory.CHARACTERISTIC_READ_FAILED.getTroubleshootingSteps(),
+            BleErrorCategory.CHARACTERISTIC_WRITE_FAILED.getTroubleshootingSteps()
+        )
+    }
+
+    @Test
+    fun everyUserMessageEndsWithPeriod() {
+        for (entry in BleErrorCategory.entries) {
+            val msg = entry.getUserMessage()
+            assertTrue("$entry message doesn't end with '.': $msg", msg.endsWith("."))
+        }
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleOperationDispatcherTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleOperationDispatcherTest.kt
@@ -1,0 +1,134 @@
+package com.dsm.wallet.bridge.ble
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests for [BleOperationDispatcher] priority ordering and dispatching.
+ *
+ * Uses Robolectric to shadow android.util.Log (called in error/drop paths).
+ * The dispatcher's supervisor coroutine runs on Dispatchers.Default so that
+ * dispatchBlocking (which uses runBlocking internally) does not deadlock.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class BleOperationDispatcherTest {
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var dispatcher: BleOperationDispatcher
+
+    @Before
+    fun setUp() {
+        val handler = CoroutineExceptionHandler { _, _ -> }
+        scope = CoroutineScope(Dispatchers.Default + SupervisorJob() + handler)
+        dispatcher = BleOperationDispatcher(scope)
+    }
+
+    @After
+    fun tearDown() {
+        dispatcher.shutdown()
+        scope.cancel()
+    }
+
+    // ── dispatch (fire-and-forget) ────────────────────────────────────────
+
+    @Test
+    fun dispatch_executesOp() {
+        val latch = CountDownLatch(1)
+        dispatcher.dispatch(BleOpLane.TRANSFER) { latch.countDown() }
+        assertTrue("Op should execute within timeout", latch.await(5, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun dispatch_allLanesExecute() {
+        val latch = CountDownLatch(3)
+        dispatcher.dispatch(BleOpLane.LIFECYCLE) { latch.countDown() }
+        dispatcher.dispatch(BleOpLane.PAIRING) { latch.countDown() }
+        dispatcher.dispatch(BleOpLane.TRANSFER) { latch.countDown() }
+        assertTrue("All lanes should execute", latch.await(5, TimeUnit.SECONDS))
+    }
+
+    // ── dispatchBlocking ──────────────────────────────────────────────────
+
+    @Test
+    fun dispatchBlocking_returnsTrue() {
+        assertTrue(dispatcher.dispatchBlocking(BleOpLane.LIFECYCLE) { true })
+    }
+
+    @Test
+    fun dispatchBlocking_returnsFalse() {
+        assertFalse(dispatcher.dispatchBlocking(BleOpLane.PAIRING) { false })
+    }
+
+    @Test
+    fun dispatchBlocking_exceptionInOp_returnsFalse() {
+        assertFalse(
+            dispatcher.dispatchBlocking(BleOpLane.TRANSFER) { throw RuntimeException("boom") }
+        )
+    }
+
+    // ── priority ordering ─────────────────────────────────────────────────
+
+    @Test
+    fun priority_lifecycleBeforePairingBeforeTransfer() {
+        val order = Collections.synchronizedList(mutableListOf<String>())
+        val gate = CompletableDeferred<Unit>()
+        val gateStarted = CompletableDeferred<Unit>()
+        val allDone = CountDownLatch(4)
+
+        dispatcher.dispatch(BleOpLane.TRANSFER) {
+            gateStarted.complete(Unit)
+            gate.await()
+            order.add("T0")
+            allDone.countDown()
+        }
+
+        runBlocking { gateStarted.await() }
+
+        dispatcher.dispatch(BleOpLane.TRANSFER) { order.add("T1"); allDone.countDown() }
+        dispatcher.dispatch(BleOpLane.PAIRING) { order.add("P"); allDone.countDown() }
+        dispatcher.dispatch(BleOpLane.LIFECYCLE) { order.add("L"); allDone.countDown() }
+
+        gate.complete(Unit)
+        assertTrue("Ops should complete in time", allDone.await(5, TimeUnit.SECONDS))
+        assertEquals(
+            "LIFECYCLE should drain before PAIRING, PAIRING before TRANSFER",
+            listOf("T0", "L", "P", "T1"),
+            order
+        )
+    }
+
+    // ── shutdown ──────────────────────────────────────────────────────────
+
+    @Test
+    fun shutdown_rejectsFurtherOps() {
+        dispatcher.shutdown()
+        assertFalse(
+            "dispatchBlocking after shutdown should return false",
+            dispatcher.dispatchBlocking(BleOpLane.LIFECYCLE) { true }
+        )
+    }
+
+    @Test
+    fun dispatch_afterShutdown_doesNotThrow() {
+        dispatcher.shutdown()
+        dispatcher.dispatch(BleOpLane.TRANSFER) { /* no-op */ }
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleWriteBudgetTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleWriteBudgetTest.kt
@@ -1,0 +1,43 @@
+package com.dsm.wallet.bridge.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class BleWriteBudgetTest {
+
+    @Test
+    fun tryConsume_succeedsUntilCreditsExhausted() {
+        val budget = BleWriteBudget(maxCredits = 5, refillIntervalMs = 60_000L)
+        repeat(5) {
+            assertTrue("consume $it", budget.tryConsume())
+        }
+        assertFalse(budget.tryConsume())
+    }
+
+    @Test
+    fun reset_restoresFullCredits() {
+        val budget = BleWriteBudget(maxCredits = 3, refillIntervalMs = 60_000L)
+        repeat(3) { budget.tryConsume() }
+        assertFalse(budget.tryConsume())
+        budget.reset()
+        assertTrue(budget.tryConsume())
+        assertTrue(budget.tryConsume())
+        assertTrue(budget.tryConsume())
+        assertFalse(budget.tryConsume())
+    }
+
+    @Test
+    fun defaultConstructor_allowsTwentySequentialConsumes() {
+        val budget = BleWriteBudget()
+        repeat(20) {
+            assertTrue(budget.tryConsume())
+        }
+        assertFalse(budget.tryConsume())
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/PeerSessionTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/PeerSessionTest.kt
@@ -1,0 +1,305 @@
+package com.dsm.wallet.bridge.ble
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PeerSessionTest {
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  PeerIdentity
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun peerIdentity_keyIsLowercaseHex() {
+        val id = PeerIdentity(
+            deviceId = byteArrayOf(0x0A, 0xFF.toByte(), 0x00),
+            genesisHash = byteArrayOf()
+        )
+        assertEquals("0aff00", id.key)
+    }
+
+    @Test
+    fun peerIdentity_keyOf32Bytes_has64HexChars() {
+        val id = PeerIdentity(
+            deviceId = ByteArray(32) { it.toByte() },
+            genesisHash = byteArrayOf()
+        )
+        assertEquals(64, id.key.length)
+    }
+
+    @Test
+    fun peerIdentity_keyOfEmptyDeviceId_isEmpty() {
+        val id = PeerIdentity(deviceId = byteArrayOf(), genesisHash = byteArrayOf())
+        assertEquals("", id.key)
+    }
+
+    @Test
+    fun peerIdentity_equalityBasedOnDeviceIdOnly() {
+        val a = PeerIdentity(byteArrayOf(1, 2, 3), byteArrayOf(10))
+        val b = PeerIdentity(byteArrayOf(1, 2, 3), byteArrayOf(99))
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun peerIdentity_differentDeviceIds_notEqual() {
+        val a = PeerIdentity(byteArrayOf(1, 2, 3), byteArrayOf(10))
+        val b = PeerIdentity(byteArrayOf(1, 2, 4), byteArrayOf(10))
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun peerIdentity_hashCodeConsistentWithEquals() {
+        val a = PeerIdentity(byteArrayOf(1, 2, 3), byteArrayOf(10))
+        val b = PeerIdentity(byteArrayOf(1, 2, 3), byteArrayOf(99))
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun peerIdentity_notEqualToNull() {
+        val id = PeerIdentity(byteArrayOf(1), byteArrayOf())
+        assertFalse(id.equals(null))
+    }
+
+    @Test
+    fun peerIdentity_notEqualToDifferentType() {
+        val id = PeerIdentity(byteArrayOf(1), byteArrayOf())
+        assertFalse(id.equals("not a PeerIdentity"))
+    }
+
+    @Test
+    fun peerIdentity_usableAsMapKey() {
+        val a = PeerIdentity(byteArrayOf(1, 2), byteArrayOf())
+        val b = PeerIdentity(byteArrayOf(1, 2), byteArrayOf(99))
+        val map = mutableMapOf(a to "first")
+        map[b] = "second"
+        assertEquals(1, map.size)
+        assertEquals("second", map[a])
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  PeerSession – default values
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun defaultSession_isNotConnected() {
+        val s = PeerSession(address = "AA:BB:CC:DD:EE:FF")
+        assertFalse(s.isConnected)
+    }
+
+    @Test
+    fun defaultSession_mtuIs23() {
+        assertEquals(23, PeerSession(address = "X").negotiatedMtu)
+    }
+
+    @Test
+    fun defaultSession_hasNoActiveClientSession() {
+        assertFalse(PeerSession(address = "X").hasActiveClientSession)
+    }
+
+    @Test
+    fun defaultSession_isNotServerClient() {
+        assertFalse(PeerSession(address = "X").isServerClient)
+    }
+
+    @Test
+    fun defaultSession_connectionNotPending() {
+        assertFalse(PeerSession(address = "X").connectionPending)
+    }
+
+    @Test
+    fun defaultSession_isEmpty() {
+        assertTrue(PeerSession(address = "X").isEmpty)
+    }
+
+    @Test
+    fun defaultSession_reconnectAttemptCountIsZero() {
+        assertEquals(0, PeerSession(address = "X").reconnectAttemptCount)
+    }
+
+    @Test
+    fun defaultSession_serverTransferNonceIsZero() {
+        assertEquals(0.toByte(), PeerSession(address = "X").serverTransferNonce)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  PeerSession – computed properties
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun connectionPending_trueWhenConnectResultSet() {
+        val s = PeerSession(address = "X")
+        s.connectResult = CompletableDeferred()
+        assertTrue(s.connectionPending)
+    }
+
+    @Test
+    fun isEmpty_falseWhenConnectResultPending() {
+        val s = PeerSession(address = "X")
+        s.connectResult = CompletableDeferred()
+        assertFalse(s.isEmpty)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  PeerSession – isSubscribedTo
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun isSubscribedTo_returnsFalseWhenEmpty() {
+        val s = PeerSession(address = "X")
+        assertFalse(s.isSubscribedTo(UUID.randomUUID()))
+    }
+
+    @Test
+    fun isSubscribedTo_returnsTrueAfterSubscription() {
+        val uuid = UUID.randomUUID()
+        val s = PeerSession(address = "X")
+        s.subscribedCccds[uuid] = true
+        assertTrue(s.isSubscribedTo(uuid))
+    }
+
+    @Test
+    fun isSubscribedTo_returnsFalseIfSetToFalse() {
+        val uuid = UUID.randomUUID()
+        val s = PeerSession(address = "X")
+        s.subscribedCccds[uuid] = false
+        assertFalse(s.isSubscribedTo(uuid))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  PeerSession – clearClientState
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun clearClientState_resetsAllClientFields() {
+        val s = PeerSession(address = "X").apply {
+            isConnected = true
+            negotiatedMtu = 512
+            serviceDiscoveryCompleted = true
+            identityExchangeInProgress = true
+            pairingInProgress = true
+            pendingPairingConfirm = byteArrayOf(1)
+        }
+        s.clearClientState()
+
+        assertFalse(s.isConnected)
+        assertEquals(23, s.negotiatedMtu)
+        assertFalse(s.serviceDiscoveryCompleted)
+        assertNull(s.lastError)
+        assertNull(s.currentTransaction)
+        assertFalse(s.identityExchangeInProgress)
+        assertFalse(s.pairingInProgress)
+        assertNull(s.connectResult)
+        assertNull(s.pendingPairingConfirm)
+    }
+
+    @Test
+    fun clearClientState_completesConnectResultWithFalse() {
+        val deferred = CompletableDeferred<Boolean>()
+        val s = PeerSession(address = "X").apply { connectResult = deferred }
+        s.clearClientState()
+
+        assertTrue(deferred.isCompleted)
+        assertFalse(deferred.getCompleted())
+    }
+
+    @Test
+    fun clearClientState_doesNotResetReconnectAttemptCount() {
+        val s = PeerSession(address = "X").apply { reconnectAttemptCount = 5 }
+        s.clearClientState()
+        assertEquals(5, s.reconnectAttemptCount)
+    }
+
+    @Test
+    fun clearClientState_doesNotAffectServerState() {
+        val uuid = UUID.randomUUID()
+        val s = PeerSession(address = "X").apply {
+            isConnected = true
+            subscribedCccds[uuid] = true
+            serverTransferNonce = 42
+        }
+        s.clearClientState()
+
+        assertTrue(s.isSubscribedTo(uuid))
+        assertEquals(42.toByte(), s.serverTransferNonce)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  PeerSession – clearServerState
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun clearServerState_resetsAllServerFields() {
+        val uuid = UUID.randomUUID()
+        val s = PeerSession(address = "X").apply {
+            subscribedCccds[uuid] = true
+            notificationCompletion = CompletableDeferred()
+            chunkAckChannel = Channel(1)
+        }
+        s.clearServerState()
+
+        assertNull(s.serverDevice)
+        assertTrue(s.subscribedCccds.isEmpty())
+        assertNull(s.notificationCompletion)
+        assertNull(s.chunkAckChannel)
+    }
+
+    @Test
+    fun clearServerState_cancelsNotificationCompletion() {
+        val deferred = CompletableDeferred<Boolean>()
+        val s = PeerSession(address = "X").apply { notificationCompletion = deferred }
+        s.clearServerState()
+        assertTrue(deferred.isCancelled)
+    }
+
+    @Test
+    fun clearServerState_closesChunkAckChannel() {
+        val ch = Channel<Int>(1)
+        val s = PeerSession(address = "X").apply { chunkAckChannel = ch }
+        s.clearServerState()
+        assertTrue(ch.isClosedForSend)
+    }
+
+    @Test
+    fun clearServerState_doesNotAffectClientState() {
+        val s = PeerSession(address = "X").apply {
+            isConnected = true
+            negotiatedMtu = 256
+        }
+        s.clearServerState()
+
+        assertTrue(s.isConnected)
+        assertEquals(256, s.negotiatedMtu)
+    }
+
+    @Test
+    fun clearServerState_resetsWriteBudget() {
+        val s = PeerSession(address = "X")
+        s.clearServerState()
+        assertNotNull(s.writeBudget)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  PeerSession – data class copy
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun copy_preservesAddress() {
+        val s = PeerSession(address = "A")
+        val c = s.copy(negotiatedMtu = 512)
+        assertEquals("A", c.address)
+        assertEquals(512, c.negotiatedMtu)
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/diagnostics/ArchitectureCheckerTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/diagnostics/ArchitectureCheckerTest.kt
@@ -1,0 +1,269 @@
+package com.dsm.wallet.diagnostics
+
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ArchitectureCheckerTest {
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private fun setSupportedAbis(vararg abis: String) {
+        ReflectionHelpers.setStaticField(Build::class.java, "SUPPORTED_ABIS", abis)
+    }
+
+    private fun setSdkInt(sdk: Int) {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", sdk)
+    }
+
+    @Before
+    fun resetDefaults() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(33)
+    }
+
+    // ── checkCompatibility ─────────────────────────────────────────────────
+
+    @Test
+    fun arm64_api33_isFullyCompatible() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(33)
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals(ArchitectureChecker.ArchStatus.COMPATIBLE, result.status)
+        assertTrue(result.message.contains("ARM64"))
+    }
+
+    @Test
+    fun armv7_api33_isCompatibleWithWarning() {
+        setSupportedAbis("armeabi-v7a")
+        setSdkInt(33)
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals(ArchitectureChecker.ArchStatus.COMPATIBLE, result.status)
+        assertTrue(result.message.contains("ARMv7"))
+        assertTrue(result.message.contains("reduced performance"))
+    }
+
+    @Test
+    fun x86_only_isUnsupported() {
+        setSupportedAbis("x86_64", "x86")
+        setSdkInt(33)
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals(ArchitectureChecker.ArchStatus.UNSUPPORTED_ABI, result.status)
+    }
+
+    @Test
+    fun api25_isIncompatibleJvm() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(25)
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals(ArchitectureChecker.ArchStatus.INCOMPATIBLE_JVM, result.status)
+        assertTrue(result.message.contains("API 25"))
+    }
+
+    @Test
+    fun api26_isMinimumCompatible() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(26)
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals(ArchitectureChecker.ArchStatus.COMPATIBLE, result.status)
+    }
+
+    @Test
+    fun x86WithArm64Secondary_usesSecondaryAbi() {
+        setSupportedAbis("x86_64", "arm64-v8a")
+        setSdkInt(33)
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals(ArchitectureChecker.ArchStatus.COMPATIBLE, result.status)
+        assertTrue(result.message.contains("secondary ABI"))
+    }
+
+    @Test
+    fun unsupportedAbi_abiCheck_beforeSdkCheck() {
+        setSupportedAbis("x86")
+        setSdkInt(25)
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals(ArchitectureChecker.ArchStatus.UNSUPPORTED_ABI, result.status)
+    }
+
+    @Test
+    fun result_containsDeviceArch() {
+        setSupportedAbis("arm64-v8a")
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals("arm64-v8a", result.deviceArch)
+    }
+
+    @Test
+    fun result_containsSupportedAbis() {
+        setSupportedAbis("arm64-v8a", "armeabi-v7a")
+        val result = ArchitectureChecker.checkCompatibility()
+        assertEquals(listOf("arm64-v8a", "armeabi-v7a"), result.supportedAbis)
+    }
+
+    @Test
+    fun result_messageIsNotBlank() {
+        val result = ArchitectureChecker.checkCompatibility()
+        assertTrue(result.message.isNotBlank())
+    }
+
+    @Test
+    fun result_recommendationIsNotBlank() {
+        val result = ArchitectureChecker.checkCompatibility()
+        assertTrue(result.recommendation.isNotBlank())
+    }
+
+    // ── isDeviceBlocked ────────────────────────────────────────────────────
+
+    @Test
+    fun isDeviceBlocked_falseForArm64() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(33)
+        assertFalse(ArchitectureChecker.isDeviceBlocked())
+    }
+
+    @Test
+    fun isDeviceBlocked_trueForX86() {
+        setSupportedAbis("x86")
+        setSdkInt(33)
+        assertTrue(ArchitectureChecker.isDeviceBlocked())
+    }
+
+    @Test
+    fun isDeviceBlocked_trueForOldApi() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(24)
+        assertTrue(ArchitectureChecker.isDeviceBlocked())
+    }
+
+    @Test
+    fun isDeviceBlocked_falseForArmv7() {
+        setSupportedAbis("armeabi-v7a")
+        setSdkInt(28)
+        assertFalse(ArchitectureChecker.isDeviceBlocked())
+    }
+
+    // ── getBlockingErrorMessage ────────────────────────────────────────────
+
+    @Test
+    fun getBlockingErrorMessage_nullForCompatible() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(33)
+        assertNull(ArchitectureChecker.getBlockingErrorMessage())
+    }
+
+    @Test
+    fun getBlockingErrorMessage_nonNullForUnsupportedAbi() {
+        setSupportedAbis("x86")
+        setSdkInt(33)
+        val msg = ArchitectureChecker.getBlockingErrorMessage()
+        assertNotNull(msg)
+        assertTrue(msg!!.contains("Unsupported"))
+    }
+
+    @Test
+    fun getBlockingErrorMessage_nonNullForIncompatibleJvm() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(21)
+        val msg = ArchitectureChecker.getBlockingErrorMessage()
+        assertNotNull(msg)
+        assertTrue(msg!!.contains("too old"))
+    }
+
+    @Test
+    fun getBlockingErrorMessage_containsRecommendation() {
+        setSupportedAbis("x86")
+        setSdkInt(33)
+        val msg = ArchitectureChecker.getBlockingErrorMessage()!!
+        assertTrue(msg.contains("ARM"))
+    }
+
+    // ── getArchitectureSummary ─────────────────────────────────────────────
+
+    @Test
+    fun getArchitectureSummary_containsPrimaryAbi() {
+        setSupportedAbis("arm64-v8a")
+        val summary = ArchitectureChecker.getArchitectureSummary()
+        assertTrue(summary.contains("arm64-v8a"))
+    }
+
+    @Test
+    fun getArchitectureSummary_containsStatusName() {
+        setSupportedAbis("arm64-v8a")
+        setSdkInt(33)
+        val summary = ArchitectureChecker.getArchitectureSummary()
+        assertTrue(summary.contains("COMPATIBLE"))
+    }
+
+    @Test
+    fun getArchitectureSummary_containsMultipleAbis() {
+        setSupportedAbis("arm64-v8a", "armeabi-v7a")
+        val summary = ArchitectureChecker.getArchitectureSummary()
+        assertTrue(summary.contains("arm64-v8a"))
+        assertTrue(summary.contains("armeabi-v7a"))
+    }
+
+    @Test
+    fun getArchitectureSummary_hasExpectedSections() {
+        val summary = ArchitectureChecker.getArchitectureSummary()
+        assertTrue(summary.contains("Device Architecture:"))
+        assertTrue(summary.contains("Primary ABI:"))
+        assertTrue(summary.contains("All ABIs:"))
+        assertTrue(summary.contains("Status:"))
+        assertTrue(summary.contains("Message:"))
+    }
+
+    // ── ArchStatus enum ────────────────────────────────────────────────────
+
+    @Test
+    fun archStatus_has4Values() {
+        assertEquals(4, ArchitectureChecker.ArchStatus.entries.size)
+    }
+
+    @Test
+    fun archStatus_valueOfRoundTrips() {
+        for (s in ArchitectureChecker.ArchStatus.entries) {
+            assertEquals(s, ArchitectureChecker.ArchStatus.valueOf(s.name))
+        }
+    }
+
+    // ── ArchCompatibility data class ───────────────────────────────────────
+
+    @Test
+    fun archCompatibility_copyPreservesFields() {
+        val orig = ArchitectureChecker.ArchCompatibility(
+            status = ArchitectureChecker.ArchStatus.COMPATIBLE,
+            deviceArch = "arm64-v8a",
+            supportedAbis = listOf("arm64-v8a"),
+            message = "OK",
+            recommendation = "None"
+        )
+        val copy = orig.copy(message = "Updated")
+        assertEquals("Updated", copy.message)
+        assertEquals(orig.status, copy.status)
+        assertEquals(orig.deviceArch, copy.deviceArch)
+    }
+
+    @Test
+    fun archCompatibility_equalityWorks() {
+        val a = ArchitectureChecker.ArchCompatibility(
+            status = ArchitectureChecker.ArchStatus.UNKNOWN,
+            deviceArch = "x",
+            supportedAbis = emptyList(),
+            message = "m",
+            recommendation = "r"
+        )
+        val b = a.copy()
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+}

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/security/AccessLevelTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/security/AccessLevelTest.kt
@@ -1,0 +1,27 @@
+package com.dsm.wallet.security
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccessLevelTest {
+
+    @Test
+    fun minOf_returnsLowerOrdinal_lessRestrictiveFirstInEnum() {
+        // Enum order: FULL_ACCESS, PIN_REQUIRED, READ_ONLY, BLOCKED — minOf picks smaller ordinal.
+        assertEquals(AccessLevel.FULL_ACCESS, AccessLevel.minOf(AccessLevel.FULL_ACCESS, AccessLevel.READ_ONLY))
+        assertEquals(AccessLevel.READ_ONLY, AccessLevel.minOf(AccessLevel.READ_ONLY, AccessLevel.BLOCKED))
+        assertEquals(AccessLevel.FULL_ACCESS, AccessLevel.minOf(AccessLevel.PIN_REQUIRED, AccessLevel.FULL_ACCESS))
+    }
+
+    @Test
+    fun minOf_same_returnsSame() {
+        assertEquals(AccessLevel.FULL_ACCESS, AccessLevel.minOf(AccessLevel.FULL_ACCESS, AccessLevel.FULL_ACCESS))
+    }
+
+    @Test
+    fun ordinal_ordering_matches_declaration_order() {
+        assert(AccessLevel.FULL_ACCESS.ordinal < AccessLevel.PIN_REQUIRED.ordinal)
+        assert(AccessLevel.PIN_REQUIRED.ordinal < AccessLevel.READ_ONLY.ordinal)
+        assert(AccessLevel.READ_ONLY.ordinal < AccessLevel.BLOCKED.ordinal)
+    }
+}


### PR DESCRIPTION
## Summary

This PR expands Android JVM unit coverage across the wallet bridge, BLE helpers, diagnostics, and security-related code paths.

## What Changed

- adds bridge encoding and envelope codec tests
- adds bridge logger coverage
- adds BLE constants, diagnostics, error categorization, dispatcher, write-budget, and peer-session tests
- adds diagnostics coverage for architecture checks
- adds security coverage for access-level behavior

## Why

The Android-side bridge and BLE surfaces are high-risk integration points, but they were under-covered at the JVM unit level. This PR adds focused tests around encoding, session behavior, diagnostics, and guardrails so regressions are caught earlier without requiring device or instrumentation runs.

## Files to Review

- `dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/*`
- `dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/*`
- `dsm_client/android/app/src/test/java/com/dsm/wallet/diagnostics/*`
- `dsm_client/android/app/src/test/java/com/dsm/wallet/security/*`

## Validation

- branch adds 11 JVM test files
- branch diff is test-only
- total addition is focused on Android-side unit coverage