### PR TITLE
fix(token): require anchored policy commits and settle DLV claims atomically

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/transition.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/transition.rs
@@ -1059,6 +1059,31 @@ fn apply_token_balance_delta(
     current_state: &State,
     operation: &Operation,
 ) -> Result<(), DsmError> {
+    let decode_dlv_lock = |token_id: &Option<Vec<u8>>,
+                           locked_amount: &Option<Balance>,
+                           op_name: &str|
+     -> Result<Option<(String, Balance)>, DsmError> {
+        match (token_id.as_ref(), locked_amount.as_ref()) {
+            (None, None) => Ok(None),
+            (Some(_), None) | (None, Some(_)) => Err(DsmError::invalid_operation(format!(
+                "{op_name} requires both token_id and locked_amount when settling locked tokens"
+            ))),
+            (Some(token_id), Some(locked_amount)) => {
+                let token_id_str = std::str::from_utf8(token_id).map_err(|_| {
+                    DsmError::invalid_operation(format!(
+                        "{op_name} token_id must be valid UTF-8 bytes"
+                    ))
+                })?;
+                if token_id_str.is_empty() {
+                    return Err(DsmError::invalid_operation(format!(
+                        "{op_name} token_id must not be empty"
+                    )));
+                }
+                Ok(Some((token_id_str.to_string(), locked_amount.clone())))
+            }
+        }
+    };
+
     match operation {
         Operation::Transfer {
             token_id,
@@ -1069,9 +1094,9 @@ fn apply_token_balance_delta(
         } => {
             let token_id_str = String::from_utf8_lossy(token_id).to_string();
             // §8 Atomicity: all token ops MUST apply balance deltas in the
-            // same state transition. resolve_policy_commit handles both
-            // builtins (ERA/dBTC) and CPTA-anchored custom tokens.
-            let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str);
+            // same state transition. `resolve_policy_commit` must now fail
+            // closed when no canonical CPTA anchor exists.
+            let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str)?;
             let is_recipient = to_device_id.len() == 32
                 && to_device_id.as_slice() == current_state.device_info.device_id.as_slice();
 
@@ -1172,7 +1197,7 @@ fn apply_token_balance_delta(
             token_id, amount, ..
         } => {
             let token_id_str = String::from_utf8_lossy(token_id).to_string();
-            let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str);
+            let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str)?;
             let owner_key = crate::core::token::derive_canonical_balance_key(
                 &policy_commit,
                 &current_state.device_info.public_key,
@@ -1204,7 +1229,7 @@ fn apply_token_balance_delta(
             token_id, amount, ..
         } => {
             let token_id_str = String::from_utf8_lossy(token_id).to_string();
-            let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str);
+            let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str)?;
             let owner_key = crate::core::token::derive_canonical_balance_key(
                 &policy_commit,
                 &current_state.device_info.public_key,
@@ -1234,6 +1259,129 @@ fn apply_token_balance_delta(
                     current_state.state_number,
                 ),
             );
+        }
+        Operation::DlvCreate {
+            token_id,
+            locked_amount,
+            creator_public_key,
+            ..
+        } => {
+            if let Some((token_id_str, amount)) =
+                decode_dlv_lock(token_id, locked_amount, "DlvCreate")?
+            {
+                if amount.value() > 0 {
+                    let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str)?;
+                    let creator_key = crate::core::token::derive_canonical_balance_key(
+                        &policy_commit,
+                        creator_public_key.as_slice(),
+                        &token_id_str,
+                    );
+                    let creator_balance = next_state
+                        .token_balances
+                        .get(&creator_key)
+                        .cloned()
+                        .unwrap_or_else(|| {
+                            Balance::from_state(0, current_state.hash, current_state.state_number)
+                        });
+                    if creator_balance.value() < amount.value() {
+                        return Err(DsmError::insufficient_balance(
+                            token_id_str,
+                            creator_balance.value(),
+                            amount.value(),
+                        ));
+                    }
+                    next_state.token_balances.insert(
+                        creator_key,
+                        Balance::from_state(
+                            creator_balance.value() - amount.value(),
+                            current_state.hash,
+                            current_state.state_number,
+                        ),
+                    );
+                }
+            }
+        }
+        Operation::DlvInvalidate {
+            creator_public_key,
+            token_id,
+            locked_amount,
+            ..
+        } => {
+            if let Some((token_id_str, amount)) =
+                decode_dlv_lock(token_id, locked_amount, "DlvInvalidate")?
+            {
+                if amount.value() > 0 {
+                    let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str)?;
+                    let creator_key = crate::core::token::derive_canonical_balance_key(
+                        &policy_commit,
+                        creator_public_key.as_slice(),
+                        &token_id_str,
+                    );
+                    let creator_balance = next_state
+                        .token_balances
+                        .get(&creator_key)
+                        .cloned()
+                        .unwrap_or_else(|| {
+                            Balance::from_state(0, current_state.hash, current_state.state_number)
+                        });
+                    let restored_value = creator_balance
+                        .value()
+                        .checked_add(amount.value())
+                        .ok_or_else(|| {
+                            DsmError::invalid_operation(
+                                "Balance overflow on DLV invalidation restore",
+                            )
+                        })?;
+                    next_state.token_balances.insert(
+                        creator_key,
+                        Balance::from_state(
+                            restored_value,
+                            current_state.hash,
+                            current_state.state_number,
+                        ),
+                    );
+                }
+            }
+        }
+        Operation::DlvClaim {
+            claimant_public_key,
+            token_id,
+            locked_amount,
+            ..
+        } => {
+            if let Some((token_id_str, amount)) =
+                decode_dlv_lock(token_id, locked_amount, "DlvClaim")?
+            {
+                if amount.value() > 0 {
+                    let policy_commit = crate::core::token::resolve_policy_commit(&token_id_str)?;
+                    let claimant_key = crate::core::token::derive_canonical_balance_key(
+                        &policy_commit,
+                        claimant_public_key.as_slice(),
+                        &token_id_str,
+                    );
+                    let claimant_balance = next_state
+                        .token_balances
+                        .get(&claimant_key)
+                        .cloned()
+                        .unwrap_or_else(|| {
+                            Balance::from_state(0, current_state.hash, current_state.state_number)
+                        });
+                    let released_value = claimant_balance
+                        .value()
+                        .checked_add(amount.value())
+                        .ok_or_else(|| {
+                            DsmError::invalid_operation("Balance overflow on DLV claim release")
+                        })?;
+                    next_state.token_balances.insert(
+                        claimant_key,
+                        Balance::from_state(
+                            released_value,
+                            current_state.hash,
+                            current_state.state_number,
+                        ),
+                    );
+                }
+            }
         }
         _ => {}
     }
@@ -1874,6 +2022,41 @@ mod tests {
             .get(&recipient_key)
             .unwrap_or_else(|| panic!("recipient balance key should exist after credit"));
         assert_eq!(bal.value(), 10, "receiver should be credited 10 ERA");
+    }
+
+    #[test]
+    fn test_apply_token_balance_delta_dlv_invalidate_returns_locked_tokens() {
+        let current_state = create_test_state(1);
+        let mut next_state = current_state.clone();
+        let era_pc = crate::core::token::builtin_policy_commit_for_token("ERA").expect("ERA");
+        let creator_key = crate::core::token::derive_canonical_balance_key(
+            &era_pc,
+            &current_state.device_info.public_key,
+            "ERA",
+        );
+
+        let op = Operation::DlvInvalidate {
+            vault_id: vec![0x10; 32],
+            reason: "timeout".into(),
+            creator_public_key: current_state.device_info.public_key.clone(),
+            token_id: Some(b"ERA".to_vec()),
+            locked_amount: Some(Balance::from_state(
+                15,
+                current_state.hash,
+                current_state.state_number,
+            )),
+            signature: vec![0x01; 8],
+            mode: TransactionMode::Unilateral,
+        };
+
+        apply_token_balance_delta(&mut next_state, &current_state, &op)
+            .expect("DLV invalidate balance delta should apply");
+
+        let bal = next_state
+            .token_balances
+            .get(&creator_key)
+            .unwrap_or_else(|| panic!("creator balance key should be credited"));
+        assert_eq!(bal.value(), 15);
     }
 
     #[test]

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/token_state_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/token_state_manager.rs
@@ -73,23 +73,16 @@ pub fn builtin_policy_commit_for_token(token_id: &str) -> Option<[u8; 32]> {
     }
 }
 
-/// Resolve policy_commit for any token, including non-builtins.
+/// Resolve the canonical CPTA `policy_commit` for direct state-machine token ops.
 ///
-/// §9.1: All TokenOps MUST include `policy_commit`. For builtins (ERA, dBTC),
-/// the precomputed constants are returned. For CPTA-anchored custom tokens,
-/// the policy_commit is derived deterministically from the token_id using
-/// BLAKE3 domain separation. The full CPTA bytes should ideally be cached
-/// locally and verified by digest, but this derivation ensures balance
-/// mutations are never skipped for valid token operations.
-pub fn resolve_policy_commit(token_id: &str) -> [u8; 32] {
-    builtin_policy_commit_for_token(token_id).unwrap_or_else(|| {
-        // §9.3: policy_commit := BLAKE3-256("DSM/cpta\0" || canonical_cpta_bytes)
-        // For non-builtin tokens without cached CPTA bytes, derive a
-        // deterministic placeholder from the token_id. This ensures the
-        // state machine applies balance deltas for all tokens, not just
-        // builtins. The real policy_commit is verified at the receipt
-        // acceptance layer (§9.5 binding to policy).
-        crate::crypto::blake3::domain_hash_bytes("DSM/token-policy\0", token_id.as_bytes())
+/// Builtins (`ERA`, `dBTC`) resolve to their frozen anchors. Any other token must
+/// already have a verified policy anchor in the higher-level policy system; this
+/// low-level helper now fails closed instead of synthesizing a placeholder digest.
+pub fn resolve_policy_commit(token_id: &str) -> Result<[u8; 32], DsmError> {
+    builtin_policy_commit_for_token(token_id).ok_or_else(|| {
+        DsmError::invalid_operation(format!(
+            "Missing canonical policy anchor for token {token_id}"
+        ))
     })
 }
 
@@ -133,6 +126,10 @@ impl TokenStateManager {
     /// Uses an explicit token-local anchor when available, otherwise delegates
     /// to the configured `TokenPolicySystem`. Missing anchors fail closed.
     fn resolve_policy_commit(&self, token_id: &str) -> Result<[u8; 32], DsmError> {
+        if let Some(policy_commit) = builtin_policy_commit_for_token(token_id) {
+            return Ok(policy_commit);
+        }
+
         if let Some(token) = self.token_store.read().get(token_id) {
             if let Some(policy_anchor) = token.policy_anchor() {
                 return Ok(*policy_anchor);
@@ -145,6 +142,32 @@ impl TokenStateManager {
             Err(DsmError::invalid_operation(format!(
                 "Missing policy anchor for token {token_id}"
             )))
+        }
+    }
+
+    fn decode_dlv_lock_metadata(
+        token_id: &Option<Vec<u8>>,
+        locked_amount: &Option<Balance>,
+        op_name: &str,
+    ) -> Result<Option<(String, Balance)>, DsmError> {
+        match (token_id.as_ref(), locked_amount.as_ref()) {
+            (None, None) => Ok(None),
+            (Some(_), None) | (None, Some(_)) => Err(DsmError::invalid_operation(format!(
+                "{op_name} requires both token_id and locked_amount when settling locked tokens"
+            ))),
+            (Some(token_id), Some(locked_amount)) => {
+                let token_id_str = std::str::from_utf8(token_id).map_err(|_| {
+                    DsmError::invalid_operation(format!(
+                        "{op_name} token_id must be valid UTF-8 bytes"
+                    ))
+                })?;
+                if token_id_str.is_empty() {
+                    return Err(DsmError::invalid_operation(format!(
+                        "{op_name} token_id must not be empty"
+                    )));
+                }
+                Ok(Some((token_id_str.to_string(), locked_amount.clone())))
+            }
         }
     }
 
@@ -384,9 +407,10 @@ impl TokenStateManager {
                 creator_public_key,
                 ..
             } => {
-                if let (Some(tid), Some(amount)) = (token_id, locked_amount) {
+                if let Some((tid_str, amount)) =
+                    Self::decode_dlv_lock_metadata(token_id, locked_amount, "DlvCreate")?
+                {
                     if amount.value() > 0 {
-                        let tid_str = String::from_utf8_lossy(tid);
                         let creator_key =
                             self.make_balance_key(creator_public_key.as_slice(), &tid_str)?;
 
@@ -401,13 +425,12 @@ impl TokenStateManager {
 
                         if creator_balance.value() < amount.value() {
                             return Err(DsmError::insufficient_balance(
-                                tid_str.into_owned(),
+                                tid_str,
                                 creator_balance.value(),
                                 amount.value(),
                             ));
                         }
 
-                        // Deduct locked amount from creator's available balance
                         new_balances.insert(
                             creator_key,
                             Balance::from_state(
@@ -421,28 +444,81 @@ impl TokenStateManager {
             }
 
             Operation::DlvInvalidate {
-                creator_public_key, ..
+                creator_public_key,
+                token_id,
+                locked_amount,
+                ..
             } => {
-                // Vault invalidation returns locked tokens to the creator.
-                // The vault's locked_amount and token_id are not embedded in
-                // DlvInvalidate directly — the caller (DLVManager in Phase 5)
-                // is responsible for ensuring the DlvInvalidate operation is
-                // paired with correct balance restoration via the state's
-                // token_balances map before reaching this function.
-                //
-                // If the vault had no locked tokens, this is a no-op.
-                let _ = creator_public_key;
+                if let Some((tid_str, amount)) =
+                    Self::decode_dlv_lock_metadata(token_id, locked_amount, "DlvInvalidate")?
+                {
+                    if amount.value() > 0 {
+                        let creator_key =
+                            self.make_balance_key(creator_public_key.as_slice(), &tid_str)?;
+                        let creator_balance =
+                            new_balances.get(&creator_key).cloned().unwrap_or_else(|| {
+                                Balance::from_state(
+                                    0,
+                                    current_state.hash,
+                                    current_state.state_number,
+                                )
+                            });
+                        let restored_value = creator_balance
+                            .value()
+                            .checked_add(amount.value())
+                            .ok_or_else(|| {
+                                DsmError::invalid_operation(
+                                    "Balance overflow on DLV invalidation restore",
+                                )
+                            })?;
+                        new_balances.insert(
+                            creator_key,
+                            Balance::from_state(
+                                restored_value,
+                                current_state.hash,
+                                current_state.state_number,
+                            ),
+                        );
+                    }
+                }
             }
 
             Operation::DlvClaim {
                 claimant_public_key,
+                token_id,
+                locked_amount,
                 ..
             } => {
-                // Claim releases locked tokens to the claimant.
-                // Similar to DlvInvalidate, the vault's locked_amount and
-                // token_id are resolved by DLVManager and applied to the
-                // state's token_balances map before this function is called.
-                let _ = claimant_public_key;
+                if let Some((tid_str, amount)) =
+                    Self::decode_dlv_lock_metadata(token_id, locked_amount, "DlvClaim")?
+                {
+                    if amount.value() > 0 {
+                        let claimant_key =
+                            self.make_balance_key(claimant_public_key.as_slice(), &tid_str)?;
+                        let claimant_balance =
+                            new_balances.get(&claimant_key).cloned().unwrap_or_else(|| {
+                                Balance::from_state(
+                                    0,
+                                    current_state.hash,
+                                    current_state.state_number,
+                                )
+                            });
+                        let released_value = claimant_balance
+                            .value()
+                            .checked_add(amount.value())
+                            .ok_or_else(|| {
+                            DsmError::invalid_operation("Balance overflow on DLV claim release")
+                        })?;
+                        new_balances.insert(
+                            claimant_key,
+                            Balance::from_state(
+                                released_value,
+                                current_state.hash,
+                                current_state.state_number,
+                            ),
+                        );
+                    }
+                }
             }
 
             // DlvUnlock is a state-only transition (no balance change).
@@ -949,7 +1025,11 @@ impl TokenStateManager {
 
 #[cfg(test)]
 mod tests {
-    use super::derive_canonical_balance_key;
+    use super::{
+        builtin_policy_commit_for_token, derive_canonical_balance_key, resolve_policy_commit,
+        TokenStateManager,
+    };
+    use crate::types::{operations::Operation, state_types::State, token_types::Balance};
 
     #[test]
     fn canonical_balance_key_is_stable_for_same_semantic_input() {
@@ -980,5 +1060,82 @@ mod tests {
         let b = derive_canonical_balance_key(&policy_commit, &[0x44; 32], "dBTC");
 
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn resolve_policy_commit_rejects_unknown_token_without_anchor() {
+        let result = resolve_policy_commit("custom-unanchored-token");
+        assert!(
+            result.is_err(),
+            "unknown tokens must fail closed instead of synthesizing a placeholder policy commit"
+        );
+    }
+
+    #[test]
+    fn dlv_invalidate_returns_locked_balance_to_creator_atomically() {
+        use crate::types::operations::TransactionMode;
+        use crate::types::state_types::DeviceInfo;
+
+        let manager = TokenStateManager::new();
+        let era_policy = builtin_policy_commit_for_token("ERA").expect("ERA policy anchor");
+        manager.register_token_policy_anchor("ERA", era_policy);
+
+        let creator_pk = vec![0x33; 32];
+        let state = State::new_genesis([0x11; 32], DeviceInfo::new([0x22; 32], creator_pk.clone()));
+        let creator_key = manager
+            .make_balance_key(&creator_pk, "ERA")
+            .expect("creator balance key");
+
+        let op = Operation::DlvInvalidate {
+            vault_id: vec![0x44; 32],
+            reason: "invalidate".to_string(),
+            creator_public_key: creator_pk,
+            token_id: Some(b"ERA".to_vec()),
+            locked_amount: Some(Balance::from_state(25, state.hash, state.state_number)),
+            signature: vec![0x55; 16],
+            mode: TransactionMode::Unilateral,
+        };
+
+        let updated = manager
+            .apply_token_operation(&state, &op)
+            .expect("DLV invalidate should apply atomically");
+        let bal = updated
+            .get(&creator_key)
+            .unwrap_or_else(|| panic!("creator balance key should be credited"));
+        assert_eq!(bal.value(), 25);
+    }
+
+    #[test]
+    fn dlv_claim_credits_claimant_atomically() {
+        use crate::types::operations::TransactionMode;
+        use crate::types::state_types::DeviceInfo;
+
+        let manager = TokenStateManager::new();
+        let era_policy = builtin_policy_commit_for_token("ERA").expect("ERA policy anchor");
+        manager.register_token_policy_anchor("ERA", era_policy);
+
+        let claimant_pk = vec![0x66; 32];
+        let state = State::new_genesis([0x12; 32], DeviceInfo::new([0x23; 32], vec![0x99; 32]));
+        let claimant_key = manager
+            .make_balance_key(&claimant_pk, "ERA")
+            .expect("claimant balance key");
+
+        let op = Operation::DlvClaim {
+            vault_id: vec![0x77; 32],
+            claim_proof: vec![0x88; 48],
+            claimant_public_key: claimant_pk,
+            token_id: Some(b"ERA".to_vec()),
+            locked_amount: Some(Balance::from_state(40, state.hash, state.state_number)),
+            signature: vec![0x99; 16],
+            mode: TransactionMode::Unilateral,
+        };
+
+        let updated = manager
+            .apply_token_operation(&state, &op)
+            .expect("DLV claim should apply atomically");
+        let bal = updated
+            .get(&claimant_key)
+            .unwrap_or_else(|| panic!("claimant balance key should be credited"));
+        assert_eq!(bal.value(), 40);
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -484,6 +484,10 @@ pub enum Operation {
         claim_proof: Vec<u8>,
         /// SPHINCS+ public key of the claimant.
         claimant_public_key: Vec<u8>,
+        /// Binary token type locked in the vault, when token settlement is required.
+        token_id: Option<Vec<u8>>,
+        /// Amount of locked tokens to release atomically, when applicable.
+        locked_amount: Option<Balance>,
         /// SPHINCS+ signature by the claimant over canonical bytes.
         signature: Vec<u8>,
         /// Execution mode (typically Unilateral).
@@ -497,6 +501,10 @@ pub enum Operation {
         reason: String,
         /// SPHINCS+ public key of the vault creator.
         creator_public_key: Vec<u8>,
+        /// Binary token type locked in the vault, when token settlement is required.
+        token_id: Option<Vec<u8>>,
+        /// Amount of locked tokens to release atomically, when applicable.
+        locked_amount: Option<Balance>,
         /// SPHINCS+ signature by the creator over canonical bytes.
         signature: Vec<u8>,
         /// Execution mode (typically Unilateral).
@@ -997,6 +1005,8 @@ impl Operation {
                 vault_id,
                 claim_proof,
                 claimant_public_key,
+                token_id,
+                locked_amount,
                 signature,
                 mode,
             } => {
@@ -1004,6 +1014,21 @@ impl Operation {
                 put_bytes(&mut out, vault_id);
                 put_bytes(&mut out, claim_proof);
                 put_bytes(&mut out, claimant_public_key);
+                match token_id {
+                    Some(t) => {
+                        put_u8(&mut out, 1);
+                        put_bytes(&mut out, t);
+                    }
+                    None => put_u8(&mut out, 0),
+                }
+                match locked_amount {
+                    Some(a) => {
+                        put_u8(&mut out, 1);
+                        let bal = a.to_le_bytes();
+                        put_bytes(&mut out, &bal);
+                    }
+                    None => put_u8(&mut out, 0),
+                }
                 put_bytes(&mut out, signature);
                 put_mode(&mut out, mode);
             }
@@ -1011,6 +1036,8 @@ impl Operation {
                 vault_id,
                 reason,
                 creator_public_key,
+                token_id,
+                locked_amount,
                 signature,
                 mode,
             } => {
@@ -1018,6 +1045,21 @@ impl Operation {
                 put_bytes(&mut out, vault_id);
                 put_str(&mut out, reason);
                 put_bytes(&mut out, creator_public_key);
+                match token_id {
+                    Some(t) => {
+                        put_u8(&mut out, 1);
+                        put_bytes(&mut out, t);
+                    }
+                    None => put_u8(&mut out, 0),
+                }
+                match locked_amount {
+                    Some(a) => {
+                        put_u8(&mut out, 1);
+                        let bal = a.to_le_bytes();
+                        put_bytes(&mut out, &bal);
+                    }
+                    None => put_u8(&mut out, 0),
+                }
                 put_bytes(&mut out, signature);
                 put_mode(&mut out, mode);
             }
@@ -1624,12 +1666,24 @@ impl Operation {
                 let vault_id = get_bytes(&mut input)?;
                 let claim_proof = get_bytes(&mut input)?;
                 let claimant_public_key = get_bytes(&mut input)?;
+                let token_id = match get_u8(&mut input)? {
+                    0 => None,
+                    1 => Some(get_bytes(&mut input)?),
+                    _ => return Err(DsmError::invalid_operation("bad opt flag")),
+                };
+                let locked_amount = match get_u8(&mut input)? {
+                    0 => None,
+                    1 => Some(dec_balance(&mut input)?),
+                    _ => return Err(DsmError::invalid_operation("bad opt flag")),
+                };
                 let signature = get_bytes(&mut input)?;
                 let mode = dec_mode(&mut input)?;
                 DlvClaim {
                     vault_id,
                     claim_proof,
                     claimant_public_key,
+                    token_id,
+                    locked_amount,
                     signature,
                     mode,
                 }
@@ -1638,12 +1692,24 @@ impl Operation {
                 let vault_id = get_bytes(&mut input)?;
                 let reason = get_str(&mut input)?;
                 let creator_public_key = get_bytes(&mut input)?;
+                let token_id = match get_u8(&mut input)? {
+                    0 => None,
+                    1 => Some(get_bytes(&mut input)?),
+                    _ => return Err(DsmError::invalid_operation("bad opt flag")),
+                };
+                let locked_amount = match get_u8(&mut input)? {
+                    0 => None,
+                    1 => Some(dec_balance(&mut input)?),
+                    _ => return Err(DsmError::invalid_operation("bad opt flag")),
+                };
                 let signature = get_bytes(&mut input)?;
                 let mode = dec_mode(&mut input)?;
                 DlvInvalidate {
                     vault_id,
                     reason,
                     creator_public_key,
+                    token_id,
+                    locked_amount,
                     signature,
                     mode,
                 }
@@ -2453,6 +2519,8 @@ mod tests {
                 vault_id: vec![0x01; 32],
                 claim_proof: vec![0x02; 64],
                 claimant_public_key: vec![0x03; 64],
+                token_id: Some(b"ERA".to_vec()),
+                locked_amount: Some(Balance::from_state(7, [0u8; 32], 0)),
                 signature: vec![0x04; 48],
                 mode: TransactionMode::Bilateral,
             });
@@ -2464,6 +2532,8 @@ mod tests {
                 vault_id: vec![0x01; 32],
                 reason: "timeout expired".into(),
                 creator_public_key: vec![0x02; 64],
+                token_id: Some(b"ERA".to_vec()),
+                locked_amount: Some(Balance::from_state(9, [0u8; 32], 0)),
                 signature: vec![0x03; 48],
                 mode: TransactionMode::Unilateral,
             });
@@ -2716,6 +2786,8 @@ mod tests {
                     vault_id: vec![],
                     claim_proof: vec![],
                     claimant_public_key: vec![],
+                    token_id: None,
+                    locked_amount: None,
                     signature: vec![],
                     mode: TransactionMode::Bilateral,
                 }
@@ -2728,6 +2800,8 @@ mod tests {
                     vault_id: vec![],
                     reason: String::new(),
                     creator_public_key: vec![],
+                    token_id: None,
+                    locked_amount: None,
                     signature: vec![],
                     mode: TransactionMode::Bilateral,
                 }

--- a/dsm_client/deterministic_state_machine/dsm/src/vault/dlv_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/vault/dlv_manager.rs
@@ -14,10 +14,15 @@ use crate::types::{error::DsmError, state_types::State};
 use prost::Message; // for encode_to_vec()
 use std::{collections::HashMap, sync::Arc};
 
+type VaultSettlementMetadata = (Option<Vec<u8>>, Option<Balance>);
+
 /// Manages Limbo Vaults
 pub struct DLVManager {
     /// Vaults managed by this instance, keyed by vault ID
     vaults: tokio::sync::RwLock<HashMap<String, Arc<tokio::sync::Mutex<LimboVault>>>>,
+    /// Token-lock metadata tracked alongside each vault so claim/invalidate
+    /// can settle balances atomically in the same state transition.
+    settlement_metadata: tokio::sync::RwLock<HashMap<String, VaultSettlementMetadata>>,
 }
 
 impl DLVManager {
@@ -25,7 +30,59 @@ impl DLVManager {
     pub fn new() -> Self {
         Self {
             vaults: tokio::sync::RwLock::new(HashMap::new()),
+            settlement_metadata: tokio::sync::RwLock::new(HashMap::new()),
         }
+    }
+
+    fn fallback_settlement_metadata(
+        vault: &LimboVault,
+        state_hash: [u8; 32],
+        state_number: u64,
+    ) -> VaultSettlementMetadata {
+        match &vault.fulfillment_condition {
+            FulfillmentMechanism::Payment {
+                amount, token_id, ..
+            } if *amount > 0 && !token_id.is_empty() => (
+                Some(token_id.as_bytes().to_vec()),
+                Some(Balance::from_state(*amount, state_hash, state_number)),
+            ),
+            _ => (None, None),
+        }
+    }
+
+    async fn settlement_metadata_for_vault(
+        &self,
+        vault_id: &str,
+        vault: &LimboVault,
+        reference_state: &State,
+    ) -> Result<VaultSettlementMetadata, DsmError> {
+        let tracked = {
+            let metadata = self.settlement_metadata.read().await;
+            metadata.get(vault_id).cloned()
+        };
+
+        if let Some((token_id, locked_amount)) = tracked {
+            return match (&token_id, &locked_amount) {
+                (None, None) => Ok((None, None)),
+                (Some(_), Some(amount)) => Ok((
+                    token_id,
+                    Some(Balance::from_state(
+                        amount.value(),
+                        reference_state.hash,
+                        reference_state.state_number,
+                    )),
+                )),
+                _ => Err(DsmError::invalid_operation(format!(
+                    "Vault {vault_id} has incomplete settlement metadata"
+                ))),
+            };
+        }
+
+        Ok(Self::fallback_settlement_metadata(
+            vault,
+            reference_state.hash,
+            reference_state.state_number,
+        ))
     }
 
     /// Create a new vault and return the vault ID with an unsigned `Operation::DlvCreate`.
@@ -62,6 +119,7 @@ impl DLVManager {
         let fulfillment_bytes = fm_proto.encode_to_vec();
 
         // Build the unsigned DlvCreate operation
+        let locked_token_id = token_id.map(|s| s.as_bytes().to_vec());
         let locked_balance = locked_amount.map(|amt| {
             Balance::from_state(amt, reference_state.hash, reference_state.state_number)
         });
@@ -72,15 +130,18 @@ impl DLVManager {
             parameters_hash: vault.parameters_hash.clone(),
             fulfillment_condition: fulfillment_bytes,
             intended_recipient: intended_recipient.clone(),
-            token_id: token_id.map(|s| s.as_bytes().to_vec()),
-            locked_amount: locked_balance,
+            token_id: locked_token_id.clone(),
+            locked_amount: locked_balance.clone(),
             signature: vec![], // unsigned — caller must sign
             mode: TransactionMode::Unilateral,
         };
 
-        // Store the vault
+        // Store the vault and its settlement metadata.
         let mut vaults = self.vaults.write().await;
         vaults.insert(vault_id.clone(), Arc::new(tokio::sync::Mutex::new(vault)));
+        drop(vaults);
+        let mut settlement_metadata = self.settlement_metadata.write().await;
+        settlement_metadata.insert(vault_id.clone(), (locked_token_id, locked_balance));
 
         Ok((vault_id, operation))
     }
@@ -192,11 +253,19 @@ impl DLVManager {
         let vault_lock = self.get_vault(vault_id).await?;
         let mut vault = vault_lock.lock().await;
         let result = vault.claim(claimant_kyber_sk, reference_state)?;
+        let vault_snapshot = result.vault.clone();
+        drop(vault);
+
+        let (token_id, locked_amount) = self
+            .settlement_metadata_for_vault(vault_id, &vault_snapshot, reference_state)
+            .await?;
 
         let operation = Operation::DlvClaim {
             vault_id: vault_id.as_bytes().to_vec(),
             claim_proof: result.claim_proof.clone(),
             claimant_public_key: claimant_signing_pk.to_vec(),
+            token_id,
+            locked_amount,
             signature: vec![], // unsigned — caller must sign
             mode: TransactionMode::Unilateral,
         };
@@ -222,11 +291,19 @@ impl DLVManager {
         let creator_pk = vault.creator_public_key.clone();
 
         vault.invalidate(reason, creator_private_key, reference_state)?;
+        let vault_snapshot = vault.clone();
+        drop(vault);
+
+        let (token_id, locked_amount) = self
+            .settlement_metadata_for_vault(vault_id, &vault_snapshot, reference_state)
+            .await?;
 
         let operation = Operation::DlvInvalidate {
             vault_id: vault_id.as_bytes().to_vec(),
             reason: reason.to_string(),
             creator_public_key: creator_pk,
+            token_id,
+            locked_amount,
             signature: vec![], // unsigned — caller must sign
             mode: TransactionMode::Unilateral,
         };
@@ -237,8 +314,16 @@ impl DLVManager {
     /// Add an existing vault to the manager
     pub async fn add_vault(&self, vault: LimboVault) -> Result<String, DsmError> {
         let vault_id = vault.id.clone();
+        let fallback = Self::fallback_settlement_metadata(
+            &vault,
+            vault.reference_state_hash,
+            vault.created_at_state,
+        );
         let mut vaults = self.vaults.write().await;
         vaults.insert(vault_id.clone(), Arc::new(tokio::sync::Mutex::new(vault)));
+        drop(vaults);
+        let mut settlement_metadata = self.settlement_metadata.write().await;
+        settlement_metadata.insert(vault_id.clone(), fallback);
         Ok(vault_id)
     }
 


### PR DESCRIPTION
### What changed
- reject synthetic fallback policy commits for unknown tokens
- carry DLV settlement metadata through operations
- settle DLV create/claim/invalidate token balances atomically in both token and transition paths
- add regressions for unknown-token rejection and DLV credit/restore behavior

### Why
The previous behavior allowed unanchored token operations to proceed with a fabricated digest and left DLV claim/invalidate settlement to external coordination, which could cause balance drift.


Closes #196