### PR TITLE
cleanup(common): prune dead utilities and standardize domain tag usage

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/common/canonical_encoding.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/canonical_encoding.rs
@@ -7,8 +7,6 @@
 //!
 //! This module provides:
 //! - Consistent byte ordering and field inclusion
-//! - Standardized length prefixing
-//! - Domain separation for cryptographic operations
 //! - Single source of truth for all canonical encodings
 
 use crate::DsmError;
@@ -31,121 +29,9 @@ pub trait CanonicalEncode {
 // helpers were `pub` and reachable by any downstream caller, which would
 // silently produce a commitment byte sequence incompatible with the
 // canonical Envelope wire v3 protobuf-only path. Removed entirely. The
-// only surviving exports from this module are the `CanonicalEncode`
-// trait, `length_prefix` helpers (used for `dsm_max_len`-bounded
-// length-prefixed framing inside protobuf), and `domain_separated_hash`.
+// only surviving export from this module is the `CanonicalEncode`
+// trait.
 //
 // If a future protocol extension genuinely needs structured byte streams
 // outside protobuf, define a new domain-tagged primitive — do not
 // resurrect generic CBOR.
-
-/// Length-prefixed encoding helpers (replaces scattered pushLP/writeLP/putU32 functions)
-pub mod length_prefix {
-    use crate::DsmError;
-
-    /// Encode with 4-byte big-endian length prefix
-    #[inline]
-    pub fn encode_u32_prefix(buf: &mut Vec<u8>, data: &[u8]) -> Result<(), DsmError> {
-        if data.len() > u32::MAX as usize {
-            return Err(DsmError::InvalidOperation(
-                "Data too large for u32 length prefix".to_string(),
-            ));
-        }
-        buf.extend_from_slice(&(data.len() as u32).to_be_bytes());
-        buf.extend_from_slice(data);
-        Ok(())
-    }
-
-    /// Encode with variable-length prefix (1, 2, or 4 bytes as needed)
-    #[inline]
-    pub fn encode_variable_prefix(buf: &mut Vec<u8>, data: &[u8]) -> Result<(), DsmError> {
-        let len = data.len();
-        if len <= 0xFF {
-            buf.push(len as u8);
-        } else if len <= 0xFFFF {
-            buf.extend_from_slice(&(len as u16).to_be_bytes());
-        } else if len <= 0xFFFF_FFFF {
-            buf.extend_from_slice(&(len as u32).to_be_bytes());
-        } else {
-            return Err(DsmError::InvalidOperation(
-                "Data too large for variable length prefix".to_string(),
-            ));
-        }
-        buf.extend_from_slice(data);
-        Ok(())
-    }
-}
-
-/// Helper for domain-separated hashing
-#[inline]
-pub fn domain_separated_hash(tag: &str, data: &[u8]) -> [u8; 32] {
-    let mut hasher = crate::crypto::blake3::dsm_domain_hasher(tag);
-    hasher.update(data);
-    *hasher.finalize().as_bytes()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_length_prefix_u32() {
-        let mut buf = Vec::new();
-        let data = b"hello";
-        length_prefix::encode_u32_prefix(&mut buf, data).unwrap();
-
-        assert_eq!(buf.len(), 9);
-        assert_eq!(u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]), 5);
-        assert_eq!(&buf[4..], data);
-    }
-
-    #[test]
-    fn test_length_prefix_u32_empty_data() {
-        let mut buf = Vec::new();
-        length_prefix::encode_u32_prefix(&mut buf, &[]).unwrap();
-        assert_eq!(buf.len(), 4);
-        assert_eq!(u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]), 0);
-    }
-
-    #[test]
-    fn test_length_prefix_variable_small() {
-        let mut buf = Vec::new();
-        let data = b"abc";
-        length_prefix::encode_variable_prefix(&mut buf, data).unwrap();
-
-        assert_eq!(buf[0], 3u8); // 1-byte length
-        assert_eq!(&buf[1..], data.as_slice());
-    }
-
-    #[test]
-    fn test_length_prefix_variable_medium() {
-        let data = vec![0x42; 300];
-        let mut buf = Vec::new();
-        length_prefix::encode_variable_prefix(&mut buf, &data).unwrap();
-
-        let len = u16::from_be_bytes([buf[0], buf[1]]);
-        assert_eq!(len, 300);
-        assert_eq!(&buf[2..], &data[..]);
-    }
-
-    #[test]
-    fn test_domain_separated_hash_deterministic() {
-        let h1 = domain_separated_hash("DSM/test-tag", b"payload");
-        let h2 = domain_separated_hash("DSM/test-tag", b"payload");
-        assert_eq!(h1, h2);
-    }
-
-    #[test]
-    fn test_domain_separated_hash_different_tags_differ() {
-        let h1 = domain_separated_hash("DSM/tag-a", b"payload");
-        let h2 = domain_separated_hash("DSM/tag-b", b"payload");
-        assert_ne!(h1, h2);
-    }
-
-    #[test]
-    fn test_domain_separated_hash_different_data_differ() {
-        let h1 = domain_separated_hash("DSM/tag", b"data-1");
-        let h2 = domain_separated_hash("DSM/tag", b"data-2");
-        assert_ne!(h1, h2);
-    }
-}

--- a/dsm_client/deterministic_state_machine/dsm/src/common/deterministic_id.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/deterministic_id.rs
@@ -3,18 +3,14 @@
 //! Deterministic ID Generation (No UUID, No Wall-Clock)
 //!
 //! This module provides deterministic, reproducible ID generation for all DSM components.
-//! All IDs are derived from cryptographic hashes and/or atomic counters, never random UUIDs.
+//! All IDs are derived from cryptographic hashes, never random UUIDs.
 //!
 //! Constraints:
 //! - No UUID::new_v4() or UUID::now_v7() (non-deterministic)
 //! - No wall-clock unix_tss
-//! - All IDs are reproducible from inputs or monotonic counters
+//! - All IDs are reproducible from explicit inputs
 
 use crate::crypto::blake3::dsm_domain_hasher;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-/// Global atomic counter for deterministic sequential IDs
-static SEQUENTIAL_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 /// Generate a deterministic ID from domain-separated hash of inputs
 ///
@@ -47,116 +43,7 @@ pub fn derive_id_from_hash(domain: &str, inputs: &[&[u8]]) -> String {
     )
 }
 
-/// Generate a deterministic sequential ID
-///
-/// # Arguments
-/// * `prefix` - Prefix for the ID (e.g., "tx", "msg", "batch")
-///
-/// # Returns
-/// String in format "{prefix}_{counter}" where counter is monotonically increasing
-pub fn generate_sequential_id(prefix: &str) -> String {
-    let counter = SEQUENTIAL_COUNTER.fetch_add(1, Ordering::SeqCst);
-    format!("{}_{:016x}", prefix, counter)
-}
-
-/// Generate a deterministic transaction ID from sender, recipient, and operation hash
-pub fn generate_tx_id(sender_id: &[u8], recipient_id: &[u8], op_hash: &[u8]) -> String {
-    derive_id_from_hash("DSM/tx-id", &[sender_id, recipient_id, op_hash])
-}
-
-/// Generate a deterministic message ID from sender and sequence
-pub fn generate_message_id(sender_id: &[u8], sequence: u64) -> String {
-    let seq_bytes = sequence.to_le_bytes();
-    derive_id_from_hash("DSM/msg-id", &[sender_id, &seq_bytes])
-}
-
-/// Generate a deterministic batch ID from batch contents hash
-pub fn generate_batch_id(batch_hash: &[u8]) -> String {
-    derive_id_from_hash("DSM/batch-id", &[batch_hash])
-}
-
 /// Generate a deterministic session ID from participants and unix_ts-free context
 pub fn generate_session_id(context: &[u8]) -> String {
     derive_id_from_hash("DSM/session-id", &[context])
-}
-
-/// Generate a deterministic entry ID from entry data hash
-pub fn generate_entry_id(entry_hash: &[u8]) -> String {
-    derive_id_from_hash("DSM/entry-id", &[entry_hash])
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_deterministic_hash_based_id() {
-        let sender = b"sender123";
-        let recipient = b"recipient456";
-        let op_hash = b"op_hash_data";
-
-        let id1 = generate_tx_id(sender, recipient, op_hash);
-        let id2 = generate_tx_id(sender, recipient, op_hash);
-
-        // Same inputs should produce same ID
-        assert_eq!(id1, id2);
-
-        // Different inputs should produce different ID
-        let id3 = generate_tx_id(b"different", recipient, op_hash);
-        assert_ne!(id1, id3);
-    }
-
-    #[test]
-    fn test_sequential_id_monotonic() {
-        let id1 = generate_sequential_id("test");
-        let id2 = generate_sequential_id("test");
-
-        // IDs should be different and monotonically increasing
-        assert_ne!(id1, id2);
-        assert!(id2 > id1);
-    }
-
-    #[test]
-    fn test_message_id_deterministic() {
-        let sender = b"device_abc";
-        let seq1 = 42u64;
-        let seq2 = 43u64;
-
-        let msg1 = generate_message_id(sender, seq1);
-        let msg2 = generate_message_id(sender, seq1);
-        let msg3 = generate_message_id(sender, seq2);
-
-        // Same inputs produce same ID
-        assert_eq!(msg1, msg2);
-
-        // Different sequence produces different ID
-        assert_ne!(msg1, msg3);
-    }
-
-    #[test]
-    fn test_id_format_uuid_compatible() {
-        let sender = b"test";
-        let recipient = b"test2";
-        let op_hash = b"hash";
-
-        let id = generate_tx_id(sender, recipient, op_hash);
-
-        // Should match UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-        assert_eq!(id.len(), 36);
-        assert_eq!(&id[8..9], "-");
-        assert_eq!(&id[13..14], "-");
-        assert_eq!(&id[18..19], "-");
-        assert_eq!(&id[23..24], "-");
-    }
-
-    #[test]
-    fn test_domain_separation() {
-        let data = b"same_data";
-
-        let tx_id = derive_id_from_hash("DSM/tx-id", &[data]);
-        let msg_id = derive_id_from_hash("DSM/msg-id", &[data]);
-
-        // Different domains with same data should produce different IDs
-        assert_ne!(tx_id, msg_id);
-    }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/common/device_tree.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/device_tree.rs
@@ -112,13 +112,9 @@ impl DevTreeProof {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::new();
 
-        // Number of siblings
         buf.extend_from_slice(&(self.siblings.len() as u32).to_le_bytes());
-
-        // leaf_to_root flag
         buf.push(if self.leaf_to_root { 1 } else { 0 });
 
-        // Pack path_bits into bytes
         let mut packed_bits = vec![0u8; self.path_bits.len().div_ceil(8)];
         for (i, &bit) in self.path_bits.iter().enumerate() {
             if bit {
@@ -128,7 +124,6 @@ impl DevTreeProof {
         buf.extend_from_slice(&(self.path_bits.len() as u32).to_le_bytes());
         buf.extend_from_slice(&packed_bits);
 
-        // Siblings (each 32 bytes)
         for sib in &self.siblings {
             buf.extend_from_slice(sib);
         }
@@ -136,31 +131,27 @@ impl DevTreeProof {
         buf
     }
 
-    /// Deserialize proof from bytes
+    /// Deserialize proof from bytes.
     pub fn from_bytes(data: &[u8]) -> Option<Self> {
         if data.len() < 9 {
-            return None; // Need at least num_siblings(4) + flag(1) + path_bits_len(4)
+            return None;
         }
 
         let mut offset = 0;
 
-        // Read num_siblings
         let mut num_siblings_bytes = [0u8; 4];
         num_siblings_bytes.copy_from_slice(&data[offset..offset + 4]);
         let num_siblings = u32::from_le_bytes(num_siblings_bytes) as usize;
         offset += 4;
 
-        // Read leaf_to_root flag
         let leaf_to_root = data[offset] != 0;
         offset += 1;
 
-        // Read path_bits length
         let mut path_bits_len_bytes = [0u8; 4];
         path_bits_len_bytes.copy_from_slice(&data[offset..offset + 4]);
         let path_bits_len = u32::from_le_bytes(path_bits_len_bytes) as usize;
         offset += 4;
 
-        // Read packed path_bits
         let packed_len = path_bits_len.div_ceil(8);
         if offset + packed_len > data.len() {
             return None;
@@ -174,9 +165,8 @@ impl DevTreeProof {
             path_bits.push(bit);
         }
 
-        // Read siblings
         if offset + num_siblings * 32 != data.len() {
-            return None; // Size mismatch
+            return None;
         }
 
         let mut siblings = Vec::with_capacity(num_siblings);
@@ -195,20 +185,11 @@ impl DevTreeProof {
     }
 }
 
-// ---------------------------------------------------------------------------
-// DeviceTree builder — standard binary Merkle tree over sorted DevIDs.
-// ---------------------------------------------------------------------------
-
-/// Device Tree builder for one genesis account (§2.2, §2.3).
+/// Device Tree builder for one genesis account.
 ///
 /// Leaves are DevIDs sorted lexicographically. Root is R_G.
-/// For N=0: root = empty_root()
-/// For N=1: root = hash_leaf(devid) — empty proof
-/// For N>1: sorted leaves, standard balanced binary Merkle construction
 pub struct DeviceTree {
-    /// Sorted, deduplicated leaves (DevIDs).
     leaves: Vec<[u8; 32]>,
-    /// Precomputed root hash R_G.
     root: [u8; 32],
 }
 
@@ -228,7 +209,7 @@ impl DeviceTree {
         }
     }
 
-    /// Convenience: single-device tree (current default).
+    /// Convenience constructor for single-device trees.
     pub fn single(dev_id: [u8; 32]) -> Self {
         Self::new(vec![dev_id])
     }
@@ -264,13 +245,10 @@ impl DeviceTree {
     }
 
     /// Generate an inclusion proof for `dev_id`.
-    /// Returns `None` if `dev_id` is not a member of this tree.
+    /// Returns `None` if `dev_id` is not in this tree.
     pub fn proof(&self, dev_id: &[u8; 32]) -> Option<DevTreeProof> {
         let idx = self.leaves.iter().position(|l| l == dev_id)?;
         if self.leaves.len() == 1 {
-            // Single-device: empty proof is correct.
-            // verify_device_tree_inclusion_proof_bytes() accepts this when
-            // root == hash_leaf(devid).
             return Some(DevTreeProof {
                 siblings: Vec::new(),
                 path_bits: Vec::new(),
@@ -280,8 +258,6 @@ impl DeviceTree {
         Some(Self::build_merkle_proof(&self.leaves, idx))
     }
 
-    // --- Private: balanced binary Merkle tree construction ---
-
     fn compute_merkle_root(sorted_leaves: &[[u8; 32]]) -> [u8; 32] {
         let mut level: Vec<[u8; 32]> = sorted_leaves.iter().map(hash_leaf).collect();
         while level.len() > 1 {
@@ -290,10 +266,6 @@ impl DeviceTree {
                 if chunk.len() == 2 {
                     next.push(hash_node(&chunk[0], &chunk[1]));
                 } else {
-                    // Odd promotion: pair with the canonical padding
-                    // leaf (Issue #182 Finding #4) instead of duplicating
-                    // the lone child. Different domain tag prevents any
-                    // collision with a real DevID-derived leaf.
                     next.push(hash_node(&chunk[0], &pad_leaf()));
                 }
             }
@@ -317,12 +289,10 @@ impl DeviceTree {
             let sib = if sib_idx < level.len() {
                 level[sib_idx]
             } else {
-                // Odd promotion at this level: sibling is the canonical
-                // padding leaf, NOT the lone child duplicated.
                 pad_leaf()
             };
             siblings.push(sib);
-            path_bits.push(!idx.is_multiple_of(2)); // true = right child
+            path_bits.push(!idx.is_multiple_of(2));
 
             let mut next = Vec::with_capacity(level.len().div_ceil(2));
             for chunk in level.chunks(2) {

--- a/dsm_client/deterministic_state_machine/dsm/src/common/domain_tags.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/domain_tags.rs
@@ -24,10 +24,16 @@
 //! tag identifier. So tag identifiers carried as Rust `&str` constants
 //! should NOT include the NUL byte.
 
+// Receipt canonical commit domain.
 pub const TAG_RECEIPT_COMMIT: &str = "DSM/receipt-commit";
+
+// SMT node/leaf domains.
 pub const TAG_SMT_NODE: &str = "DSM/smt-node";
 pub const TAG_SMT_LEAF: &str = "DSM/smt-leaf";
+
+// DBRW root domain.
 pub const TAG_DBRW: &str = "DSM/dbrw";
+
 // Device Tree (standard Merkle) — see Issue #182 Finding #2 for the
 // open spec ambiguity between §2.2 (`merkle-node`/`merkle-leaf`) and
 // §16.3 (`dev-merkle`/`dev-empty`). Implementation continues to use

--- a/dsm_client/deterministic_state_machine/dsm/src/common/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/mod.rs
@@ -9,18 +9,6 @@
 //! - No hex/json/base64/serde encodings for identifiers or binary values.
 //! - Binary-only helpers; canonicality first.
 
-/// DSM Protocol Version identifier (wire-level compat)
-pub const PROTOCOL_VERSION: &str = "0.1.0";
-
-/// Standard BLAKE3-256 output length (bytes)
-pub const HASH_LENGTH: usize = 32;
-
-/// Default symmetric key size (bytes)
-pub const KEY_SIZE: usize = 32;
-
-/// Maximum buffer size for internal I/O (defensive ceiling)
-pub const MAX_BUFFER_SIZE: usize = 4_096;
-
 /// Centralized canonical encoding for cryptographic commitments
 pub mod canonical_encoding;
 /// Deterministic ID generation (no UUID, no wall-clock)
@@ -28,61 +16,3 @@ pub mod deterministic_id;
 pub mod device_tree;
 /// Domain tag constants for BLAKE3 domain-separated hashing
 pub mod domain_tags;
-
-/// DSM protocol magic bytes ("SECI")
-pub const PROTOCOL_MAGIC: [u8; 4] = [0x53, 0x45, 0x43, 0x49];
-
-/// Centralized non-time-based constants
-pub mod constants {
-    /// Default network port for DSM nodes
-    pub const DEFAULT_PORT: u16 = 8421;
-
-    /// Default network buffer size (bytes)
-    pub const DEFAULT_BUFFER_SIZE: usize = 8_192;
-
-    /// Default data directory path
-    pub const DEFAULT_DB_PATH: &str = "./seci_data";
-
-    /// Minimum acceptable password length
-    pub const MIN_PASSWORD_LENGTH: usize = 12;
-
-    /// Default iteration count for password-based KDFs
-    pub const DEFAULT_KEY_DERIVATION_ITERATIONS: u32 = 100_000;
-}
-
-/// Binary-only helpers. No encoders/decoders. No time.
-pub mod helpers {
-    /// Return `true` iff all bytes are zero.
-    #[inline]
-    pub fn is_all_zeros(data: &[u8]) -> bool {
-        data.iter().all(|&b| b == 0)
-    }
-
-    /// Branchless byte-wise equality to reduce timing variance.
-    /// Not a substitute for a dedicated constant-time lib, but avoids
-    /// early-return equality and keeps comparisons uniform.
-    #[inline]
-    pub fn secure_eq(a: &[u8], b: &[u8]) -> bool {
-        if a.len() != b.len() {
-            return false;
-        }
-        let mut diff = 0u8;
-        for i in 0..a.len() {
-            diff |= a[i] ^ b[i];
-        }
-        diff == 0
-    }
-
-    /// Clamp a slice to at most `max_len` bytes (no allocation).
-    #[inline]
-    pub fn clamp_slice(bytes: &[u8], max_len: usize) -> &[u8] {
-        if bytes.len() <= max_len {
-            bytes
-        } else {
-            &bytes[..max_len]
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {}

--- a/dsm_client/deterministic_state_machine/dsm/src/merkle/sparse_merkle_tree.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/merkle/sparse_merkle_tree.rs
@@ -22,6 +22,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::OnceLock;
 
+use crate::common::domain_tags::{TAG_SMT_LEAF, TAG_SMT_NODE};
 use crate::crypto::blake3::dsm_domain_hasher;
 
 // ───────────────────────────────────────────────────────────────────
@@ -45,7 +46,7 @@ pub fn empty_leaf() -> [u8; 32] {
 ///
 /// Per spec §2.2: `Leaf(X) := BLAKE3-256("DSM/smt-leaf\0" || X)`.
 pub fn hash_smt_leaf(value: &[u8; 32]) -> [u8; 32] {
-    let mut hasher = dsm_domain_hasher("DSM/smt-leaf");
+    let mut hasher = dsm_domain_hasher(TAG_SMT_LEAF);
     hasher.update(value);
     *hasher.finalize().as_bytes()
 }
@@ -54,7 +55,7 @@ pub fn hash_smt_leaf(value: &[u8; 32]) -> [u8; 32] {
 ///
 /// Per spec §2.2: `Node(L, R) := BLAKE3-256("DSM/smt-node\0" || L || R)`.
 pub fn hash_smt_node(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
-    let mut hasher = dsm_domain_hasher("DSM/smt-node");
+    let mut hasher = dsm_domain_hasher(TAG_SMT_NODE);
     hasher.update(left);
     hasher.update(right);
     *hasher.finalize().as_bytes()

--- a/dsm_client/deterministic_state_machine/dsm/src/types/receipt_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/receipt_types.rs
@@ -15,6 +15,7 @@
 
 use crate::types::error::DsmError;
 use std::collections::HashMap;
+use crate::common::domain_tags::TAG_RECEIPT_COMMIT;
 
 /// Canonical Stitched Receipt V2
 ///
@@ -475,7 +476,7 @@ impl StitchedReceiptV2 {
         let protobuf_bytes = self.to_canonical_protobuf()?;
 
         // Domain-separated BLAKE3-256: BLAKE3("DSM/receipt-commit\0" || canonical_protobuf_bytes)
-        let hash = crate::crypto::blake3::domain_hash("DSM/receipt-commit", &protobuf_bytes);
+        let hash = crate::crypto::blake3::domain_hash(TAG_RECEIPT_COMMIT, &protobuf_bytes);
         Ok(*hash.as_bytes())
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/verification/smt_replace_witness.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/verification/smt_replace_witness.rs
@@ -7,17 +7,11 @@
 //! Used by acceptance predicates that must be able to recompute an SMT root
 //! from a leaf hash and a sibling path, deterministically and fail-closed.
 
+use crate::common::domain_tags::{TAG_SMT_LEAF, TAG_SMT_NODE};
 use crate::types::error::DsmError;
 
-// Domain tag constants for `DSM/smt-key` / `DSM/smt-leaf` / `DSM/smt-node`
-// REMOVED — Issue #182 Finding #3. The constants were `pub const &[u8]`
-// with trailing `\0` and never consumed (every hash site in this module
-// uses inline string literals like `dsm_domain_hasher("DSM/smt-leaf")`,
-// which produces the canonical `"DSM/smt-leaf\0" || data` preimage via
-// the auto-NUL hasher primitive). The dead constants were inconsistent
-// with the unified `domain_tags::TAG_*` set that drops the trailing NUL
-// per the new module-level convention. If a future caller wants
-// pre-resolved constants, use `dsm::common::domain_tags::TAG_SMT_*`.
+// Domain tags are centralized in `common::domain_tags` and intentionally do
+// not include trailing NUL (`dsm_domain_hasher` appends NUL internally).
 
 /// Hard cap for witness path length (DoS resistance).
 pub const MAX_SMT_WITNESS_PATH_LEN: usize = 256;
@@ -88,14 +82,14 @@ pub use crate::core::bilateral_transaction_manager::compute_smt_key;
 /// Per spec §2.2: `Leaf(X) := BLAKE3("DSM/smt-leaf\0" ∥ X)`.
 /// The relationship key is NOT part of the leaf hash.
 pub fn hash_smt_leaf(tip: &[u8; 32]) -> [u8; 32] {
-    let mut hasher = crate::crypto::blake3::dsm_domain_hasher("DSM/smt-leaf");
+    let mut hasher = crate::crypto::blake3::dsm_domain_hasher(TAG_SMT_LEAF);
     hasher.update(tip);
     *hasher.finalize().as_bytes()
 }
 
 /// Hash an SMT internal node deterministically.
 pub fn hash_smt_node(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
-    let mut hasher = crate::crypto::blake3::dsm_domain_hasher("DSM/smt-node");
+    let mut hasher = crate::crypto::blake3::dsm_domain_hasher(TAG_SMT_NODE);
     hasher.update(left);
     hasher.update(right);
     *hasher.finalize().as_bytes()

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/receipts.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/receipts.rs
@@ -7,6 +7,7 @@
 //! counter checking on stitched receipts.
 
 use dsm::types::error::DsmError;
+use dsm::common::domain_tags::TAG_RECEIPT_COMMIT;
 
 // Re-export canonical types from dsm core
 pub use dsm::types::receipt_types::{
@@ -944,7 +945,7 @@ pub fn deserialize_inclusion_proof(
 /// Callers should prefer a true `StitchedReceiptV2::compute_commitment()` when
 /// available. This helper mirrors the same domain and deterministic framing.
 pub fn derive_stitched_receipt_sigma(parts: &[&[u8]]) -> [u8; 32] {
-    let mut hasher = dsm::crypto::blake3::dsm_domain_hasher("DSM/receipt-commit");
+    let mut hasher = dsm::crypto::blake3::dsm_domain_hasher(TAG_RECEIPT_COMMIT);
     for part in parts {
         hasher.update(&(part.len() as u32).to_le_bytes());
         hasher.update(part);


### PR DESCRIPTION
### Summary
This PR cleans up common utilities in the DSM core/SDK by removing dead code, tightening common exports, and standardizing domain-tag usage across hash callsites. The goal is to reduce drift risk in deterministic hashing paths while preserving current protocol behavior.

### What Changed
- Removed unused helpers from common canonical encoding and deterministic ID modules.
- Restored and documented centralized domain tag constants, including receipt and SMT tags.
- Replaced hard-coded hash-domain literals at callsites with shared constants to avoid divergence.
- Trimmed unused common-module exports and non-essential helper surface.
- Simplified device-tree module comments and removed unused helper/test-only scaffolding.

### Why
- Reduces maintenance burden and dead-code surface.
- Prevents domain-tag drift across crates that could cause subtle commitment mismatches.
- Keeps deterministic hashing paths explicit and auditable.

### Validation
- cargo check -p dsm
- cargo check -p dsm_sdk
- cargo check -p dsm --tests
- Repository pre-commit protocol gates passed during commits (formatting, no-clock/no-json, canonical bilateral gates, flow assertions).

### Risk / Compatibility
- Functional behavior is intended to remain unchanged for protocol-critical hashing and receipt derivation.
- Main compatibility impact is reduced common-module API surface from removed dead exports.