### PR TITLE
fix(security): reject malformed token ids in balance checks

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/security/manipulation_resistance.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/security/manipulation_resistance.rs
@@ -290,10 +290,14 @@ impl ManipulationResistance {
             } => {
                 let amount_value = amount.value();
 
-                // Convert binary token_id to string key for balance lookup
-                let token_key = std::str::from_utf8(token_id).unwrap_or("");
+                let token_key = match std::str::from_utf8(token_id) {
+                    Ok(key) if !key.is_empty() => key,
+                    _ => return Ok(false),
+                };
 
-                // Check balance for the specific token being transferred
+                // Check balance for the specific token being transferred.
+                // Malformed token IDs must be rejected rather than collapsing
+                // onto an empty-string balance key.
                 let current_balance = current
                     .token_balances
                     .get(token_key)
@@ -725,6 +729,44 @@ mod tests {
 
         let result = ManipulationResistance::verify_balance_conservation(&current, &next).unwrap();
         assert!(!result);
+    }
+
+    #[test]
+    fn balance_conservation_rejects_malformed_transfer_token_id() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("".into(), Balance::from_state(100, [0; 32], 5));
+
+        let mut next = make_state(6);
+        next.operation = make_transfer_op(40, b"alice", &[0xFF, 0xFE, 0xFD]);
+        next.token_balances
+            .insert("".into(), Balance::from_state(60, [0; 32], 6));
+
+        let result = ManipulationResistance::verify_balance_conservation(&current, &next).unwrap();
+        assert!(
+            !result,
+            "non-UTF8 token ids must be rejected instead of collapsing to the empty key"
+        );
+    }
+
+    #[test]
+    fn balance_conservation_rejects_empty_transfer_token_id() {
+        let mut current = make_state(5);
+        current
+            .token_balances
+            .insert("".into(), Balance::from_state(100, [0; 32], 5));
+
+        let mut next = make_state(6);
+        next.operation = make_transfer_op(40, b"alice", b"");
+        next.token_balances
+            .insert("".into(), Balance::from_state(60, [0; 32], 6));
+
+        let result = ManipulationResistance::verify_balance_conservation(&current, &next).unwrap();
+        assert!(
+            !result,
+            "empty token ids must be rejected instead of aliasing the empty balance slot"
+        );
     }
 
     // ── verify_signatures (state gap) ───────────────────────────────

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bilateral_sessions.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bilateral_sessions.rs
@@ -359,7 +359,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn store_bilateral_session_accepts_all_valid_phases() {
+        init_test_db();
+
         let valid_phases = [
             "prepare",
             "accept",


### PR DESCRIPTION
# Summary

Closes https://github.com/deterministicstatemachine/dsm/issues/193

This PR hardens the balance-conservation verifier so malformed or empty transfer `token_id` bytes are rejected instead of being silently coerced into the empty-string balance key.

### Applied fixes
- remove the `from_utf8(...).unwrap_or("")` fallback from `ManipulationResistance::verify_balance_conservation()`
- reject malformed and empty token IDs during transfer verification
- add regression coverage proving malformed token IDs can no longer alias `""`
- keep the shared `dsm_sdk` bilateral-session test isolated so the full pre-push workflow stays green on issue branches created from `main`

## Notes

This is a fail-closed change: malformed token identifiers are no longer tolerated or silently remapped during security-critical balance verification.