### PR TITLE
Harden recovery capsule and rollup input validation

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/capsule.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/capsule.rs
@@ -525,6 +525,18 @@ fn validate_capsule(capsule: &RecoveryCapsule, metadata: &CapsuleMetadata) -> Re
     if capsule.challenge.len() != 32 {
         return Err(DsmError::verification("Invalid capsule challenge length"));
     }
+    if !capsule.source_device_id.is_empty() && capsule.source_device_id.len() != 32 {
+        return Err(DsmError::verification(format!(
+            "Invalid source_device_id length: expected 32 or empty, got {}",
+            capsule.source_device_id.len()
+        )));
+    }
+    if !capsule.genesis_hash.is_empty() && capsule.genesis_hash.len() != 32 {
+        return Err(DsmError::verification(format!(
+            "Invalid genesis_hash length: expected 32 or empty, got {}",
+            capsule.genesis_hash.len()
+        )));
+    }
     if capsule.metadata.version != metadata.version
         || capsule.metadata.counter != metadata.counter
         || capsule.metadata.logical_time != metadata.logical_time
@@ -1030,6 +1042,58 @@ mod tests {
 
         assert!(plaintext.cert_chain_heads.is_empty());
         assert!(plaintext.last_certs.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_capsule_rejects_invalid_source_device_id_length() -> Result<(), DsmError> {
+        init_capsule_subsystem()?;
+        let key = derive_recovery_key(MNEMONIC)?;
+
+        let capsule = RecoveryCapsule {
+            smt_root: vec![0x11; 32],
+            counterparty_tips: HashMap::new(),
+            rollup_hash: vec![0x22; 32],
+            challenge: derive_challenge(&[0x22; 32], &[0x11; 32], 1).to_vec(),
+            metadata: CapsuleMetadata {
+                version: 3,
+                flags: 0,
+                logical_time: 1,
+                counter: 1,
+            },
+            source_device_id: vec![0x44; 31],
+            genesis_hash: vec![0x55; 32],
+            cert_chain_heads: HashMap::new(),
+            last_certs: HashMap::new(),
+        };
+
+        assert!(encrypt_capsule_with_key(&capsule, &key).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_capsule_rejects_invalid_genesis_hash_length() -> Result<(), DsmError> {
+        init_capsule_subsystem()?;
+        let key = derive_recovery_key(MNEMONIC)?;
+
+        let capsule = RecoveryCapsule {
+            smt_root: vec![0x11; 32],
+            counterparty_tips: HashMap::new(),
+            rollup_hash: vec![0x22; 32],
+            challenge: derive_challenge(&[0x22; 32], &[0x11; 32], 2).to_vec(),
+            metadata: CapsuleMetadata {
+                version: 3,
+                flags: 0,
+                logical_time: 2,
+                counter: 2,
+            },
+            source_device_id: vec![0x44; 32],
+            genesis_hash: vec![0x55; 31],
+            cert_chain_heads: HashMap::new(),
+            last_certs: HashMap::new(),
+        };
+
+        assert!(encrypt_capsule_with_key(&capsule, &key).is_err());
         Ok(())
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/rollup.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/rollup.rs
@@ -87,6 +87,23 @@ pub fn update_rollup(
     counterparty_id: &str,
     new_height: u64,
 ) -> Result<(), DsmError> {
+    if receipt_id.is_empty() {
+        return Err(DsmError::invalid_parameter(
+            "receipt_id must not be empty for recovery rollup updates",
+        ));
+    }
+    if receipt_hash.len() != 32 {
+        return Err(DsmError::invalid_parameter(format!(
+            "receipt_hash must be 32 bytes, got {}",
+            receipt_hash.len()
+        )));
+    }
+    if counterparty_id.is_empty() {
+        return Err(DsmError::invalid_parameter(
+            "counterparty_id must not be empty for recovery rollup updates",
+        ));
+    }
+
     // Create 8-byte counterparty digest from counterparty_id
     let peer_digest = create_peer_digest(counterparty_id);
 
@@ -219,5 +236,22 @@ mod tests {
         assert_eq!(digest2.len(), 8);
         assert_ne!(digest1, digest2);
         assert_eq!(digest1, digest1_again);
+    }
+
+    #[test]
+    fn test_rollup_rejects_invalid_inputs() {
+        let mut rollup = ReceiptRollup::new();
+
+        let err = update_rollup(&mut rollup, b"", &[1; 32], "peer1", 1)
+            .expect_err("empty receipt id must reject");
+        assert!(matches!(err, DsmError::InvalidParameter(_)));
+
+        let err = update_rollup(&mut rollup, b"r1", &[1; 31], "peer1", 1)
+            .expect_err("short receipt hash must reject");
+        assert!(matches!(err, DsmError::InvalidParameter(_)));
+
+        let err = update_rollup(&mut rollup, b"r1", &[1; 32], "", 1)
+            .expect_err("empty counterparty id must reject");
+        assert!(matches!(err, DsmError::InvalidParameter(_)));
     }
 }


### PR DESCRIPTION
## Summary
This PR hardens recovery-path input validation to reject malformed artifacts early and deterministically.

## What Changed
- [dsm_client/deterministic_state_machine/dsm/src/recovery/capsule.rs](dsm_client/deterministic_state_machine/dsm/src/recovery/capsule.rs)
  - Enforced strict length validation for:
    - `source_device_id` (must be empty or 32 bytes)
    - `genesis_hash` (must be empty or 32 bytes)
  - Added regression tests that assert invalid lengths are rejected.

- [dsm_client/deterministic_state_machine/dsm/src/recovery/rollup.rs](dsm_client/deterministic_state_machine/dsm/src/recovery/rollup.rs)
  - Added input guards for `update_rollup`:
    - `receipt_id` must be non-empty
    - `receipt_hash` must be exactly 32 bytes
    - `counterparty_id` must be non-empty
  - Added regression tests for each invalid-input case.

## Scope
Only recovery hardening changes are included, focused on capsule and rollup validation paths.
