### PR TITLE
fix(cpta): enforce policy checks on execution path and normalize policy anchor binding

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/mod.rs
@@ -73,6 +73,23 @@ impl TokenPolicySystem {
         policy_file: PolicyFile,
     ) -> Result<PolicyAnchor, DsmError> {
         let anchor = PolicyAnchor::from_policy(&policy_file)?;
+        self.register_token_policy_with_anchor(token_id, policy_file, anchor.clone())
+            .await?;
+        Ok(anchor)
+    }
+
+    /// Register a token policy while preserving an already-authoritative
+    /// policy anchor.
+    ///
+    /// Use this when the policy bytes are committed externally (for example,
+    /// via storage-layer `DSM/policy` anchoring) and token operations must
+    /// bind to that exact 32-byte commitment.
+    pub async fn register_token_policy_with_anchor(
+        &self,
+        token_id: &str,
+        policy_file: PolicyFile,
+        anchor: PolicyAnchor,
+    ) -> Result<(), DsmError> {
 
         // Validate policy deterministically
         let validation_context = ValidationContext::new(token_id, &policy_file);
@@ -89,7 +106,7 @@ impl TokenPolicySystem {
             ));
         }
 
-        let token_policy = TokenPolicy::new(policy_file)?;
+        let token_policy = TokenPolicy::new_with_anchor(policy_file, anchor.clone());
         self.policy_cache.store_policy(anchor.clone(), token_policy);
 
         // Register mappings
@@ -100,7 +117,7 @@ impl TokenPolicySystem {
             .insert(token_id.to_string(), anchor.clone());
 
         log::info!("Registered policy for token {}", token_id);
-        Ok(anchor)
+        Ok(())
     }
 
     pub async fn get_token_policy(&self, token_id: &str) -> Result<Option<TokenPolicy>, DsmError> {
@@ -123,9 +140,10 @@ impl TokenPolicySystem {
                 .enforce_policy(&policy, operation_type, context)
                 .await
         } else {
-            // No policy registered -> allow by default.
-            // tick is best-effort; use peek (non-advancing) via enforcer default patterns elsewhere.
-            Ok(EnforcementResult::allowed("No policy restrictions", 0))
+            Ok(EnforcementResult::denied(
+                "No policy registered for token",
+                0,
+            ))
         }
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/mod.rs
@@ -139,6 +139,18 @@ impl TokenPolicySystem {
             self.enforcer
                 .enforce_policy(&policy, operation_type, context)
                 .await
+        } else if crate::core::token::token_state_manager::builtin_policy_commit_for_token(token_id)
+            .is_some()
+        {
+            // Built-in tokens (ERA, dBTC) carry their constraints in dedicated
+            // code paths (e.g. the Bitcoin-tap flow) and were never gated by the
+            // TokenPolicySystem. Default-denying them here is a regression, so
+            // the fail-closed default applies only to genuinely-unknown,
+            // user-created tokens that registered no policy.
+            Ok(EnforcementResult::allowed(
+                "Built-in token; no TokenPolicySystem restrictions",
+                0,
+            ))
         } else {
             Ok(EnforcementResult::denied(
                 "No policy registered for token",
@@ -329,6 +341,33 @@ mod tests {
             "missing_token",
         );
         assert!(resolved.is_err());
+    }
+
+    /// Regression: the fail-closed default for an unregistered token must NOT
+    /// catch built-in tokens (ERA, dBTC) — they were never gated by the
+    /// TokenPolicySystem and carry their constraints elsewhere. Only genuinely
+    /// unknown, user-created tokens with no registered policy are denied.
+    #[tokio::test]
+    async fn enforce_policy_allows_unregistered_builtin_but_denies_unknown() {
+        let system = TokenPolicySystem::new().unwrap();
+        let ctx = std::collections::HashMap::new();
+
+        // dBTC: builtin, no TokenPolicySystem policy registered -> allowed.
+        let dbtc = system.enforce_policy("dBTC", "transfer", &ctx).await.unwrap();
+        assert!(
+            dbtc.allowed,
+            "unregistered builtin dBTC must not be default-denied"
+        );
+
+        // Unknown user token, no policy -> denied (fail closed).
+        let unknown = system
+            .enforce_policy("UNKNOWN_USER_TOKEN", "transfer", &ctx)
+            .await
+            .unwrap();
+        assert!(
+            !unknown.allowed,
+            "unknown unregistered token must be denied"
+        );
     }
 
     #[tokio::test]

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/mod.rs
@@ -90,7 +90,6 @@ impl TokenPolicySystem {
         policy_file: PolicyFile,
         anchor: PolicyAnchor,
     ) -> Result<(), DsmError> {
-
         // Validate policy deterministically
         let validation_context = ValidationContext::new(token_id, &policy_file);
         let validation_result = self.validator.validate_policy(&validation_context).await?;
@@ -353,7 +352,10 @@ mod tests {
         let ctx = std::collections::HashMap::new();
 
         // dBTC: builtin, no TokenPolicySystem policy registered -> allowed.
-        let dbtc = system.enforce_policy("dBTC", "transfer", &ctx).await.unwrap();
+        let dbtc = system
+            .enforce_policy("dBTC", "transfer", &ctx)
+            .await
+            .unwrap();
         assert!(
             dbtc.allowed,
             "unregistered builtin dBTC must not be default-denied"

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/token_state_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/token_state_manager.rs
@@ -541,10 +541,20 @@ impl TokenStateManager {
         };
 
         let mut context = std::collections::HashMap::new();
+        context.insert(
+            "tick".to_string(),
+            crate::utils::deterministic_time::tick_index()
+                .to_le_bytes()
+                .to_vec(),
+        );
         match operation {
             Operation::Transfer {
                 amount, recipient, ..
             } => {
+                context.insert(
+                    "amount_u64".to_string(),
+                    amount.value().to_le_bytes().to_vec(),
+                );
                 context.insert(
                     "amount".to_string(),
                     amount.value().to_string().into_bytes(),
@@ -557,6 +567,10 @@ impl TokenStateManager {
                 ..
             } => {
                 context.insert(
+                    "amount_u64".to_string(),
+                    amount.value().to_le_bytes().to_vec(),
+                );
+                context.insert(
                     "amount".to_string(),
                     amount.value().to_string().into_bytes(),
                 );
@@ -564,9 +578,33 @@ impl TokenStateManager {
             }
             Operation::Burn { amount, .. } => {
                 context.insert(
+                    "amount_u64".to_string(),
+                    amount.value().to_le_bytes().to_vec(),
+                );
+                context.insert(
                     "amount".to_string(),
                     amount.value().to_string().into_bytes(),
                 );
+            }
+            Operation::LockToken { amount, purpose, .. } => {
+                let amount_u64 = u64::try_from(*amount).map_err(|_| {
+                    DsmError::invalid_operation(
+                        "Policy verification rejected: LockToken amount must be non-negative",
+                    )
+                })?;
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                context.insert("purpose".to_string(), purpose.clone());
+            }
+            Operation::UnlockToken { amount, purpose, .. } => {
+                let amount_u64 = u64::try_from(*amount).map_err(|_| {
+                    DsmError::invalid_operation(
+                        "Policy verification rejected: UnlockToken amount must be non-negative",
+                    )
+                })?;
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                context.insert("purpose".to_string(), purpose.clone());
             }
             Operation::Lock {
                 amount,
@@ -574,6 +612,10 @@ impl TokenStateManager {
                 owner,
                 ..
             } => {
+                context.insert(
+                    "amount_u64".to_string(),
+                    amount.value().to_le_bytes().to_vec(),
+                );
                 context.insert(
                     "amount".to_string(),
                     amount.value().to_string().into_bytes(),
@@ -587,6 +629,10 @@ impl TokenStateManager {
                 owner,
                 ..
             } => {
+                context.insert(
+                    "amount_u64".to_string(),
+                    amount.value().to_le_bytes().to_vec(),
+                );
                 context.insert(
                     "amount".to_string(),
                     amount.value().to_string().into_bytes(),
@@ -606,6 +652,8 @@ impl TokenStateManager {
             Operation::Transfer { .. } => "transfer",
             Operation::Mint { .. } => "mint",
             Operation::Burn { .. } => "burn",
+            Operation::LockToken { .. } => "lock",
+            Operation::UnlockToken { .. } => "unlock",
             Operation::Lock { .. } => "lock",
             Operation::Unlock { .. } => "unlock",
             _ => "unknown",

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/token_state_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/token_state_manager.rs
@@ -586,7 +586,9 @@ impl TokenStateManager {
                     amount.value().to_string().into_bytes(),
                 );
             }
-            Operation::LockToken { amount, purpose, .. } => {
+            Operation::LockToken {
+                amount, purpose, ..
+            } => {
                 let amount_u64 = u64::try_from(*amount).map_err(|_| {
                     DsmError::invalid_operation(
                         "Policy verification rejected: LockToken amount must be non-negative",
@@ -596,7 +598,9 @@ impl TokenStateManager {
                 context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
                 context.insert("purpose".to_string(), purpose.clone());
             }
-            Operation::UnlockToken { amount, purpose, .. } => {
+            Operation::UnlockToken {
+                amount, purpose, ..
+            } => {
                 let amount_u64 = u64::try_from(*amount).map_err(|_| {
                     DsmError::invalid_operation(
                         "Policy verification rejected: UnlockToken amount must be non-negative",

--- a/dsm_client/deterministic_state_machine/dsm/src/types/policy_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/policy_types.rs
@@ -602,13 +602,22 @@ pub struct TokenPolicy {
 impl TokenPolicy {
     pub fn new(file: PolicyFile) -> Result<Self, DsmError> {
         let anchor = file.generate_anchor()?;
+        Ok(Self::new_with_anchor(file, anchor))
+    }
+
+    /// Construct a runtime policy using an already-authoritative anchor.
+    ///
+    /// This is used when the canonical policy commitment is obtained from a
+    /// storage-layer anchor (for example, `DSM/policy` anchored bytes) and
+    /// must be preserved exactly in runtime mapping.
+    pub fn new_with_anchor(file: PolicyFile, anchor: PolicyAnchor) -> Self {
         let now = dt::tick().1;
-        Ok(Self {
+        Self {
             file,
             anchor,
             verified: false,
             last_verified: now,
-        })
+        }
     }
 
     pub fn mark_verified(&mut self) {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/token_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/token_routes.rs
@@ -399,6 +399,12 @@ impl AppRouterImpl {
                 if req.policy_anchor.len() != 32 {
                     return err("token.create: policy_anchor must be 32 bytes".into());
                 }
+                let policy_anchor: [u8; 32] = match req.policy_anchor.as_slice().try_into() {
+                    Ok(a) => a,
+                    Err(_) => {
+                        return err("token.create: policy_anchor must be 32 bytes".into());
+                    }
+                };
 
                 let mut max_supply: u128 = 0;
                 for b in &req.max_supply_u128 {
@@ -406,18 +412,18 @@ impl AppRouterImpl {
                 }
 
                 let mut id_hasher = dsm::crypto::blake3::dsm_domain_hasher("DSM/token-id");
-                id_hasher.update(&req.policy_anchor);
+                id_hasher.update(&policy_anchor);
                 id_hasher.update(ticker.as_bytes());
                 let token_id =
                     crate::util::text_id::encode_base32_crockford(id_hasher.finalize().as_bytes());
 
-                let anchor_b32 = crate::util::text_id::encode_base32_crockford(&req.policy_anchor);
+                let anchor_b32 = crate::util::text_id::encode_base32_crockford(&policy_anchor);
                 let mut fields = HashMap::new();
                 fields.insert("max_supply".to_string(), max_supply.to_string());
                 fields.insert("policy_anchor".to_string(), anchor_b32.clone());
 
                 let parsed = self
-                    .load_policy_bytes(req.policy_anchor[..].try_into().unwrap_or([0u8; 32]))
+                    .load_policy_bytes(policy_anchor)
                     .await
                     .ok()
                     .flatten()
@@ -453,9 +459,8 @@ impl AppRouterImpl {
                     fields,
                 };
 
-                // Build a PolicyFile matching the parsed TLV so
-                // `PolicyAnchor::from_policy` produces the authoritative
-                // policy_commit used by every subsequent balance op.
+                // Build a PolicyFile matching parsed policy bytes, then bind it
+                // to the externally supplied policy_anchor commitment.
                 let policy_file = {
                     let transferable = parsed.as_ref().map(|p| p.transferable).unwrap_or(true);
                     let description = parsed.as_ref().and_then(|p| p.description.clone());
@@ -474,20 +479,16 @@ impl AppRouterImpl {
                     pf
                 };
 
-                // Register the policy with TokenPolicySystem so PolicyEnforcer
-                // (and resolve_policy_commit_strict) can bind policy_commit for
-                // every downstream op on this token_id.
-                let anchor = match self
+                // Register policy mapping using the explicit anchor from the
+                // request so token_id -> policy_commit remains stable.
+                if let Err(e) = self
                     .core_sdk
-                    .register_token_policy(&token_id, policy_file)
+                    .register_token_policy_with_anchor(&token_id, policy_file, policy_anchor)
                     .await
                 {
-                    Ok(a) => a,
-                    Err(e) => {
-                        return err(format!("token.create: register_token_policy failed: {e}"));
-                    }
-                };
-                let policy_commit: [u8; 32] = *anchor.as_bytes();
+                    return err(format!("token.create: register_token_policy failed: {e}"));
+                }
+                let policy_commit: [u8; 32] = policy_anchor;
 
                 // Cache authoritative TokenMetadata (no Generic shim op).
                 if let Err(e) = self
@@ -557,7 +558,7 @@ impl AppRouterImpl {
                 let resp = generated::TokenCreateResponse {
                     success: true,
                     token_id,
-                    policy_anchor: req.policy_anchor,
+                    policy_anchor: policy_anchor.to_vec(),
                     message: "Token created".to_string(),
                 };
                 pack_envelope_ok(generated::envelope::Payload::TokenCreateResponse(resp))

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -14,6 +14,7 @@ use blake3::{hash, Hasher};
 use dsm::crypto::blake3 as dsm_blake3;
 use parking_lot::Mutex;
 use prost::Message;
+use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 
 use dsm::core::identity::genesis::create_genesis_via_blind_mpc_with_contributors;
@@ -573,6 +574,251 @@ impl CoreSDK {
             .await
     }
 
+    /// Register policy bytes while preserving an externally-authoritative
+    /// policy anchor (for example, a storage-layer `DSM/policy` commitment).
+    pub async fn register_token_policy_with_anchor(
+        &self,
+        token_id: &str,
+        policy_file: dsm::types::policy_types::PolicyFile,
+        anchor: [u8; 32],
+    ) -> Result<(), DsmError> {
+        self.policy_system
+            .register_token_policy_with_anchor(
+                token_id,
+                policy_file,
+                dsm::types::policy_types::PolicyAnchor::from_bytes(anchor),
+            )
+            .await
+    }
+
+    fn canonical_token_id_str(token_id: &[u8]) -> Option<&str> {
+        std::str::from_utf8(token_id)
+            .ok()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    }
+
+    fn build_token_policy_context(
+        operation: &dsm::types::operations::Operation,
+        state_hash: [u8; 32],
+    ) -> Result<Option<(String, String, HashMap<String, Vec<u8>>)>, DsmError> {
+        let mut context = HashMap::new();
+        context.insert(
+            "tick".to_string(),
+            dsm::utils::deterministic_time::tick_index()
+                .to_le_bytes()
+                .to_vec(),
+        );
+        context.insert("state_hash".to_string(), state_hash.to_vec());
+
+        match operation {
+            DsmOperation::Transfer {
+                token_id,
+                amount,
+                recipient,
+                ..
+            } => {
+                let token_id = Self::canonical_token_id_str(token_id).ok_or_else(|| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: malformed or empty token_id",
+                    )
+                })?;
+                let amount_u64 = amount.value();
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                context.insert("recipient".to_string(), recipient.clone());
+                Ok(Some((
+                    token_id.to_string(),
+                    "transfer".to_string(),
+                    context,
+                )))
+            }
+            DsmOperation::Mint {
+                token_id,
+                amount,
+                authorized_by,
+                ..
+            } => {
+                let token_id = Self::canonical_token_id_str(token_id).ok_or_else(|| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: malformed or empty token_id",
+                    )
+                })?;
+                let amount_u64 = amount.value();
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                context.insert("authorized_by".to_string(), authorized_by.clone());
+                Ok(Some((token_id.to_string(), "mint".to_string(), context)))
+            }
+            DsmOperation::Burn {
+                token_id, amount, ..
+            } => {
+                let token_id = Self::canonical_token_id_str(token_id).ok_or_else(|| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: malformed or empty token_id",
+                    )
+                })?;
+                let amount_u64 = amount.value();
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                Ok(Some((token_id.to_string(), "burn".to_string(), context)))
+            }
+            DsmOperation::Lock {
+                token_id,
+                amount,
+                purpose,
+                owner,
+                ..
+            } => {
+                let token_id = Self::canonical_token_id_str(token_id).ok_or_else(|| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: malformed or empty token_id",
+                    )
+                })?;
+                let amount_u64 = amount.value();
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                context.insert("purpose".to_string(), purpose.clone());
+                context.insert("owner".to_string(), owner.clone());
+                Ok(Some((token_id.to_string(), "lock".to_string(), context)))
+            }
+            DsmOperation::Unlock {
+                token_id,
+                amount,
+                purpose,
+                owner,
+                ..
+            } => {
+                let token_id = Self::canonical_token_id_str(token_id).ok_or_else(|| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: malformed or empty token_id",
+                    )
+                })?;
+                let amount_u64 = amount.value();
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                context.insert("purpose".to_string(), purpose.clone());
+                context.insert("owner".to_string(), owner.clone());
+                Ok(Some((token_id.to_string(), "unlock".to_string(), context)))
+            }
+            DsmOperation::LockToken {
+                token_id,
+                amount,
+                purpose,
+                ..
+            } => {
+                let token_id = Self::canonical_token_id_str(token_id).ok_or_else(|| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: malformed or empty token_id",
+                    )
+                })?;
+                let amount_u64 = u64::try_from(*amount).map_err(|_| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: LockToken amount must be non-negative",
+                    )
+                })?;
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                context.insert("purpose".to_string(), purpose.clone());
+                Ok(Some((token_id.to_string(), "lock".to_string(), context)))
+            }
+            DsmOperation::UnlockToken {
+                token_id,
+                amount,
+                purpose,
+                ..
+            } => {
+                let token_id = Self::canonical_token_id_str(token_id).ok_or_else(|| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: malformed or empty token_id",
+                    )
+                })?;
+                let amount_u64 = u64::try_from(*amount).map_err(|_| {
+                    DsmError::invalid_operation(
+                        "Policy enforcement rejected: UnlockToken amount must be non-negative",
+                    )
+                })?;
+                context.insert("amount_u64".to_string(), amount_u64.to_le_bytes().to_vec());
+                context.insert("amount".to_string(), amount_u64.to_string().into_bytes());
+                context.insert("purpose".to_string(), purpose.clone());
+                Ok(Some((token_id.to_string(), "unlock".to_string(), context)))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn enforce_policy_for_operation(
+        &self,
+        operation: &dsm::types::operations::Operation,
+        state_hash: [u8; 32],
+    ) -> Result<(), DsmError> {
+        let Some((token_id, op_type, context)) =
+            Self::build_token_policy_context(operation, state_hash)?
+        else {
+            return Ok(());
+        };
+
+        let result = if tokio::runtime::Handle::try_current().is_ok() {
+            let policy_system = self.policy_system.clone();
+            let token_id_for_thread = token_id.clone();
+            let op_type_for_thread = op_type.clone();
+            let context_for_thread = context.clone();
+            let join_res = std::thread::spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| {
+                        DsmError::internal(
+                            format!("Failed to build runtime for policy enforcement: {e}"),
+                            None::<std::convert::Infallible>,
+                        )
+                    })?;
+                rt.block_on(async {
+                    policy_system
+                        .enforce_policy(&token_id_for_thread, &op_type_for_thread, &context_for_thread)
+                        .await
+                })
+            })
+            .join();
+
+            match join_res {
+                Ok(res) => res?,
+                Err(_) => {
+                    return Err(DsmError::internal(
+                        "Failed to join policy enforcement thread",
+                        None::<std::convert::Infallible>,
+                    ));
+                }
+            }
+        } else {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    DsmError::internal(
+                        format!("Failed to build runtime for policy enforcement: {e}"),
+                        None::<std::convert::Infallible>,
+                    )
+                })?;
+
+            rt.block_on(async {
+                self.policy_system
+                    .enforce_policy(&token_id, &op_type, &context)
+                    .await
+            })?
+        };
+
+        if !result.allowed {
+            return Err(DsmError::policy_violation(
+                token_id,
+                result.reason,
+                None::<std::convert::Infallible>,
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Execute a DSM operation on a specific relationship chain (§2.2, §4.2).
     ///
     /// Returns `(State, AdvanceOutcome)` where the `State` is a compatibility
@@ -588,6 +834,12 @@ impl CoreSDK {
         initial_chain_tip: Option<[u8; 32]>,
     ) -> Result<(State, dsm::types::device_state::AdvanceOutcome), DsmError> {
         let mut sm = self.state_machine.lock();
+
+        // Enforce token policy constraints on the operation that will advance
+        // state. This closes the previous gap where registration existed but
+        // execution path skipped policy checks.
+        let current_state_hash = sm.device_head().map(|ds| ds.root()).unwrap_or([0u8; 32]);
+        self.enforce_policy_for_operation(&operation, current_state_hash)?;
 
         // Phase 4.1 fail-closed pattern (§4.3 acceptance, §6.1 single-writer):
         //   1. PREPARE — derive the AdvanceOutcome (pure; no head mutation).

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -775,7 +775,11 @@ impl CoreSDK {
                     })?;
                 rt.block_on(async {
                     policy_system
-                        .enforce_policy(&token_id_for_thread, &op_type_for_thread, &context_for_thread)
+                        .enforce_policy(
+                            &token_id_for_thread,
+                            &op_type_for_thread,
+                            &context_for_thread,
+                        )
                         .await
                 })
             })


### PR DESCRIPTION
## Summary
- Enforces CPTA policy checks directly in the token execution path instead of relying on indirect validation.
- Adds explicit policy registration with anchor binding so policy identity is consistent from create through enforcement.
- Normalizes token.create anchor handling and returns the normalized anchor in the route response.
- Expands policy context witness inputs to include deterministic fields needed by constraints, including tick and amount_u64.
- Hardens token state verification coverage for lock and unlock style token operations.

## Why this change
- Closes a fail-open gap where execution could proceed without strict policy enforcement.
- Prevents anchor drift between registration, cache lookups, and runtime enforcement.
- Aligns runtime behavior with deterministic CPTA expectations in the core token flow.

## Scope
- Core token policy system updates.
- Core token state manager policy verification updates.
- Token policy type constructor updates.
- SDK execution path enforcement updates.
- Token route registration and anchor normalization updates.

## Impact
- Behavior is now fail-closed when a required token policy is missing at execution time.
- No protocol schema or wire format changes in this patch.
- Focused to CPTA enforcement and anchor consistency.

## Validation
- Passed: cargo check -p dsm -p dsm_sdk
- Passed: cargo test -p dsm_sdk token_create_request_roundtrip
- Passed: cargo test -p dsm token_state_manager
- Executed ignored lifecycle test: cargo test -p dsm_sdk --test e2e_token_create_lifecycle -- --ignored --nocapture
- Lifecycle test status in this environment: blocked at genesis precondition because platform silicon inputs (hw and env) are required before MPC genesis

## Notes for reviewers
- This PR intentionally tightens enforcement semantics to reduce policy bypass risk.
- Main review focus should be policy registration consistency, execution-path gating, and context witness correctness.