### PR TITLE
Revert PR #327 — rand 0.10.1 bump broke the build on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,7 @@ dependencies = [
  "prost-types 0.14.3",
  "protoc-bin-vendored",
  "quickcheck",
- "rand 0.10.1",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rocksdb",
  "rstest",
@@ -1308,7 +1308,7 @@ dependencies = [
  "prost-types 0.14.3",
  "protoc-bin-vendored",
  "quickcheck",
- "rand 0.10.1",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rcgen",
  "reqwest",
@@ -1360,7 +1360,7 @@ dependencies = [
  "ml-kem",
  "once_cell",
  "prost 0.14.3",
- "rand 0.10.1",
+ "rand 0.8.6",
  "reqwest",
  "rusqlite",
  "rustls",
@@ -1412,7 +1412,7 @@ dependencies = [
  "dsm",
  "instant",
  "prost 0.14.3",
- "rand 0.10.1",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "regex",
  "reqwest",
@@ -3639,6 +3639,17 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "rand"

--- a/dsm_client/deterministic_state_machine/dsm/Cargo.toml
+++ b/dsm_client/deterministic_state_machine/dsm/Cargo.toml
@@ -124,7 +124,7 @@ bitflags = "2.4.2"
 arrayref = "0.3.9"
 argon2 = "0.5.3"
 
-rand = "0.10.1"
+rand = "0.8.6"
 uuid = { version = "1.23", features = ["std"] }
 # serde_cbor removed from code paths (unmaintained); deterministic CBOR is hand-encoded locally
 # Prefer stable crypto crates to reduce duplicate dependency versions across workspace.

--- a/dsm_client/deterministic_state_machine/dsm_sdk/Cargo.toml
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/Cargo.toml
@@ -98,7 +98,7 @@ blake3 = "1.5.0"
 # AEAD
 chacha20poly1305 = { version = "0.10", default-features = false, features = ["alloc", "std"] }
 hmac = "0.13.0"
-rand = "0.10.1"
+rand = "0.8.6"
 rand_chacha = "0.3.1"
 getrandom = "0.4.2"
 merlin = "3.0.0"

--- a/dsm_storage_node/Cargo.toml
+++ b/dsm_storage_node/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = "1.0.75"
 # Cryptography (quantum-resistant)
 blake3 = "1.4.0"
 ml-kem = "0.2.0"
-rand = "0.10.1"
+rand = "0.8.6"
 zeroize = { version = "1.6.0", features = ["derive"] }
 subtle = "2"
 

--- a/tools/vertical_validation/Cargo.toml
+++ b/tools/vertical_validation/Cargo.toml
@@ -43,7 +43,7 @@ instant = "0.1"
 dsm = { version = "0.1.0-beta.3", path = "../../dsm_client/deterministic_state_machine/dsm" }
 
 # Deterministic seeded RNG for reproducible property tests
-rand = "0.10"
+rand = "0.8"
 rand_chacha = "0.3.1"
 
 [lints]


### PR DESCRIPTION
## Why

PR #327 (\"build(deps): bump rand from 0.8.6 to 0.10.1\") was merged without the API migration. \`main\` no longer compiles:

\`\`\`
$ cargo check --workspace --features dsm_storage_node/local-dev
error[E0432]: unresolved import \`rand::RngCore\`
   --> dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis.rs:17:5
error[E0432]: unresolved import \`rand::rngs::OsRng\`
   --> dsm_client/deterministic_state_machine/dsm/src/crypto/kyber.rs:36:5
… (10 errors total)
\`\`\`

rand 0.9 reorganized exports (\`OsRng\`, \`RngCore\` moved to \`rand_core\`), and rand 0.10 dropped the top-level re-exports entirely. Every consumer in \`dsm/src\` still imports them from \`rand\`. The dependabot bump should have been blocked by CI but slipped through.

## What

Reverts the four affected \`Cargo.toml\` manifests back to \`rand = \"0.8.6\"\` (\`\"0.8\"\` for \`vertical_validation\`). Refreshes both \`Cargo.lock\`s.

- \`dsm_client/deterministic_state_machine/dsm/Cargo.toml\`
- \`dsm_client/deterministic_state_machine/dsm_sdk/Cargo.toml\`
- \`dsm_storage_node/Cargo.toml\`
- \`tools/vertical_validation/Cargo.toml\`

## Security

rand 0.8.6 is the patched version for GHSA-cq8v-f236-94qc (vulnerable range was 0.7.0..0.8.6). This revert keeps the patch; the security alert does not re-open.

## Precedent

Same pattern as the existing reverts on main:

- \`Revert \"chore(deps): bump rcgen in workspace (PR #338)\"\`
- \`Revert \"chore(deps): bump rand_chacha 0.3.1->0.9.0 (PR #340)\"\`

## Test plan

- [x] \`cargo check --workspace --features dsm_storage_node/local-dev\` clean.
- [ ] CI green on this PR.
- [ ] Reviewer confirms revert scope is limited to the four manifests + the two \`Cargo.lock\` refreshes.

## Follow-up

The proper rand 0.10 migration — switching to \`rand_core::{OsRng, RngCore}\` and updating call sites — is a separate, multi-file effort that should land as its own PR with the full migration done in lockstep, not as a bare manifest bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)