### PR TITLE
test(dsm-sdk): isolate bilateral session db test

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bilateral_sessions.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bilateral_sessions.rs
@@ -359,7 +359,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn store_bilateral_session_accepts_all_valid_phases() {
+        init_test_db();
         let valid_phases = [
             "prepare",
             "accept",


### PR DESCRIPTION
## Summary

Fix a flaky `dsm_sdk` unit test caused by shared test database state leaking across bilateral session tests.

## Changes

- add `#[serial]` to `store_bilateral_session_accepts_all_valid_phases()`
- call `init_test_db()` at the start of that test
- keep the bilateral session DB test isolated from neighboring test cases

## Root Cause

`store_bilateral_session_accepts_all_valid_phases()` was writing to the shared client DB without resetting/isolation, which could leave residual rows behind and intermittently break:

- `storage::client_db::bilateral_sessions::tests::delete_nonexistent_bilateral_session_is_noop`