### PR TITLE
fix(state-machine): require local unilateral signature checks

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/relationship.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/relationship.rs
@@ -908,21 +908,31 @@ impl RelationshipManager {
         }
     }
 
+    fn canonical_party_id(entity_id: &[u8; 32]) -> String {
+        let mut hi = [0u8; 16];
+        hi.copy_from_slice(&entity_id[..16]);
+        let mut lo = [0u8; 16];
+        lo.copy_from_slice(&entity_id[16..]);
+        format!("ID:{}:{}", u128::from_be_bytes(hi), u128::from_be_bytes(lo))
+    }
+
     /// Derive a canonical relationship key using entity and counterparty IDs.
-    /// For `Hashed`, renders as "H:<u128_low>:<u128_high>" (decimal; no hex/base64).
+    /// All live strategies use exact binary-bound decimal renderings; no Base32 or
+    /// other text encodings appear on the key-derivation path.
     pub fn get_relationship_key(&self, entity_id: &[u8; 32], counterparty_id: &[u8; 32]) -> String {
+        let entity_key = Self::canonical_party_id(entity_id);
+        let counterparty_key = Self::canonical_party_id(counterparty_id);
+
         match self.key_derivation_strategy {
             KeyDerivationStrategy::Canonical => {
-                let entity_str = base32::encode(base32::Alphabet::Crockford, entity_id);
-                let counterparty_str = base32::encode(base32::Alphabet::Crockford, counterparty_id);
-                let mut ids = [entity_str, counterparty_str];
-                ids.sort();
-                format!("{}:{}", ids[0], ids[1])
+                if entity_id <= counterparty_id {
+                    format!("REL:{entity_key}|{counterparty_key}")
+                } else {
+                    format!("REL:{counterparty_key}|{entity_key}")
+                }
             }
             KeyDerivationStrategy::EntityCentric => {
-                let entity_str = base32::encode(base32::Alphabet::Crockford, entity_id);
-                let counterparty_str = base32::encode(base32::Alphabet::Crockford, counterparty_id);
-                format!("{entity_str}:{counterparty_str}")
+                format!("RELCTX:{entity_key}|{counterparty_key}")
             }
             KeyDerivationStrategy::Hashed => {
                 let mut h = dsm_domain_hasher("DSM/RELKEY/v2");
@@ -1403,10 +1413,11 @@ mod tests {
             .unwrap();
         assert!(exists);
 
-        // Canonical keys are symmetric in order
+        // Canonical keys are symmetric in order and remain binary-bound rather than Base32 text.
         let canonical_key = manager.get_relationship_key(&entity_id, &counterparty_id);
         let canonical_key2 = manager.get_relationship_key(&counterparty_id, &entity_id);
         assert_eq!(canonical_key, canonical_key2);
+        assert!(canonical_key.starts_with("REL:ID:"));
 
         // Hashed key (no hex) returns a decimal-tagged string, stable and non-empty
         let hashed_manager = RelationshipManager::new(KeyDerivationStrategy::Hashed);

--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/transition.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/transition.rs
@@ -872,17 +872,24 @@ pub fn create_next_state(
             }
             let is_local_recipient = to_device_id.len() == 32
                 && to_device_id.as_slice() == current_state.device_info.device_id.as_slice();
-            if is_local_recipient && matches!(mode, TransactionMode::Unilateral) {
-                log::warn!(
-                    "Transfer signature verified upstream for incoming unilateral transfer; skipping local key check"
-                );
+            let verification_key = if is_local_recipient
+                && matches!(mode, TransactionMode::Unilateral)
+            {
+                current_state
+                    .relationship_context
+                    .as_ref()
+                    .filter(|ctx| !ctx.counterparty_public_key.is_empty())
+                    .map(|ctx| ctx.counterparty_public_key.as_slice())
+                    .ok_or_else(|| {
+                        DsmError::invalid_operation(
+                            "Incoming unilateral transfer missing counterparty public key for local signature verification",
+                        )
+                    })?
             } else {
-                verify_operation_signature(
-                    &operation,
-                    &current_state.device_info.public_key,
-                    "Transfer",
-                )?;
-            }
+                current_state.device_info.public_key.as_slice()
+            };
+
+            verify_operation_signature(&operation, verification_key, "Transfer")?;
         }
 
         // ── Device-key signed operations ──────────────────────────
@@ -1833,10 +1840,17 @@ mod tests {
     #[test]
     fn test_create_next_state_incoming_transfer_adds_balance() {
         // Whitepaper §8: balance delta is applied atomically inside create_next_state.
-        // When this device is the recipient (to_device_id == local device_id),
-        // apply_token_balance_delta credits using the device's public_key (not device_id),
-        // because all balance reads derive keys from public_key.
-        let current_state = create_test_state(1);
+        // Incoming unilateral transfers must still verify locally using the
+        // counterparty public key stored in the relationship context.
+        let (sender_pk, sender_sk) = generate_sphincs_keypair().expect("sender keypair");
+        let mut current_state = create_test_state(1);
+        current_state.relationship_context =
+            Some(crate::types::state_types::RelationshipContext::new(
+                current_state.device_info.device_id,
+                [0x44; 32],
+                sender_pk.clone(),
+            ));
+
         let policy_commit =
             crate::core::token::builtin_policy_commit_for_token("ERA").expect("ERA policy commit");
         let recipient_key = crate::core::token::derive_canonical_balance_key(
@@ -1844,6 +1858,23 @@ mod tests {
             &current_state.device_info.public_key,
             "ERA",
         );
+
+        let signature = {
+            let unsigned = Operation::Transfer {
+                amount: Balance::from_state(10, current_state.hash, 0),
+                token_id: b"ERA".to_vec(),
+                to_device_id: TEST_DEVICE_ID.to_vec(),
+                nonce: vec![1, 2, 3],
+                pre_commit: None,
+                recipient: TEST_DEVICE_ID.to_vec(),
+                message: "incoming".to_string(),
+                mode: TransactionMode::Unilateral,
+                verification: OpVerificationType::Standard,
+                to: TEST_DEVICE_ID.to_vec(),
+                signature: Vec::new(),
+            };
+            sphincs_sign(&sender_sk, &unsigned.to_bytes()).expect("sign incoming transfer")
+        };
 
         let operation = Operation::Transfer {
             amount: Balance::from_state(10, current_state.hash, 0),
@@ -1855,8 +1886,8 @@ mod tests {
             message: "incoming".to_string(),
             mode: TransactionMode::Unilateral,
             verification: OpVerificationType::Standard,
-            to: b"recipient".to_vec(),
-            signature: vec![1u8],
+            to: TEST_DEVICE_ID.to_vec(),
+            signature,
         };
 
         let entropy = vec![1, 2, 3, 4];
@@ -1874,6 +1905,57 @@ mod tests {
             .get(&recipient_key)
             .unwrap_or_else(|| panic!("recipient balance key should exist after credit"));
         assert_eq!(bal.value(), 10, "receiver should be credited 10 ERA");
+    }
+
+    #[test]
+    fn test_create_next_state_incoming_transfer_requires_counterparty_key() {
+        let (_sender_pk, sender_sk) = generate_sphincs_keypair().expect("sender keypair");
+        let current_state = create_test_state(1);
+
+        let signature = {
+            let unsigned = Operation::Transfer {
+                amount: Balance::from_state(10, current_state.hash, 0),
+                token_id: b"ERA".to_vec(),
+                to_device_id: TEST_DEVICE_ID.to_vec(),
+                nonce: vec![9, 8, 7],
+                pre_commit: None,
+                recipient: TEST_DEVICE_ID.to_vec(),
+                message: "incoming without relationship context".to_string(),
+                mode: TransactionMode::Unilateral,
+                verification: OpVerificationType::Standard,
+                to: TEST_DEVICE_ID.to_vec(),
+                signature: Vec::new(),
+            };
+            sphincs_sign(&sender_sk, &unsigned.to_bytes()).expect("sign incoming transfer")
+        };
+
+        let operation = Operation::Transfer {
+            amount: Balance::from_state(10, current_state.hash, 0),
+            token_id: b"ERA".to_vec(),
+            to_device_id: TEST_DEVICE_ID.to_vec(),
+            nonce: vec![9, 8, 7],
+            pre_commit: None,
+            recipient: TEST_DEVICE_ID.to_vec(),
+            message: "incoming without relationship context".to_string(),
+            mode: TransactionMode::Unilateral,
+            verification: OpVerificationType::Standard,
+            to: TEST_DEVICE_ID.to_vec(),
+            signature,
+        };
+
+        let err = create_next_state(
+            &current_state,
+            operation,
+            &[1, 2, 3, 4],
+            &super::VerificationType::Standard,
+            false,
+        )
+        .expect_err("incoming unilateral transfer without a counterparty key must fail closed");
+
+        assert!(
+            err.to_string().contains("counterparty public key"),
+            "error should explain the missing local verification key: {err}"
+        );
     }
 
     #[test]

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bilateral_sessions.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bilateral_sessions.rs
@@ -359,7 +359,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn store_bilateral_session_accepts_all_valid_phases() {
+        init_test_db();
+
         let valid_phases = [
             "prepare",
             "accept",


### PR DESCRIPTION
## Summary

Closes https://github.com/deterministicstatemachine/dsm/issues/194

This PR hardens the state-machine trust boundary in two places:

- removes Base32/text-derived relationship keys from live canonical/entity-centric strategies
- makes incoming unilateral transfers verify locally with the counterparty public key instead of trusting an upstream “already verified” claim

### Applied fixes
- derive relationship keys from the exact 32-byte IDs using binary-bound canonical formatting
- fail closed if an incoming unilateral transfer lacks a counterparty public key for local verification
- add regression coverage for both the corrected relationship-key behavior and the unilateral receive signature gate


## Notes

This is a fail-closed trust-boundary fix: local devices no longer accept unilateral incoming transfers based solely on upstream verification claims.