### PR TITLE
normalize canonical operations and harden evaluation

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/policy_enforcement.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/policy_enforcement.rs
@@ -261,7 +261,7 @@ impl PolicyEnforcer {
             PolicyCondition::OperationRestriction { allowed_operations } => {
                 let allowed = allowed_operations
                     .iter()
-                    .any(|op| op.eq_ignore_ascii_case(&ctx.operation_type));
+                    .any(|op| op == &ctx.operation_type);
                 if allowed {
                     Ok(EnforcementResult::allowed("Operation permitted", tick))
                 } else {
@@ -487,10 +487,7 @@ impl PolicyEnforcer {
 
         for role in roles {
             if self.user_has_role(identity, &role.id).await {
-                let permitted = role
-                    .permissions
-                    .iter()
-                    .any(|op| op.eq_ignore_ascii_case(&ctx.operation_type));
+                let permitted = role.permissions.iter().any(|op| op == &ctx.operation_type);
                 if permitted {
                     return Ok(true);
                 }
@@ -511,13 +508,9 @@ impl PolicyEnforcer {
             return false;
         }
         match &id.derivation_path {
-            Some(path) if !path.is_empty() => {
-                if let Some(tail) = path.last() {
-                    allowed.iter().any(|a| a == tail)
-                } else {
-                    false
-                }
-            }
+            Some(path) if !path.is_empty() => path
+                .iter()
+                .any(|ancestor| allowed.iter().any(|allowed_id| allowed_id == ancestor)),
             _ => false,
         }
     }
@@ -547,6 +540,74 @@ mod tests {
 
         let res = enforcer.enforce_policy(&pol, "transfer", &ctx).await?;
         assert!(!res.allowed);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn operation_restriction_requires_canonical_case_match(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let cache = Arc::new(PolicyCache::new(PolicyCacheConfig::default()));
+        let enforcer = PolicyEnforcer::new(cache);
+
+        let mut pf = PolicyFile::new("OP", "1.0.0", "a");
+        pf.add_condition(PolicyCondition::OperationRestriction {
+            allowed_operations: vec!["Transfer".into()],
+        });
+        let pol = TokenPolicy::new(pf)?;
+
+        let mut ctx = HashMap::new();
+        ctx.insert("tick".into(), 7_u64.to_le_bytes().to_vec());
+
+        let allowed = enforcer.enforce_policy(&pol, "transfer", &ctx).await?;
+        assert!(
+            allowed.allowed,
+            "canonical lower-case operation should pass"
+        );
+
+        let denied = enforcer.enforce_policy(&pol, "Transfer", &ctx).await?;
+        assert!(
+            !denied.allowed,
+            "mixed-case operation input must not pass via case-insensitive matching"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn identity_constraint_accepts_any_allowed_ancestor(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let cache = Arc::new(PolicyCache::new(PolicyCacheConfig::default()));
+        let enforcer = PolicyEnforcer::new(cache);
+
+        let ctx = EnforcementContext {
+            operation_type: "transfer".to_string(),
+            tick: 9,
+            identity: Some(IdentityContext {
+                id: "leaf".to_string(),
+                assigned_roles: None,
+                derivation_path: Some(vec![
+                    "root".to_string(),
+                    "mid".to_string(),
+                    "parent".to_string(),
+                ]),
+            }),
+            region: None,
+            data: HashMap::new(),
+            vault_context: None,
+        };
+
+        let res = enforcer
+            .check_condition(
+                &PolicyCondition::IdentityConstraint {
+                    allowed_identities: vec!["root".to_string()],
+                    allow_derived: true,
+                },
+                &ctx,
+            )
+            .await?;
+        assert!(
+            res.allowed,
+            "full ancestry should satisfy allow_derived checks"
+        );
         Ok(())
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/cpta/default_policy.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/cpta/default_policy.rs
@@ -54,7 +54,7 @@ pub fn generate_default_policy(
 
     // Basic operation restrictions (allow transfer by default)
     policy.add_condition(PolicyCondition::OperationRestriction {
-        allowed_operations: vec!["Transfer".to_string()],
+        allowed_operations: vec!["transfer".to_string()],
     });
 
     // Minimal metadata (no wall-clock fields)
@@ -66,16 +66,16 @@ pub fn generate_default_policy(
     policy.add_role(PolicyRole {
         id: "owner".to_string(),
         name: "Token Owner".to_string(),
-        permissions: vec!["Transfer".to_string()],
+        permissions: vec!["transfer".to_string()],
     });
 
     policy.add_role(PolicyRole {
         id: "user".to_string(),
         name: "Token User".to_string(),
         permissions: vec![
-            "Transfer".to_string(),
-            "LockToken".to_string(),
-            "UnlockToken".to_string(),
+            "transfer".to_string(),
+            "lock_token".to_string(),
+            "unlock_token".to_string(),
         ],
     });
 
@@ -142,7 +142,7 @@ pub fn generate_specialized_policy(
                 ops.split(',').map(|s| s.trim().to_string()).collect()
             } else {
                 // Default to transfer-only if not specified
-                vec!["Transfer".to_string()]
+                vec!["transfer".to_string()]
             };
 
             // Replace default operation restrictions
@@ -172,7 +172,7 @@ pub fn create_policy(params: PolicyParameters) -> Result<PolicyFile, DsmError> {
 
     // Add verification/operation condition driven by parameters
     policy.add_condition(PolicyCondition::OperationRestriction {
-        allowed_operations: vec!["Transfer".to_string()],
+        allowed_operations: vec!["transfer".to_string()],
     });
 
     Ok(policy)
@@ -213,12 +213,12 @@ mod tests {
             matches!(
                 c,
                 PolicyCondition::OperationRestriction { allowed_operations }
-                if allowed_operations == &["Transfer".to_string()]
+                if allowed_operations == &["transfer".to_string()]
             )
         });
         assert!(
             has_ops,
-            "default policy must restrict operations to Transfer"
+            "default policy must restrict operations to transfer"
         );
     }
 
@@ -231,10 +231,10 @@ mod tests {
         assert_eq!(policy.roles[1].id, "user");
         assert!(policy.roles[1]
             .permissions
-            .contains(&"LockToken".to_string()));
+            .contains(&"lock_token".to_string()));
         assert!(policy.roles[1]
             .permissions
-            .contains(&"UnlockToken".to_string()));
+            .contains(&"unlock_token".to_string()));
     }
 
     #[test]
@@ -337,7 +337,7 @@ mod tests {
             Some(PolicyCondition::OperationRestriction { allowed_operations }) => {
                 assert_eq!(
                     allowed_operations,
-                    &["Transfer".to_string(), "Burn".to_string()]
+                    &["burn".to_string(), "transfer".to_string()]
                 );
             }
             _ => panic!("expected OperationRestriction"),
@@ -356,7 +356,7 @@ mod tests {
             .find(|c| matches!(c, PolicyCondition::OperationRestriction { .. }));
         match ops_condition {
             Some(PolicyCondition::OperationRestriction { allowed_operations }) => {
-                assert_eq!(allowed_operations, &["Transfer".to_string()]);
+                assert_eq!(allowed_operations, &["transfer".to_string()]);
             }
             _ => panic!("expected OperationRestriction"),
         }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/policy_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/policy_types.rs
@@ -17,6 +17,65 @@ use prost::Message;
 /// Fixed-length digest type for anchors and policy-bound hashes.
 pub type Digest32 = [u8; 32];
 
+fn canonical_operation_name(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    let mut out = String::with_capacity(value.len());
+
+    for (idx, ch) in chars.iter().copied().enumerate() {
+        if ch.is_ascii_alphanumeric() {
+            let prev = idx.checked_sub(1).and_then(|i| chars.get(i)).copied();
+            let next = chars.get(idx + 1).copied();
+            let prev_is_lower_or_digit = prev
+                .map(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+                .unwrap_or(false);
+            let next_is_lower = next.map(|c| c.is_ascii_lowercase()).unwrap_or(false);
+
+            if ch.is_ascii_uppercase()
+                && !out.is_empty()
+                && !out.ends_with('_')
+                && (prev_is_lower_or_digit || next_is_lower)
+            {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else if !out.is_empty() && !out.ends_with('_') {
+            out.push('_');
+        }
+    }
+
+    while out.ends_with('_') {
+        out.pop();
+    }
+
+    out
+}
+
+fn canonical_operation_set(values: &[String]) -> Vec<String> {
+    let mut normalized: Vec<String> = values
+        .iter()
+        .map(|value| canonical_operation_name(value))
+        .collect();
+    normalized.sort();
+    normalized.dedup();
+    normalized
+}
+
+fn normalize_policy_condition(condition: PolicyCondition) -> PolicyCondition {
+    match condition {
+        PolicyCondition::OperationRestriction { allowed_operations } => {
+            PolicyCondition::OperationRestriction {
+                allowed_operations: canonical_operation_set(&allowed_operations),
+            }
+        }
+        other => other,
+    }
+}
+
+fn normalize_policy_role(mut role: PolicyRole) -> PolicyRole {
+    role.permissions = canonical_operation_set(&role.permissions);
+    role
+}
+
 /// PolicyAnchor is the 32-byte identifier (BLAKE3) of a canonical policy file.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PolicyAnchor(pub Digest32);
@@ -234,12 +293,12 @@ impl PolicyFile {
     }
 
     pub fn add_condition(&mut self, condition: PolicyCondition) -> &mut Self {
-        self.conditions.push(condition);
+        self.conditions.push(normalize_policy_condition(condition));
         self
     }
 
     pub fn add_role(&mut self, role: PolicyRole) -> &mut Self {
-        self.roles.push(role);
+        self.roles.push(normalize_policy_role(role));
         self
     }
 
@@ -392,8 +451,7 @@ impl From<&PolicyCondition> for crate::types::proto::PolicyConditionProto {
                 })
             }
             PolicyCondition::OperationRestriction { allowed_operations } => {
-                let mut sorted = allowed_operations.clone();
-                sorted.sort();
+                let sorted = canonical_operation_set(allowed_operations);
                 Kind::OperationRestriction(OperationRestrictionProto {
                     allowed_operations: sorted,
                 })
@@ -440,7 +498,7 @@ impl From<&PolicyCondition> for crate::types::proto::PolicyConditionProto {
                 kv.sort_by(|a, b| a.key.cmp(&b.key));
                 Kind::Custom(CustomConstraintProto {
                     constraint_type: constraint_type.clone(),
-                    parameters: parameters.clone(),
+                    parameters: HashMap::new(),
                     parameters_kv: kv,
                 })
             }
@@ -482,7 +540,7 @@ impl TryFrom<&crate::types::proto::PolicyConditionProto> for PolicyCondition {
                     .try_into()?,
             }),
             Some(Kind::OperationRestriction(p)) => Ok(PolicyCondition::OperationRestriction {
-                allowed_operations: p.allowed_operations.clone(),
+                allowed_operations: canonical_operation_set(&p.allowed_operations),
             }),
             Some(Kind::LogicalTimeConstraint(p)) => Ok(PolicyCondition::LogicalTimeConstraint {
                 min_tick: p.min_tick,
@@ -555,8 +613,7 @@ impl TryFrom<&crate::types::proto::VaultConditionProto> for VaultCondition {
 
 impl From<&PolicyRole> for crate::types::proto::PolicyRoleProto {
     fn from(role: &PolicyRole) -> Self {
-        let mut sorted_permissions = role.permissions.clone();
-        sorted_permissions.sort();
+        let sorted_permissions = canonical_operation_set(&role.permissions);
         Self {
             id: role.id.clone(),
             name: role.name.clone(),
@@ -570,7 +627,7 @@ impl From<&crate::types::proto::PolicyRoleProto> for PolicyRole {
         Self {
             id: proto.id.clone(),
             name: proto.name.clone(),
-            permissions: proto.permissions.clone(),
+            permissions: canonical_operation_set(&proto.permissions),
         }
     }
 }
@@ -585,7 +642,14 @@ pub struct TokenPolicy {
 }
 
 impl TokenPolicy {
-    pub fn new(file: PolicyFile) -> Result<Self, DsmError> {
+    pub fn new(mut file: PolicyFile) -> Result<Self, DsmError> {
+        file.conditions = file
+            .conditions
+            .into_iter()
+            .map(normalize_policy_condition)
+            .collect();
+        file.roles = file.roles.into_iter().map(normalize_policy_role).collect();
+
         let anchor = file.generate_anchor()?;
         let now = dt::tick().1;
         Ok(Self {
@@ -601,13 +665,39 @@ impl TokenPolicy {
         self.last_verified = dt::tick().1;
     }
 
-    /// No time-based conditions are supported.
-    pub fn is_condition_satisfied(&self, _condition: &PolicyCondition) -> bool {
-        true
+    /// Conservative standalone check for stateless callers.
+    ///
+    /// This helper must never bypass full `PolicyEnforcer` evaluation. Conditions
+    /// that require contextual witnesses fail closed here.
+    pub fn is_condition_satisfied(&self, condition: &PolicyCondition) -> bool {
+        if !self.file.conditions.iter().any(|c| c == condition) {
+            return false;
+        }
+
+        match condition {
+            PolicyCondition::LogicalTimeConstraint { min_tick, max_tick } => {
+                self.last_verified >= *min_tick && self.last_verified <= *max_tick
+            }
+            PolicyCondition::EmissionsSchedule { .. }
+            | PolicyCondition::CreditBundlePolicy { .. }
+            | PolicyCondition::BitcoinTapConstraint { .. } => true,
+            PolicyCondition::IdentityConstraint { .. }
+            | PolicyCondition::VaultEnforcement { .. }
+            | PolicyCondition::OperationRestriction { .. }
+            | PolicyCondition::Custom { .. } => false,
+        }
     }
 
     pub fn are_time_conditions_satisfied(&self) -> bool {
-        true
+        self.file
+            .conditions
+            .iter()
+            .all(|condition| match condition {
+                PolicyCondition::LogicalTimeConstraint { min_tick, max_tick } => {
+                    self.last_verified >= *min_tick && self.last_verified <= *max_tick
+                }
+                _ => true,
+            })
     }
 }
 
@@ -843,15 +933,79 @@ mod tests {
     }
 
     #[test]
-    fn token_policy_conditions_always_satisfied() {
-        let pf = PolicyFile::new("tp", "v1", "auth");
-        let tp = TokenPolicy::new(pf).unwrap();
-        let cond = PolicyCondition::LogicalTimeConstraint {
-            min_tick: 0,
-            max_tick: 100,
+    fn token_policy_condition_checks_fail_closed_without_context() {
+        let mut pf = PolicyFile::new("tp", "v1", "auth");
+        let identity_cond = PolicyCondition::IdentityConstraint {
+            allowed_identities: vec!["alice".into()],
+            allow_derived: true,
         };
-        assert!(tp.is_condition_satisfied(&cond));
-        assert!(tp.are_time_conditions_satisfied());
+        pf.add_condition(identity_cond.clone());
+        pf.add_condition(PolicyCondition::LogicalTimeConstraint {
+            min_tick: u64::MAX - 10,
+            max_tick: u64::MAX,
+        });
+        let tp = TokenPolicy::new(pf).unwrap();
+
+        assert!(
+            !tp.is_condition_satisfied(&identity_cond),
+            "context-free identity checks must fail closed"
+        );
+        assert!(
+            !tp.are_time_conditions_satisfied(),
+            "time checks must evaluate the real stored tick window"
+        );
+    }
+
+    #[test]
+    fn canonical_custom_policy_uses_only_sorted_parameters_kv() {
+        use crate::types::proto::policy_condition_proto::Kind;
+
+        let mut params = HashMap::new();
+        params.insert("z_key".to_string(), "last".to_string());
+        params.insert("a_key".to_string(), "first".to_string());
+
+        let mut pf = PolicyFile::new("custom", "v1", "author");
+        pf.add_condition(PolicyCondition::Custom {
+            constraint_type: "rate_limit".to_string(),
+            parameters: params,
+        });
+
+        let canonical = pf.canonical_bytes().unwrap();
+        let proto = crate::types::proto::CanonicalPolicy::decode(canonical.as_slice()).unwrap();
+        let custom = match proto.conditions[0].kind.as_ref().unwrap() {
+            Kind::Custom(custom) => custom,
+            other => panic!("expected custom constraint, got {:?}", other),
+        };
+
+        assert!(
+            custom.parameters.is_empty(),
+            "canonical hashing must exclude the non-deterministic map field"
+        );
+        let ordered_keys: Vec<&str> = custom
+            .parameters_kv
+            .iter()
+            .map(|kv| kv.key.as_str())
+            .collect();
+        assert_eq!(ordered_keys, vec!["a_key", "z_key"]);
+    }
+
+    #[test]
+    fn operation_restriction_anchor_normalizes_case() {
+        let mut lower = PolicyFile::new("ops", "v1", "author");
+        lower.add_condition(PolicyCondition::OperationRestriction {
+            allowed_operations: vec!["transfer".into(), "mint".into()],
+        });
+
+        let mut mixed = PolicyFile::new("ops", "v1", "author");
+        mixed.add_condition(PolicyCondition::OperationRestriction {
+            allowed_operations: vec!["Transfer".into(), "MINT".into()],
+        });
+
+        assert_eq!(
+            lower.generate_anchor().unwrap().0,
+            mixed.generate_anchor().unwrap().0,
+            "operation casing should not fork policy anchors"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Root cause
- Canonical policy bytes were still serializing the non-deterministic `parameters` map for `Custom` constraints instead of relying only on sorted `parameters_kv`.
- `TokenPolicy` exposed public helper checks that unconditionally returned `true`, bypassing real policy evaluation.
- Operation restrictions and role permissions were anchored with one casing but enforced with `eq_ignore_ascii_case`, creating a semantic gap.
- Derived-identity authorization only compared `path.last()` instead of the full ancestor chain.

## Fix summary
### Production code
- `dsm_client/deterministic_state_machine/dsm/src/types/policy_types.rs`
  - canonical custom-policy serialization now zeros the non-deterministic `parameters` map and hashes only sorted `parameters_kv`
  - operation restrictions and role permissions are normalized into canonical snake/lower case for runtime and anchor stability
  - the public `TokenPolicy` helper checks now fail closed for context-dependent conditions and evaluate real logical-time windows instead of returning `true`
- `dsm_client/deterministic_state_machine/dsm/src/core/token/policy/policy_enforcement.rs`
  - replaced `eq_ignore_ascii_case` matching with exact-match enforcement on canonicalized operation names
  - `allow_derived` now accepts any allowed ancestor in the derivation path, not just the last hop
- `dsm_client/deterministic_state_machine/dsm/src/cpta/default_policy.rs`
  - aligned generated default/restricted policy operation strings and permissions with the canonical operation naming used by enforcement

### Regression coverage
Added targeted regressions for:
- excluding the `parameters` map from canonical custom-policy bytes
- anchor equality across case-only operation variants
- fail-closed standalone token policy checks
- exact-match operation enforcement
- full-ancestry `allow_derived` acceptance
- default-policy canonical operation expectations

Closes #183 