### PR TITLE
fix(identity): bind store and invalidation to canonical genesis ids

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis.rs
@@ -9,7 +9,6 @@
 //! - Hashing: BLAKE3 everywhere (32-byte outputs).
 
 use crate::core::identity::Identity;
-use crate::core::utility::labeling;
 use crate::crypto::kyber;
 use crate::crypto::sphincs;
 use crate::types::error::DsmError;
@@ -254,29 +253,57 @@ pub fn derive_device_sub_genesis(
 
 // -------------------- Invalidation --------------------
 
+const INVALIDATION_REQUEST_DOMAIN: &[u8] = b"DSM/identity/invalidate\0";
+
 pub fn create_invalidation_request(identity: &Identity, reason: &str) -> Result<Vec<u8>, DsmError> {
-    let id_str = labeling::identity_to_string(identity);
-    let mut out = Vec::with_capacity(11 + id_str.len() + 1 + reason.len());
-    out.extend_from_slice(b"INVALIDATE:");
-    out.extend_from_slice(id_str.as_bytes());
-    out.extend_from_slice(b":");
-    out.extend_from_slice(reason.as_bytes());
+    let reason_bytes = reason.as_bytes();
+    let reason_len = u32::try_from(reason_bytes.len())
+        .map_err(|_| DsmError::invalid_operation("Invalidation reason exceeds u32 length"))?;
+
+    let mut out = Vec::with_capacity(
+        INVALIDATION_REQUEST_DOMAIN.len()
+            + identity.master_genesis.hash.len()
+            + 4
+            + reason_bytes.len(),
+    );
+    out.extend_from_slice(INVALIDATION_REQUEST_DOMAIN);
+    out.extend_from_slice(&identity.master_genesis.hash);
+    out.extend_from_slice(&reason_len.to_be_bytes());
+    out.extend_from_slice(reason_bytes);
     Ok(out)
 }
 
 pub fn process_invalidation(identity: &Identity, request: &[u8]) -> Result<bool, DsmError> {
-    let s = std::str::from_utf8(request)
-        .map_err(|_| DsmError::invalid_operation("Invalid UTF-8 in invalidation request"))?;
-    if !s.starts_with("INVALIDATE:") {
+    let expected_prefix_len =
+        INVALIDATION_REQUEST_DOMAIN.len() + identity.master_genesis.hash.len() + 4;
+    if request.len() < expected_prefix_len {
         return Ok(false);
     }
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() < 3 {
+
+    let domain_end = INVALIDATION_REQUEST_DOMAIN.len();
+    if &request[..domain_end] != INVALIDATION_REQUEST_DOMAIN {
         return Ok(false);
     }
-    if parts[1] != labeling::identity_to_string(identity) {
+
+    let genesis_end = domain_end + identity.master_genesis.hash.len();
+    if request[domain_end..genesis_end] != identity.master_genesis.hash {
         return Ok(false);
     }
+
+    let reason_len_end = genesis_end + 4;
+    let reason_len = u32::from_be_bytes(
+        request[genesis_end..reason_len_end]
+            .try_into()
+            .map_err(|_| DsmError::invalid_operation("Invalid invalidation length header"))?,
+    ) as usize;
+
+    if request.len() != reason_len_end + reason_len {
+        return Ok(false);
+    }
+
+    std::str::from_utf8(&request[reason_len_end..])
+        .map_err(|_| DsmError::invalid_operation("Invalid UTF-8 in invalidation request reason"))?;
+
     Ok(true)
 }
 
@@ -448,6 +475,25 @@ pub fn convert_session_to_genesis_state_compat(
 mod tests {
     use super::*;
 
+    fn test_identity(name: &str, hash_byte: u8) -> Identity {
+        Identity::with_genesis(
+            name.to_string(),
+            GenesisState {
+                hash: [hash_byte; 32],
+                initial_entropy: [hash_byte.wrapping_add(1); 32],
+                threshold: 3,
+                participants: ["p1".to_string(), "p2".to_string(), "p3".to_string()]
+                    .into_iter()
+                    .collect(),
+                merkle_root: None,
+                device_id: None,
+                signing_key: SigningKey::new().expect("signing key"),
+                kyber_keypair: KyberKey::new().expect("kyber key"),
+                contributions: vec![],
+            },
+        )
+    }
+
     #[tokio::test]
     async fn test_genesis_state_creation_mpc_only() {
         let nodes = vec![NodeId::new("n1"), NodeId::new("n2"), NodeId::new("n3")];
@@ -546,5 +592,23 @@ mod tests {
         );
         assert_eq!(g.kyber_keypair.public_key.len(), kyber::public_key_bytes());
         assert_eq!(g.kyber_keypair.secret_key.len(), kyber::secret_key_bytes());
+    }
+
+    #[test]
+    fn test_invalidation_request_is_bound_to_exact_master_genesis_hash() {
+        let identity_a = test_identity("alice", 0x11);
+        let identity_b = test_identity("alice-clone", 0x22);
+
+        let request = create_invalidation_request(&identity_a, "device compromise")
+            .expect("binary invalidation request should be created");
+
+        assert!(
+            request.starts_with(INVALIDATION_REQUEST_DOMAIN),
+            "request must use the canonical binary invalidation domain"
+        );
+        assert!(process_invalidation(&identity_a, &request)
+            .expect("owner identity must accept its own request"));
+        assert!(!process_invalidation(&identity_b, &request)
+            .expect("different identities must not accept replayed requests"));
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/core/identity/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/identity/mod.rs
@@ -38,7 +38,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use crate::types::error::DsmError;
-use crate::core::utility::labeling;
 use crate::types::identifiers::NodeId;
 use crate::types::state_types::State;
 use crate::prelude::*; // common items incl. Uuid, etc.
@@ -321,7 +320,7 @@ pub async fn create_trustless_genesis<
 /// Replaces global store to enforce bilateral isolation (no global state)
 #[derive(Clone)]
 pub struct IdentityStore {
-    pub store: Arc<RwLock<HashMap<String, Identity>>>,
+    pub store: Arc<RwLock<HashMap<[u8; 32], Identity>>>,
 }
 
 impl Default for IdentityStore {
@@ -338,9 +337,9 @@ impl IdentityStore {
         }
     }
 
-    /// Retrieve an identity by its genesis ID
+    /// Retrieve an identity by its exact canonical master genesis hash.
     #[allow(clippy::unused_async)]
-    pub async fn get_identity(&self, genesis_id: &str) -> Option<Identity> {
+    pub async fn get_identity(&self, genesis_id: &[u8; 32]) -> Option<Identity> {
         if let Ok(store) = self.store.read() {
             store.get(genesis_id).cloned()
         } else {
@@ -348,11 +347,11 @@ impl IdentityStore {
         }
     }
 
-    /// Insert or update an identity in the store
+    /// Insert or update an identity in the store.
     #[allow(clippy::unused_async)]
     pub async fn insert_identity(&self, identity: Identity) -> Result<(), IdentityError> {
         if let Ok(mut store) = self.store.write() {
-            store.insert(labeling::identity_to_string(&identity), identity);
+            store.insert(identity.master_genesis.hash, identity);
             Ok(())
         } else {
             Err(IdentityError::StorageError(
@@ -361,9 +360,9 @@ impl IdentityStore {
         }
     }
 
-    /// Check if an identity has been invalidated
+    /// Check if an identity has been invalidated.
     #[allow(clippy::unused_async)]
-    pub async fn is_invalidated(&self, genesis_id: &str) -> Result<bool, IdentityError> {
+    pub async fn is_invalidated(&self, genesis_id: &[u8; 32]) -> Result<bool, IdentityError> {
         if let Ok(store) = self.store.read() {
             let identity = store
                 .get(genesis_id)
@@ -376,9 +375,9 @@ impl IdentityStore {
         }
     }
 
-    /// Add a new device to an existing identity
+    /// Add a new device to an existing identity.
     #[allow(clippy::unused_async)]
-    pub async fn add_device(&self, genesis_id: &str) -> Result<DeviceIdentity, IdentityError> {
+    pub async fn add_device(&self, genesis_id: &[u8; 32]) -> Result<DeviceIdentity, IdentityError> {
         if let Ok(mut store) = self.store.write() {
             let identity = store
                 .get_mut(genesis_id)
@@ -510,7 +509,7 @@ impl IdentityStore {
         };
 
         if let Ok(mut store) = self.store.write() {
-            store.insert(labeling::identity_to_string(&identity), identity.clone());
+            store.insert(identity.master_genesis.hash, identity.clone());
         }
 
         Ok(identity)
@@ -697,10 +696,22 @@ pub struct Identity {
     pub invalidated: bool,
 }
 
+fn canonical_identity_id(genesis_hash: &[u8; 32]) -> String {
+    let mut hi = [0u8; 16];
+    hi.copy_from_slice(&genesis_hash[..16]);
+    let mut lo = [0u8; 16];
+    lo.copy_from_slice(&genesis_hash[16..]);
+    format!(
+        "genesis:{}:{}",
+        u128::from_be_bytes(hi),
+        u128::from_be_bytes(lo)
+    )
+}
+
 impl Identity {
-    /// Get the string representation of the identity ID
+    /// Get the canonical string representation of the exact master genesis hash.
     pub fn id(&self) -> String {
-        labeling::identity_to_string(self)
+        canonical_identity_id(&self.master_genesis.hash)
     }
 
     /// Construct an Identity from a provided genesis, with default fields initialized.

--- a/dsm_client/deterministic_state_machine/dsm/src/crypto_verification/storage_integration_test.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/crypto_verification/storage_integration_test.rs
@@ -56,7 +56,7 @@ mod tests {
 
         // Test store operations
         store.insert_identity(identity.clone()).await?;
-        let identity_id = identity.id();
+        let identity_id = identity.master_genesis.hash;
         let retrieved = store.get_identity(&identity_id).await;
         assert!(
             retrieved.is_some(),
@@ -113,7 +113,7 @@ mod tests {
 
         // Test store operations
         store.insert_identity(identity.clone()).await?;
-        let identity_id = identity.id();
+        let identity_id = identity.master_genesis.hash;
         let retrieved = store.get_identity(&identity_id).await;
         assert!(
             retrieved.is_some(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bilateral_sessions.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bilateral_sessions.rs
@@ -359,7 +359,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn store_bilateral_session_accepts_all_valid_phases() {
+        init_test_db();
+
         let valid_phases = [
             "prepare",
             "accept",


### PR DESCRIPTION
## Summary

Closes https://github.com/deterministicstatemachine/dsm/issues/192

This PR removes presentation-layer label usage from the core identity persistence and invalidation flow.

### Code changes applied
- changed `IdentityStore` in `dsm_client/deterministic_state_machine/dsm/src/core/identity/mod.rs`
  - from `HashMap<String, Identity>` keyed by `labeling::identity_to_string(&identity)`
  - to `HashMap<[u8; 32], Identity>` keyed by the exact `identity.master_genesis.hash`
- updated `IdentityStore::{get_identity, is_invalidated, add_device}` to operate on the canonical `[u8; 32]` master genesis hash instead of a UI label string
- changed `Identity::id()` to return a stable full-length canonical representation of the exact master genesis hash rather than a shortened UI label
- replaced the old textual `INVALIDATE:<label>:<reason>` format in `dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis.rs` with a canonical binary request envelope:
  - `DSM/identity/invalidate\0 || master_genesis.hash || u32(reason_len) || reason_bytes`
- added a regression proving invalidation requests are accepted only for the exact owning identity and rejected for replay against a different genesis hash
- isolated the pre-existing `dsm_sdk` bilateral session DB-writing test so the repo-wide pre-push gate passes reliably again

## Notes

This change keeps the identity path deterministic and exact-hash-bound, eliminating reliance on shortened or UI-oriented labels in security-sensitive code.
