### PR TITLE
fix(verification): enforce real signature checks

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/verification/dual_mode_verifier.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/verification/dual_mode_verifier.rs
@@ -159,9 +159,9 @@ impl DualModeVerifier {
 
             // Verify entity signature
             match crypto::verify_signature(
+                &next_state.device_info.public_key,
                 &state_data,
                 entity_sig,
-                &next_state.device_info.public_key,
             ) {
                 Ok(valid) => {
                     if !valid {
@@ -174,9 +174,9 @@ impl DualModeVerifier {
             // Verify counterparty signature if relationship exists
             if let Some(relationship) = &next_state.relationship_context {
                 match crypto::verify_signature(
+                    &relationship.counterparty_public_key,
                     &state_data,
                     counterparty_sig,
-                    &relationship.counterparty_public_key,
                 ) {
                     Ok(valid) => {
                         if !valid {
@@ -207,7 +207,7 @@ impl DualModeVerifier {
             //     state_data.extend_from_slice(data);
             // }
 
-            crypto::verify_signature(&state_data, signature, &next_state.device_info.public_key)
+            crypto::verify_signature(&next_state.device_info.public_key, &state_data, signature)
         } else {
             Ok(false)
         }
@@ -355,6 +355,7 @@ impl DualModeVerifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::crypto::signatures::SignatureKeyPair;
     use crate::types::state_types::{DeviceInfo, State, StateParams, RelationshipContext};
 
     fn make_device_info() -> DeviceInfo {
@@ -382,6 +383,18 @@ mod tests {
         let mut s = State::new(params);
         s.token_balances = prev.token_balances.clone();
         s
+    }
+
+    fn make_signed_state_with_keypair(device_id: [u8; 32]) -> (StateTypesState, SignatureKeyPair) {
+        let keypair = SignatureKeyPair::new().expect("keypair");
+        let mut state = State::new_genesis(
+            [0xAA; 32],
+            DeviceInfo::new(device_id, keypair.public_key.clone()),
+        );
+        state
+            .token_balances
+            .insert("ERA".to_string(), Balance::from_state(1000, [0u8; 32], 0));
+        (state, keypair)
     }
 
     #[test]
@@ -539,5 +552,72 @@ mod tests {
         ));
         let result = DualModeVerifier::verify_recipient_identity(&state).unwrap();
         assert!(!result, "empty counterparty public key should fail");
+    }
+
+    #[test]
+    fn verify_unilateral_accepts_valid_entity_signature() {
+        let (current, entity_keys) = make_signed_state_with_keypair([0x11; 32]);
+        let transfer = Operation::Transfer {
+            to_device_id: vec![0x33; 32],
+            amount: Balance::from_state(10, [0u8; 32], 0),
+            token_id: b"ERA".to_vec(),
+            mode: TransactionMode::Unilateral,
+            nonce: vec![7, 7, 7],
+            verification: crate::types::operations::VerificationType::Standard,
+            pre_commit: None,
+            recipient: vec![0x33; 32],
+            to: vec![0x33; 32],
+            message: "unilateral".to_string(),
+            signature: vec![],
+        };
+        let mut next = make_next_state(&current, transfer.clone(), vec![0xAB; 32]);
+        next.device_info.public_key = entity_keys.public_key.clone();
+        next.relationship_context = Some(RelationshipContext::new(
+            [0x11; 32],
+            [0x33; 32],
+            vec![0x44; 64],
+        ));
+        let state_data = next.hash().unwrap().to_vec();
+        next.entity_sig = Some(entity_keys.sign(&state_data).expect("sign entity state"));
+
+        let result = DualModeVerifier::verify_transition(&current, &next, &transfer).unwrap();
+        assert!(result, "valid unilateral entity signature should verify");
+    }
+
+    #[test]
+    fn verify_bilateral_accepts_valid_entity_and_counterparty_signatures() {
+        let (current, entity_keys) = make_signed_state_with_keypair([0x11; 32]);
+        let counterparty_keys = SignatureKeyPair::new().expect("counterparty keypair");
+
+        let transfer = Operation::Transfer {
+            to_device_id: vec![0x33; 32],
+            amount: Balance::from_state(10, [0u8; 32], 0),
+            token_id: b"ERA".to_vec(),
+            mode: TransactionMode::Bilateral,
+            nonce: vec![8, 8, 8],
+            verification: crate::types::operations::VerificationType::Standard,
+            pre_commit: None,
+            recipient: vec![0x33; 32],
+            to: vec![0x33; 32],
+            message: "bilateral".to_string(),
+            signature: vec![],
+        };
+        let mut next = make_next_state(&current, transfer.clone(), vec![0xBC; 32]);
+        next.device_info.public_key = entity_keys.public_key.clone();
+        next.relationship_context = Some(RelationshipContext::new(
+            [0x11; 32],
+            [0x33; 32],
+            counterparty_keys.public_key.clone(),
+        ));
+        let state_data = next.hash().unwrap().to_vec();
+        next.entity_sig = Some(entity_keys.sign(&state_data).expect("sign entity state"));
+        next.counterparty_sig = Some(
+            counterparty_keys
+                .sign(&state_data)
+                .expect("sign counterparty state"),
+        );
+
+        let result = DualModeVerifier::verify_transition(&current, &next, &transfer).unwrap();
+        assert!(result, "valid bilateral signatures should verify");
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/core/verification/identity_verifier.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/verification/identity_verifier.rs
@@ -29,12 +29,17 @@ impl IdentityVerifier {
             return Ok(false);
         }
 
-        // 2. Verify the claim signature using cryptographic primitives
+        // 2. The claim must present the same public key as the registered anchor.
+        if claim.public_key != anchor.public_key {
+            return Ok(false);
+        }
+
+        // 3. Verify the claim signature using cryptographic primitives.
         if !Self::verify_claim_signature(claim)? {
             return Ok(false);
         }
 
-        // 3. Verify the claim commitments against anchor expectations
+        // 4. Verify the claim commitments against anchor expectations
         if !Self::verify_claim_commitments(claim, anchor)? {
             return Ok(false);
         }
@@ -42,32 +47,27 @@ impl IdentityVerifier {
         Ok(true)
     }
 
-    /// Verify identity claim signature
+    /// Verify identity claim signature using the claim's anchored SPHINCS+ public key.
     fn verify_claim_signature(claim: &IdentityClaim) -> Result<bool, DsmError> {
-        // Generate hash of claim data
         let mut hasher = crate::crypto::blake3::dsm_domain_hasher("DSM/identity/claim");
-
-        // Add all claim fields to hash
         hasher.update(claim.identity_id.as_bytes());
         hasher.update(&claim.tick.to_le_bytes());
         hasher.update(&claim.expires_at_tick.to_le_bytes());
-
-        // Verify signature on the hash
         let claimed_hash = hasher.finalize();
 
-        // In a real implementation, this would verify the signature
-        // using the appropriate signature scheme (e.g., ECDSA, EdDSA)
-        // For now, we simply check that the signature is not empty
-        if claim.signature.is_empty() {
+        if claim.signature.is_empty() || claim.public_key.is_empty() {
             return Ok(false);
         }
 
-        // Compare hash to the expected value (in real implementation this would check signature)
         if claimed_hash.as_bytes() != claim.claim_hash.as_slice() {
             return Ok(false);
         }
 
-        Ok(true)
+        crate::crypto::verify_signature(
+            &claim.public_key,
+            claimed_hash.as_bytes(),
+            &claim.signature,
+        )
     }
 
     /// Verify claim commitments against anchor expectations
@@ -121,6 +121,7 @@ impl IdentityVerifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::crypto::signatures::SignatureKeyPair;
     use crate::types::state_types::DeviceInfo;
     use std::collections::HashMap;
 
@@ -150,15 +151,17 @@ mod tests {
         let expires_at_tick = 100u64;
         let created_at_tick = 5u64;
 
+        let keypair = SignatureKeyPair::new().expect("identity keypair");
         let claim_hash = compute_claim_hash(identity_id, tick, expires_at_tick);
+        let signature = keypair.sign(&claim_hash).expect("sign identity claim");
         let anchor_commitment = compute_anchor_commitment(identity_id, created_at_tick, None);
 
         let claim = IdentityClaim {
             identity_id: identity_id.to_string(),
             tick,
             expires_at_tick,
-            public_key: vec![0x42; 32],
-            signature: vec![0xFF; 64], // non-empty
+            public_key: keypair.public_key.clone(),
+            signature,
             claim_hash,
             anchor_commitment,
             device_info: DeviceInfo::default(),
@@ -167,7 +170,7 @@ mod tests {
 
         let anchor = IdentityAnchor {
             identity_id: identity_id.to_string(),
-            public_key: vec![0x42; 32],
+            public_key: keypair.public_key.clone(),
             created_at_tick,
             revoked_at_tick: None,
             meta_data: HashMap::new(),
@@ -208,6 +211,27 @@ mod tests {
 
         let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
         assert!(!result, "wrong claim hash should fail");
+    }
+
+    #[test]
+    fn verify_rejects_non_cryptographic_signature_bytes() {
+        let (mut claim, anchor) = make_valid_claim_and_anchor();
+        claim.signature = vec![0xAA; 64];
+
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(
+            !result,
+            "a non-empty but invalid signature must fail real cryptographic verification"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_anchor_public_key_mismatch() {
+        let (claim, mut anchor) = make_valid_claim_and_anchor();
+        anchor.public_key = vec![0x55; 32];
+
+        let result = IdentityVerifier::verify_identity_claim(&claim, &anchor).unwrap();
+        assert!(!result, "anchor/public-key mismatch should fail");
     }
 
     #[test]
@@ -274,12 +298,15 @@ mod tests {
         let anchor_commitment =
             compute_anchor_commitment(identity_id, created_at_tick, revoked_at_tick);
 
+        let keypair = SignatureKeyPair::new().expect("identity keypair");
+        let signature = keypair.sign(&claim_hash).expect("sign identity claim");
+
         let claim = IdentityClaim {
             identity_id: identity_id.to_string(),
             tick,
             expires_at_tick: expires,
-            public_key: vec![0x42; 32],
-            signature: vec![0xFF; 64],
+            public_key: keypair.public_key.clone(),
+            signature,
             claim_hash,
             anchor_commitment,
             device_info: DeviceInfo::default(),
@@ -288,7 +315,7 @@ mod tests {
 
         let anchor = IdentityAnchor {
             identity_id: identity_id.to_string(),
-            public_key: vec![0x42; 32],
+            public_key: keypair.public_key.clone(),
             created_at_tick,
             revoked_at_tick,
             meta_data: HashMap::new(),


### PR DESCRIPTION
## Summary

Closes #195 

This PR hardens the verification layer in two critical places:

- fixes the live `verify_signature()` call sites in `DualModeVerifier` so they pass `(public_key, message, signature)` in the correct order
- replaces the placeholder identity-claim signature check with real fail-closed cryptographic verification

### Applied fixes
- correct the bilateral and unilateral state-signature verification call order
- require identity claims to verify against the reconstructed claim hash with the anchored public key
- reject non-empty garbage signatures and anchor/public-key mismatches
- add regression tests covering both corrected verification paths


## Notes

This is a fail-closed verification fix: claims and state transitions now require the intended cryptographic checks instead of relying on swapped parameters or placeholder non-empty-signature logic.