### PR TITLE
ci: green the Rust + Coverage gates (pin 1.96.0, reformat, clippy production-safety, real PaidK trace proof, serialize time tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned: rustfmt/clippy output is version-specific. `@stable` drifts on
+      # every release and then fails unchanged code on `cargo fmt --check`.
+      # Bump this pin deliberately and reformat in the same PR.
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt, clippy
 
@@ -87,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
 
       - uses: actions/setup-java@v5
         with:
@@ -208,7 +211,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: llvm-tools-preview
 
@@ -330,7 +333,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/dsm_client/deterministic_state_machine/dsm/src/bitcoin/header_chain.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/bitcoin/header_chain.rs
@@ -146,10 +146,9 @@ pub fn verify_header_chain(
         {
             let _ = network;
             return Err(DsmError::Validation {
-                context:
-                    "No checkpoints available for network; SPV verification cannot proceed (\
+                context: "No checkpoints available for network; SPV verification cannot proceed (\
                      production build — testnet bypass disabled)"
-                        .to_string(),
+                    .to_string(),
                 source: None,
             });
         }

--- a/dsm_client/deterministic_state_machine/dsm/src/bitcoin/trust.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/bitcoin/trust.rs
@@ -199,8 +199,8 @@ mod tests {
                 },
                 spv_inclusion_valid: true,
                 pow_valid: true,
-                checkpoint_rooted: false,    // would have passed under bypass
-                same_chain_anchored: false,  // would have passed under bypass
+                checkpoint_rooted: false,   // would have passed under bypass
+                same_chain_anchored: false, // would have passed under bypass
             };
             assert_eq!(
                 evidence.observation.trust_profile(),

--- a/dsm_client/deterministic_state_machine/dsm/src/bitcoin/types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/bitcoin/types.rs
@@ -149,9 +149,18 @@ mod tests {
     // back to Mainnet (the STRICTEST profile), never to Signet.
     #[test]
     fn try_from_u32_accepts_only_known_values() {
-        assert_eq!(BitcoinNetwork::try_from_u32(0).unwrap(), BitcoinNetwork::Mainnet);
-        assert_eq!(BitcoinNetwork::try_from_u32(1).unwrap(), BitcoinNetwork::Testnet);
-        assert_eq!(BitcoinNetwork::try_from_u32(2).unwrap(), BitcoinNetwork::Signet);
+        assert_eq!(
+            BitcoinNetwork::try_from_u32(0).unwrap(),
+            BitcoinNetwork::Mainnet
+        );
+        assert_eq!(
+            BitcoinNetwork::try_from_u32(1).unwrap(),
+            BitcoinNetwork::Testnet
+        );
+        assert_eq!(
+            BitcoinNetwork::try_from_u32(2).unwrap(),
+            BitcoinNetwork::Signet
+        );
         for n in [3u32, 4, 5, 99, 1000, u32::MAX] {
             assert!(
                 BitcoinNetwork::try_from_u32(n).is_err(),

--- a/dsm_client/deterministic_state_machine/dsm/src/commitments/deterministic.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/commitments/deterministic.rs
@@ -632,9 +632,8 @@ mod tests {
         let recipient = b"r";
         let unlock_slot = 0xDEAD_BEEFu64;
 
-        let from_api =
-            create_time_locked_commitment(&state_hash, &op, recipient, unlock_slot)
-                .expect("commitment");
+        let from_api = create_time_locked_commitment(&state_hash, &op, recipient, unlock_slot)
+            .expect("commitment");
         let mut extra = [0u8; 8];
         extra.copy_from_slice(&unlock_slot.to_le_bytes());
         let expected = independent_hash_fields(
@@ -656,9 +655,8 @@ mod tests {
         // Force canonicalization through trim + lowercase.
         let cond = "  BTC_Price_GT_50000  ";
         let oracle = "  Crypto_Price_Oracle  ";
-        let from_api =
-            create_conditional_commitment(&state_hash, &op, recipient, cond, oracle)
-                .expect("commitment");
+        let from_api = create_conditional_commitment(&state_hash, &op, recipient, cond, oracle)
+            .expect("commitment");
 
         let combined = format!(
             "cond={};oracle={}",
@@ -687,9 +685,8 @@ mod tests {
         let period: u64 = 17;
         let end: u64 = 999;
 
-        let from_api =
-            create_recurring_commitment(&state_hash, &op, recipient, period, end)
-                .expect("commitment");
+        let from_api = create_recurring_commitment(&state_hash, &op, recipient, period, end)
+            .expect("commitment");
         let mut extra = [0u8; 16];
         extra[0..8].copy_from_slice(&period.to_le_bytes());
         extra[8..16].copy_from_slice(&end.to_le_bytes());
@@ -713,17 +710,12 @@ mod tests {
         let op = mk_transfer(100);
         let recipient = b"r";
 
-        let a = create_deterministic_commitment(&state_hash, &op, recipient, Some("hello"))
-            .expect("a");
-        let b = create_deterministic_commitment(&state_hash, &op, recipient, Some("HELLO"))
-            .expect("b");
-        let c = create_deterministic_commitment(
-            &state_hash,
-            &op,
-            recipient,
-            Some("  HeLLo   "),
-        )
-        .expect("c");
+        let a =
+            create_deterministic_commitment(&state_hash, &op, recipient, Some("hello")).expect("a");
+        let b =
+            create_deterministic_commitment(&state_hash, &op, recipient, Some("HELLO")).expect("b");
+        let c = create_deterministic_commitment(&state_hash, &op, recipient, Some("  HeLLo   "))
+            .expect("c");
         assert_eq!(a, b, "case must be canonicalized");
         assert_eq!(a, c, "whitespace must be canonicalized");
 
@@ -746,9 +738,8 @@ mod tests {
         let state_hash = [0x66u8; 32];
         let op = mk_transfer(100);
         let recipient = b"r";
-        let baseline =
-            create_deterministic_commitment(&state_hash, &op, recipient, Some("cond"))
-                .expect("baseline");
+        let baseline = create_deterministic_commitment(&state_hash, &op, recipient, Some("cond"))
+            .expect("baseline");
 
         // Mutate state_hash.
         let mut sh = state_hash;
@@ -764,13 +755,9 @@ mod tests {
         assert_ne!(baseline, mutated, "operation must affect digest");
 
         // Mutate recipient_info.
-        let mutated = create_deterministic_commitment(
-            &state_hash,
-            &op,
-            b"different-recipient",
-            Some("cond"),
-        )
-        .expect("mutated recipient");
+        let mutated =
+            create_deterministic_commitment(&state_hash, &op, b"different-recipient", Some("cond"))
+                .expect("mutated recipient");
         assert_ne!(baseline, mutated, "recipient_info must affect digest");
 
         // Mutate condition.
@@ -779,9 +766,12 @@ mod tests {
         assert_ne!(baseline, mutated, "conditions must affect digest");
 
         // None vs Some — must differ.
-        let no_cond = create_deterministic_commitment(&state_hash, &op, recipient, None)
-            .expect("no cond");
-        assert_ne!(baseline, no_cond, "presence of conditions must affect digest");
+        let no_cond =
+            create_deterministic_commitment(&state_hash, &op, recipient, None).expect("no cond");
+        assert_ne!(
+            baseline, no_cond,
+            "presence of conditions must affect digest"
+        );
     }
 
     #[test]
@@ -794,12 +784,12 @@ mod tests {
         let op = mk_transfer(100);
         let recipient = b"r";
 
-        let base = create_deterministic_commitment(&state_hash, &op, recipient, None)
-            .expect("base");
-        let timelock = create_time_locked_commitment(&state_hash, &op, recipient, 0)
-            .expect("timelock");
-        let recurring = create_recurring_commitment(&state_hash, &op, recipient, 0, 0)
-            .expect("recurring");
+        let base =
+            create_deterministic_commitment(&state_hash, &op, recipient, None).expect("base");
+        let timelock =
+            create_time_locked_commitment(&state_hash, &op, recipient, 0).expect("timelock");
+        let recurring =
+            create_recurring_commitment(&state_hash, &op, recipient, 0, 0).expect("recurring");
 
         assert_ne!(base, timelock, "base != timelock");
         assert_ne!(base, recurring, "base != recurring");
@@ -821,13 +811,7 @@ mod tests {
                 let mut corrupted = commitment.clone();
                 corrupted[byte_idx] ^= 1 << bit;
                 assert!(
-                    !verify_deterministic_commitment(
-                        &corrupted,
-                        &state_hash,
-                        &op,
-                        recipient,
-                        cond,
-                    ),
+                    !verify_deterministic_commitment(&corrupted, &state_hash, &op, recipient, cond,),
                     "verify must reject corruption at byte {byte_idx} bit {bit}"
                 );
             }

--- a/dsm_client/deterministic_state_machine/dsm/src/commitments/precommit.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/commitments/precommit.rs
@@ -1505,8 +1505,8 @@ mod tests {
 
         for id in signer_ids {
             let entropy = format!("DSM/test/{id}").into_bytes();
-            let kp = SignatureKeyPair::generate_from_entropy(&entropy)
-                .expect("generate test keypair");
+            let kp =
+                SignatureKeyPair::generate_from_entropy(&entropy).expect("generate test keypair");
             let sig = kp.sign(&digest).expect("sign test digest");
             signatures.insert((*id).to_string(), sig);
             public_keys.insert((*id).to_string(), kp.public_key().to_vec());
@@ -1528,13 +1528,8 @@ mod tests {
 
     #[test]
     fn verify_integrity_accepts_valid_signatures() {
-        let (proof, pks, _sks) = signed_invalidation_proof(
-            &["s1", "s2", "s3"],
-            "forkA",
-            [0x11; 32],
-            [0x22; 32],
-            42,
-        );
+        let (proof, pks, _sks) =
+            signed_invalidation_proof(&["s1", "s2", "s3"], "forkA", [0x11; 32], [0x22; 32], 42);
         let ok = proof
             .verify_integrity(&proof.fork_hash, 3, &pks)
             .expect("verify must not error on well-formed input");
@@ -1544,13 +1539,8 @@ mod tests {
     #[test]
     fn verify_integrity_rejects_when_signatures_dont_verify() {
         // Tamper with one signature so cryptographic verify fails on it.
-        let (mut proof, pks, _sks) = signed_invalidation_proof(
-            &["s1", "s2", "s3"],
-            "forkA",
-            [0x11; 32],
-            [0x22; 32],
-            42,
-        );
+        let (mut proof, pks, _sks) =
+            signed_invalidation_proof(&["s1", "s2", "s3"], "forkA", [0x11; 32], [0x22; 32], 42);
         if let Some(sig) = proof.signatures.get_mut("s2") {
             sig[0] ^= 0xFF; // flip a byte so verification fails
         }
@@ -1574,13 +1564,8 @@ mod tests {
     fn verify_integrity_rejects_unknown_signer_ids() {
         // Build a proof with 3 signatures, but only supply 1 public key. The
         // other two signer_ids are unknown to the verifier and must NOT count.
-        let (proof, mut pks, _sks) = signed_invalidation_proof(
-            &["s1", "s2", "s3"],
-            "forkA",
-            [0x11; 32],
-            [0x22; 32],
-            42,
-        );
+        let (proof, mut pks, _sks) =
+            signed_invalidation_proof(&["s1", "s2", "s3"], "forkA", [0x11; 32], [0x22; 32], 42);
         pks.remove("s2");
         pks.remove("s3");
         let ok = proof
@@ -1594,13 +1579,8 @@ mod tests {
 
     #[test]
     fn verify_integrity_rejects_fork_hash_mismatch() {
-        let (proof, pks, _sks) = signed_invalidation_proof(
-            &["s1", "s2", "s3"],
-            "forkA",
-            [0x11; 32],
-            [0x22; 32],
-            42,
-        );
+        let (proof, pks, _sks) =
+            signed_invalidation_proof(&["s1", "s2", "s3"], "forkA", [0x11; 32], [0x22; 32], 42);
         let wrong = [0x99u8; 32];
         let ok = proof
             .verify_integrity(&wrong, 3, &pks)

--- a/dsm_client/deterministic_state_machine/dsm/src/commitments/precommit.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/commitments/precommit.rs
@@ -1482,17 +1482,21 @@ mod tests {
     // cryptographically verify each signature, not just count entries.
     // ────────────────────────────────────────────────────────────────────────
 
+    /// `(proof, public-keys-by-id, secret-keys-by-id)`. Secret keys are
+    /// returned only so the forging tests can re-sign with the wrong key.
+    type SignedInvalidationFixture = (
+        ForkInvalidationProof,
+        HashMap<String, Vec<u8>>,
+        HashMap<String, Vec<u8>>,
+    );
+
     fn signed_invalidation_proof(
         signer_ids: &[&str],
         fork_id: &str,
         fork_hash: [u8; 32],
         selected_fork_hash: [u8; 32],
         tick: u64,
-    ) -> (
-        ForkInvalidationProof,
-        HashMap<String, Vec<u8>>,
-        HashMap<String, Vec<u8>>, // signing-key (secret) by id, for forging tests
-    ) {
+    ) -> SignedInvalidationFixture {
         use crate::crypto::signatures::SignatureKeyPair;
 
         let canonical_bytes =

--- a/dsm_client/deterministic_state_machine/dsm/src/commitments/smart_commitment.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/commitments/smart_commitment.rs
@@ -622,11 +622,9 @@ impl SmartCommitment {
                         let Some(sig) = ctx.signatures.get(required_pk) else {
                             continue;
                         };
-                        if let Ok(true) = crate::crypto::sphincs::sphincs_verify(
-                            required_pk,
-                            msg.as_bytes(),
-                            sig,
-                        ) {
+                        if let Ok(true) =
+                            crate::crypto::sphincs::sphincs_verify(required_pk, msg.as_bytes(), sig)
+                        {
                             ok += 1;
                         }
                     }
@@ -715,7 +713,8 @@ impl SmartCommitment {
                 let Some(sig) = oracle_signature else {
                     return Ok(false);
                 };
-                let mut buf = Vec::with_capacity(32 + 32 + self.recipient.len() + 8 + condition.len());
+                let mut buf =
+                    Vec::with_capacity(32 + 32 + self.recipient.len() + 8 + condition.len());
                 buf.extend_from_slice(&self.commitment_hash);
                 buf.extend_from_slice(&self.origin_state_hash);
                 buf.extend_from_slice(&self.recipient);
@@ -1562,10 +1561,7 @@ mod tests {
     // signature against a commitment-bound message, not just check presence.
     // ────────────────────────────────────────────────────────────────────────
 
-    fn make_multisig_commitment(
-        required_pks: Vec<Vec<u8>>,
-        threshold: usize,
-    ) -> SmartCommitment {
+    fn make_multisig_commitment(required_pks: Vec<Vec<u8>>, threshold: usize) -> SmartCommitment {
         let (origin_hash, origin_entropy) = test_origin();
         let op = signed_update("ms_op", vec![1, 2, 3], "Multi-sig payment");
         SmartCommitment::new(
@@ -1592,8 +1588,7 @@ mod tests {
 
         let kps: Vec<_> = (0..3)
             .map(|i| {
-                SignatureKeyPair::generate_from_entropy(format!("ms-{i}").as_bytes())
-                    .expect("kp")
+                SignatureKeyPair::generate_from_entropy(format!("ms-{i}").as_bytes()).expect("kp")
             })
             .collect();
         let required: Vec<Vec<u8>> = kps.iter().map(|k| k.public_key().to_vec()).collect();
@@ -1615,8 +1610,7 @@ mod tests {
 
         let kps: Vec<_> = (0..3)
             .map(|i| {
-                SignatureKeyPair::generate_from_entropy(format!("ms-{i}").as_bytes())
-                    .expect("kp")
+                SignatureKeyPair::generate_from_entropy(format!("ms-{i}").as_bytes()).expect("kp")
             })
             .collect();
         let required: Vec<Vec<u8>> = kps.iter().map(|k| k.public_key().to_vec()).collect();
@@ -1689,9 +1683,7 @@ mod tests {
 
         let msg = oracle_signing_msg(&c, &condition);
         let sig = kp.sign(&msg).expect("sign");
-        let ok = c
-            .is_executable(Some(sig))
-            .expect("verify must not error");
+        let ok = c.is_executable(Some(sig)).expect("verify must not error");
         assert!(ok, "valid commitment-bound oracle sig must verify");
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/common/device_tree.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/device_tree.rs
@@ -87,11 +87,7 @@ impl DevTreeProof {
     /// are byte-identical for the same input.
     ///
     /// Returns the serialized proto bytes.
-    pub fn to_v1_proto_bytes(
-        &self,
-        device_id: &[u8; 32],
-        root_hash: &[u8; 32],
-    ) -> Vec<u8> {
+    pub fn to_v1_proto_bytes(&self, device_id: &[u8; 32], root_hash: &[u8; 32]) -> Vec<u8> {
         use prost::Message;
         let path_bits_len = self.path_bits.len();
         let packed_len = path_bits_len.div_ceil(8);
@@ -524,8 +520,7 @@ mod tests {
         let proof = tree.proof(&dev_b).expect("proof");
 
         let encoded = proof.to_v1_proto_bytes(&dev_b, &root);
-        let decoded =
-            DeviceInclusionProofV1::decode(encoded.as_slice()).expect("decode");
+        let decoded = DeviceInclusionProofV1::decode(encoded.as_slice()).expect("decode");
         assert_eq!(decoded.device_id, dev_b.to_vec());
         assert_eq!(decoded.root_hash, root.to_vec());
         assert_eq!(decoded.siblings.len(), proof.siblings.len());

--- a/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/policy_enforcement.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/token/policy/policy_enforcement.rs
@@ -499,10 +499,7 @@ impl PolicyEnforcer {
                 // Issue #183 Finding 3 fix: role-permission match must use
                 // case-sensitive comparison to align with the case-sensitive
                 // canonical sort of role permissions in `CanonicalPolicy`.
-                let permitted = role
-                    .permissions
-                    .iter()
-                    .any(|op| op == &ctx.operation_type);
+                let permitted = role.permissions.iter().any(|op| op == &ctx.operation_type);
                 if permitted {
                     return Ok(true);
                 }
@@ -593,8 +590,7 @@ mod tests {
     // ────────────────────────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn operation_restriction_is_case_sensitive() -> Result<(), Box<dyn std::error::Error>>
-    {
+    async fn operation_restriction_is_case_sensitive() -> Result<(), Box<dyn std::error::Error>> {
         let cache = Arc::new(PolicyCache::new(PolicyCacheConfig::default()));
         let enforcer = PolicyEnforcer::new(cache);
 

--- a/dsm_client/deterministic_state_machine/dsm/src/emissions/paidk_proof.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/emissions/paidk_proof.rs
@@ -57,9 +57,8 @@ pub fn verify_paidk_gate_proof(
         ));
     }
 
-    let proof = PaidKGateProofV1::decode(gate_proof_bytes).map_err(|e| {
-        DsmError::Verification(format!("PaidK gate_proof decode failed: {e}"))
-    })?;
+    let proof = PaidKGateProofV1::decode(gate_proof_bytes)
+        .map_err(|e| DsmError::Verification(format!("PaidK gate_proof decode failed: {e}")))?;
 
     if proof.receipts.len() < PAIDK_K {
         return Err(DsmError::Verification(format!(
@@ -167,8 +166,7 @@ mod tests {
                 mk_receipt(device, 2, PAIDK_FLAT_RATE),
             ],
         };
-        let err = verify_paidk_gate_proof(&encode(&proof), &device)
-            .expect_err("k-1 must reject");
+        let err = verify_paidk_gate_proof(&encode(&proof), &device).expect_err("k-1 must reject");
         assert!(format!("{err}").contains("requires >="));
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/tombstone.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/tombstone.rs
@@ -309,10 +309,7 @@ mod tests {
         succession.signature = sphincs_sign(&sk, &succession.succession_hash)?;
 
         let verified = verify_recovery_pair(&tombstone, &succession, &pk)?;
-        assert!(
-            verified,
-            "issue #187: equal-tick recovery pair must verify"
-        );
+        assert!(verified, "issue #187: equal-tick recovery pair must verify");
         Ok(())
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/tests/device_tree_root_lifecycle_test.rs
+++ b/dsm_client/deterministic_state_machine/dsm/tests/device_tree_root_lifecycle_test.rs
@@ -351,7 +351,10 @@ mod v1_proto_roundtrip {
         assert_eq!(decoded.device_id, original.device_id);
         assert_eq!(decoded.root_hash, original.root_hash);
         assert_eq!(decoded.siblings.len(), 5);
-        assert_eq!(decoded.siblings, siblings, "sibling ORDER must be preserved");
+        assert_eq!(
+            decoded.siblings, siblings,
+            "sibling ORDER must be preserved"
+        );
         assert_eq!(decoded.path_bits_len, 5);
         assert_eq!(decoded.path_bits, vec![0b10101]);
     }

--- a/dsm_client/deterministic_state_machine/dsm/tests/device_tree_root_lifecycle_test.rs
+++ b/dsm_client/deterministic_state_machine/dsm/tests/device_tree_root_lifecycle_test.rs
@@ -251,62 +251,67 @@ mod v1_proto_roundtrip {
     };
     use prost::Message;
 
-    fn round_trip_bytes<M: Message + Default>(msg: &M) -> M {
-        let mut buf = Vec::with_capacity(msg.encoded_len());
-        msg.encode(&mut buf).expect("encode succeeds");
-        let decoded = M::decode(buf.as_slice()).expect("decode succeeds");
+    // `.expect()` is a banned panic-path even in tests (production-safety
+    // mandate). Encoding into a `Vec` is infallible via `encode_to_vec`; the
+    // only genuinely-fallible step is decode, so the helper returns a
+    // `Result` and each test propagates with `?` and returns `Result<()>`.
+    fn round_trip_bytes<M: Message + Default>(msg: &M) -> Result<M, prost::DecodeError> {
+        let buf = msg.encode_to_vec();
+        let decoded = M::decode(buf.as_slice())?;
         // Second encode must be bitwise identical to the first — protobuf is
         // not strictly canonical, but prost's encode is deterministic for
         // these structurally-simple messages.
-        let mut buf2 = Vec::with_capacity(decoded.encoded_len());
-        decoded.encode(&mut buf2).expect("re-encode succeeds");
+        let buf2 = decoded.encode_to_vec();
         assert_eq!(buf, buf2, "encode → decode → encode must be deterministic");
-        decoded
+        Ok(decoded)
     }
 
     #[test]
-    fn device_leaf_v1_round_trip() {
+    fn device_leaf_v1_round_trip() -> Result<(), prost::DecodeError> {
         let original = DeviceLeafV1 {
             device_id: vec![0xAB; 32],
             device_name: "Brandon's phone".to_string(),
         };
-        let decoded = round_trip_bytes(&original);
+        let decoded = round_trip_bytes(&original)?;
         assert_eq!(decoded.device_id, original.device_id);
         assert_eq!(decoded.device_name, original.device_name);
+        Ok(())
     }
 
     #[test]
-    fn device_leaf_v1_empty_name_is_preserved() {
+    fn device_leaf_v1_empty_name_is_preserved() -> Result<(), prost::DecodeError> {
         // Empty UI label is legal (the leaf hash binds device_id only).
         let original = DeviceLeafV1 {
             device_id: vec![0x01; 32],
             device_name: String::new(),
         };
-        let decoded = round_trip_bytes(&original);
+        let decoded = round_trip_bytes(&original)?;
         assert_eq!(decoded.device_id, original.device_id);
         assert!(
             decoded.device_name.is_empty(),
             "empty device_name must survive the wire"
         );
+        Ok(())
     }
 
     #[test]
-    fn device_tree_v1_round_trip() {
+    fn device_tree_v1_round_trip() -> Result<(), prost::DecodeError> {
         let original = DeviceTreeV1 {
             schema_version: 1,
             root_hash: vec![0xCD; 32],
             device_count: 7,
             version_number: 42,
         };
-        let decoded = round_trip_bytes(&original);
+        let decoded = round_trip_bytes(&original)?;
         assert_eq!(decoded.schema_version, 1);
         assert_eq!(decoded.root_hash, original.root_hash);
         assert_eq!(decoded.device_count, 7);
         assert_eq!(decoded.version_number, 42);
+        Ok(())
     }
 
     #[test]
-    fn device_tree_v1_large_version_number_round_trip() {
+    fn device_tree_v1_large_version_number_round_trip() -> Result<(), prost::DecodeError> {
         // version_number is u64 — verify the full range survives.
         let original = DeviceTreeV1 {
             schema_version: 1,
@@ -314,29 +319,31 @@ mod v1_proto_roundtrip {
             device_count: u32::MAX,
             version_number: u64::MAX,
         };
-        let decoded = round_trip_bytes(&original);
+        let decoded = round_trip_bytes(&original)?;
         assert_eq!(decoded.version_number, u64::MAX);
         assert_eq!(decoded.device_count, u32::MAX);
+        Ok(())
     }
 
     #[test]
-    fn device_tree_root_update_v1_round_trip() {
+    fn device_tree_root_update_v1_round_trip() -> Result<(), prost::DecodeError> {
         let original = DeviceTreeRootUpdateV1 {
             old_root: vec![0xAAu8; 32],
             new_root: vec![0xBBu8; 32],
             version_number: 100,
             signature: vec![0xCCu8; 49_856], // SPHINCS+ SPX256f signature length
         };
-        let decoded = round_trip_bytes(&original);
+        let decoded = round_trip_bytes(&original)?;
         assert_eq!(decoded.old_root, original.old_root);
         assert_eq!(decoded.new_root, original.new_root);
         assert_eq!(decoded.version_number, 100);
         assert_eq!(decoded.signature.len(), 49_856);
         assert_eq!(decoded.signature, original.signature);
+        Ok(())
     }
 
     #[test]
-    fn device_inclusion_proof_v1_round_trip_with_siblings() {
+    fn device_inclusion_proof_v1_round_trip_with_siblings() -> Result<(), prost::DecodeError> {
         // Realistic 5-level Merkle path; siblings + path_bits + counts must
         // all survive round-trip.
         let siblings: Vec<Vec<u8>> = (0u8..5).map(|i| vec![i; 32]).collect();
@@ -347,7 +354,7 @@ mod v1_proto_roundtrip {
             path_bits_len: 5,
             path_bits: vec![0b10101], // 5 valid bits
         };
-        let decoded = round_trip_bytes(&original);
+        let decoded = round_trip_bytes(&original)?;
         assert_eq!(decoded.device_id, original.device_id);
         assert_eq!(decoded.root_hash, original.root_hash);
         assert_eq!(decoded.siblings.len(), 5);
@@ -357,10 +364,11 @@ mod v1_proto_roundtrip {
         );
         assert_eq!(decoded.path_bits_len, 5);
         assert_eq!(decoded.path_bits, vec![0b10101]);
+        Ok(())
     }
 
     #[test]
-    fn device_inclusion_proof_v1_empty_siblings_round_trip() {
+    fn device_inclusion_proof_v1_empty_siblings_round_trip() -> Result<(), prost::DecodeError> {
         // Single-leaf tree: no siblings, path_bits_len = 0.
         let original = DeviceInclusionProofV1 {
             device_id: vec![0x11u8; 32],
@@ -369,24 +377,26 @@ mod v1_proto_roundtrip {
             path_bits_len: 0,
             path_bits: Vec::new(),
         };
-        let decoded = round_trip_bytes(&original);
+        let decoded = round_trip_bytes(&original)?;
         assert_eq!(decoded.device_id, original.device_id);
         assert_eq!(decoded.root_hash, original.root_hash);
         assert!(decoded.siblings.is_empty());
         assert_eq!(decoded.path_bits_len, 0);
         assert!(decoded.path_bits.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn device_tree_v1_zero_defaults_round_trip() {
+    fn device_tree_v1_zero_defaults_round_trip() -> Result<(), prost::DecodeError> {
         // All-default message must encode + decode cleanly. Default()
         // gives an empty `root_hash` Vec, which is legal on the wire even
         // though the storage validator (Phase B.4) will reject it.
         let original = DeviceTreeV1::default();
-        let decoded = round_trip_bytes(&original);
+        let decoded = round_trip_bytes(&original)?;
         assert_eq!(decoded.schema_version, 0);
         assert!(decoded.root_hash.is_empty());
         assert_eq!(decoded.device_count, 0);
         assert_eq!(decoded.version_number, 0);
+        Ok(())
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
@@ -50,7 +50,6 @@
 //! used by the SDK handler implementations. This keeps the transport/UI
 //! bridge entirely out of the pure `dsm` core crate.
 
-
 use once_cell::sync::OnceCell;
 use std::sync::{Arc, RwLock};
 use once_cell::sync::Lazy;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/identity_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/identity_routes.rs
@@ -84,22 +84,14 @@ impl AppRouterImpl {
                     Err(e) => return err(format!("decode ArgPack failed: {e}")),
                 };
                 if pack.codec != generated::Codec::Proto as i32 {
-                    return err(
-                        "identity.devtree.snapshot: ArgPack.codec must be PROTO".into(),
-                    );
+                    return err("identity.devtree.snapshot: ArgPack.codec must be PROTO".into());
                 }
                 let req = match generated::DeviceTreeSnapshotRequest::decode(&*pack.body) {
                     Ok(r) => r,
-                    Err(e) => {
-                        return err(format!(
-                            "decode DeviceTreeSnapshotRequest failed: {e}"
-                        ))
-                    }
+                    Err(e) => return err(format!("decode DeviceTreeSnapshotRequest failed: {e}")),
                 };
                 if req.genesis_hash.len() != 32 {
-                    return err(
-                        "identity.devtree.snapshot: genesis_hash must be 32 bytes".into(),
-                    );
+                    return err("identity.devtree.snapshot: genesis_hash must be 32 bytes".into());
                 }
                 let mut genesis_hash = [0u8; 32];
                 genesis_hash.copy_from_slice(&req.genesis_hash);
@@ -110,11 +102,7 @@ impl AppRouterImpl {
                             .await
                         {
                             Ok(c) => c,
-                            Err(e) => {
-                                return Err(format!(
-                                    "No storage node config available: {e}"
-                                ))
-                            }
+                            Err(e) => return Err(format!("No storage node config available: {e}")),
                         };
                     let sdk = crate::sdk::storage_node_sdk::StorageNodeSDK::new(cfg)
                         .await
@@ -154,7 +142,9 @@ impl AppRouterImpl {
                         })
                         .collect(),
                 };
-                pack_envelope_ok(generated::envelope::Payload::DeviceTreeSnapshotResponse(resp))
+                pack_envelope_ok(generated::envelope::Payload::DeviceTreeSnapshotResponse(
+                    resp,
+                ))
             }
 
             _ => err(format!("unknown identity query: {}", q.path)),
@@ -202,9 +192,8 @@ mod tests {
 
         let decoded_pack = generated::ArgPack::decode(&*pack_bytes).expect("decode pack");
         assert_eq!(decoded_pack.codec, generated::Codec::Proto as i32);
-        let decoded_req =
-            generated::DeviceTreeSnapshotRequest::decode(&*decoded_pack.body)
-                .expect("decode request");
+        let decoded_req = generated::DeviceTreeSnapshotRequest::decode(&*decoded_pack.body)
+            .expect("decode request");
         assert_eq!(decoded_req.genesis_hash.len(), 32);
         assert_eq!(decoded_req.genesis_hash, vec![0x42u8; 32]);
     }
@@ -234,8 +223,7 @@ mod tests {
             ],
         };
         let bytes = resp.encode_to_vec();
-        let decoded =
-            generated::DeviceTreeSnapshotResponse::decode(&*bytes).expect("decode");
+        let decoded = generated::DeviceTreeSnapshotResponse::decode(&*bytes).expect("decode");
         assert!(decoded.claimed_root_matches_recomputed);
         assert_eq!(decoded.recomputed_root, vec![0xABu8; 32]);
         assert_eq!(decoded.leaves.len(), 2);
@@ -255,8 +243,7 @@ mod tests {
 
         let dev_a = [0x11u8; 32];
         let dev_b = [0x22u8; 32];
-        let canonical_root =
-            dsm::common::device_tree::DeviceTree::new(vec![dev_a, dev_b]).root();
+        let canonical_root = dsm::common::device_tree::DeviceTree::new(vec![dev_a, dev_b]).root();
 
         // Honest: claimed root matches recomputed.
         let honest = generated::DeviceTreeStateV1 {
@@ -268,8 +255,8 @@ mod tests {
             }),
             device_ids: vec![dev_a.to_vec(), dev_b.to_vec()],
         };
-        let view = build_device_tree_snapshot_view(&honest.encode_to_vec())
-            .expect("honest snapshot");
+        let view =
+            build_device_tree_snapshot_view(&honest.encode_to_vec()).expect("honest snapshot");
         assert!(view.claimed_root_matches_recomputed);
         assert_eq!(view.leaves.len(), 2);
         assert!(view.leaves.iter().all(|l| l.inclusion_verified));
@@ -284,8 +271,8 @@ mod tests {
             }),
             device_ids: vec![dev_a.to_vec(), dev_b.to_vec()],
         };
-        let view = build_device_tree_snapshot_view(&tampered.encode_to_vec())
-            .expect("tampered snapshot");
+        let view =
+            build_device_tree_snapshot_view(&tampered.encode_to_vec()).expect("tampered snapshot");
         assert!(!view.claimed_root_matches_recomputed);
         // Per-leaf verification still passes because proofs are
         // re-derived against the recomputed (not claimed) root —

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/unilateral_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/unilateral_impl.rs
@@ -5,7 +5,6 @@
 //! Implements the `UnilateralHandler` trait for one-sided state transitions
 //! (token transfers, balance queries) that do not require bilateral handshake.
 
-
 use async_trait::async_trait;
 use prost::Message;
 use std::sync::Arc;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/ble_events.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/ble_events.rs
@@ -7,7 +7,6 @@
 //! scan results, connection events, and data payloads for delivery to
 //! the Kotlin layer.
 
-
 use crate::generated as pb;
 use jni::objects::{JByteArray, JObject, JString};
 use jni::JNIEnv;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/identity.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/identity.rs
@@ -5,4 +5,3 @@
 //! Identity JNI functions have been consolidated into
 //! [`unified_protobuf_bridge`](super::unified_protobuf_bridge). This file
 //! is retained for module structure only.
-

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/secondary_device.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/secondary_device.rs
@@ -6,7 +6,6 @@
 //! Envelope v3 with headers populated (device_id + genesis_hash) for
 //! secondary device pairing.
 
-
 #![allow(clippy::too_many_arguments)]
 
 use crate::generated as pb;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/transport.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/transport.rs
@@ -5,4 +5,3 @@
 //! Transport JNI functions have been consolidated into
 //! [`unified_protobuf_bridge`](super::unified_protobuf_bridge). This file
 //! is retained for module structure only.
-

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
@@ -41,7 +41,6 @@
 //! and accepts/returns raw `jbyteArray` (prost-encoded protobuf). The
 //! `SDK_READY` atomic flag gates all post-bootstrap operations.
 
-
 use crate::generated as pb;
 use crate::jni::helpers;
 use jni::objects::{JByteArray, JString};

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/wallet.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/wallet.rs
@@ -5,4 +5,3 @@
 //! Wallet JNI functions have been consolidated into
 //! [`unified_protobuf_bridge`](super::unified_protobuf_bridge). This file
 //! is retained for module structure only.
-

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/app_state.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/app_state.rs
@@ -13,7 +13,6 @@
 //!
 //! The state file lives at `<storage_base_dir>/dsm_app_state.pb`.
 
-
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/bootstrap.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/bootstrap.rs
@@ -8,7 +8,6 @@
 //! loading device identity into the SDK; it either succeeds with a fully
 //! valid context or returns an error.
 
-
 use crate::sdk::app_state::AppState;
 use dsm::types::error::DsmError;
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/storage_node_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/storage_node_sdk.rs
@@ -1911,23 +1911,20 @@ impl StorageNodeSDK {
         // which is the same end-state we wanted.
         let publisher_node_urls = node_urls.clone();
         let publisher_client = self.inner.client.clone();
-        let initial_tree_snapshot: std::sync::Arc<
-            tokio::sync::OnceCell<DeviceTreeSnapshot>,
-        > = std::sync::Arc::new(tokio::sync::OnceCell::new());
+        let initial_tree_snapshot: std::sync::Arc<tokio::sync::OnceCell<DeviceTreeSnapshot>> =
+            std::sync::Arc::new(tokio::sync::OnceCell::new());
         let snapshot_for_publisher = initial_tree_snapshot.clone();
         let publisher = move |genesis_hash: [u8; 32]| {
             let publisher_node_urls = publisher_node_urls.clone();
             let publisher_client = publisher_client.clone();
             let snapshot_for_publisher = snapshot_for_publisher.clone();
             async move {
-                let (snapshot, payload) =
-                    Self::build_initial_device_tree_payload(genesis_hash)?;
+                let (snapshot, payload) = Self::build_initial_device_tree_payload(genesis_hash)?;
                 // Stash the snapshot so the outer scope can build the
                 // GenesisCreationResponse without recomputing it.
                 let _ = snapshot_for_publisher.set(snapshot);
 
-                let genesis_b32 =
-                    crate::util::text_id::encode_base32_crockford(&genesis_hash);
+                let genesis_b32 = crate::util::text_id::encode_base32_crockford(&genesis_hash);
                 let acks = Self::publish_initial_device_tree_to_quorum(
                     &publisher_client,
                     &publisher_node_urls,
@@ -2047,10 +2044,7 @@ impl StorageNodeSDK {
             if trimmed.is_empty() {
                 continue;
             }
-            let url = format!(
-                "{}/api/v2/identity/{}/devtree/root",
-                trimmed, genesis_b32
-            );
+            let url = format!("{}/api/v2/identity/{}/devtree/root", trimmed, genesis_b32);
             match self.inner.client.get(&url).send().await {
                 Ok(resp) if resp.status().is_success() => {
                     let bytes = resp.bytes().await.map_err(|e| {
@@ -2144,16 +2138,10 @@ impl StorageNodeSDK {
             if trimmed.is_empty() {
                 continue;
             }
-            let url = format!(
-                "{}/api/v2/identity/{}/devtree/root",
-                trimmed, genesis_b32
-            );
+            let url = format!("{}/api/v2/identity/{}/devtree/root", trimmed, genesis_b32);
             match client
                 .put(&url)
-                .header(
-                    reqwest::header::CONTENT_TYPE,
-                    "application/octet-stream",
-                )
+                .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
                 .body(payload.to_vec())
                 .send()
                 .await
@@ -2413,8 +2401,7 @@ impl StorageNodeSDK {
             )
         })?;
 
-        let (snapshot, new_bytes) =
-            apply_device_tree_mutation(&prior_bytes, genesis_hash, mutate)?;
+        let (snapshot, new_bytes) = apply_device_tree_mutation(&prior_bytes, genesis_hash, mutate)?;
 
         // Persist the new state.
         self.inner
@@ -2437,7 +2424,6 @@ impl StorageNodeSDK {
 
         Ok(snapshot)
     }
-
 
     /// Retrieve the complete device identity after Genesis creation
     pub async fn retrieve_device_identity(
@@ -3593,9 +3579,7 @@ fn apply_device_tree_mutation<F: FnOnce(&mut Vec<[u8; 32]>)>(
     let sorted_ids: Vec<[u8; 32]> = tree.leaves().to_vec();
     let root = tree.root();
     let new_version = prior_version.checked_add(1).ok_or_else(|| {
-        DsmError::invalid_operation(
-            "Device Tree version_number overflowed u64; refusing to wrap",
-        )
+        DsmError::invalid_operation("Device Tree version_number overflowed u64; refusing to wrap")
     })?;
 
     let snapshot = DeviceTreeSnapshot {
@@ -3710,8 +3694,7 @@ pub(crate) fn build_device_tree_snapshot_view(
     let claimed_root_matches_recomputed = claimed_tree.root_hash.len() == 32
         && claimed_tree.root_hash.as_slice() == recomputed_root.as_slice();
 
-    let mut leaves: Vec<DeviceTreeLeafViewRust> =
-        Vec::with_capacity(tree.leaves().len());
+    let mut leaves: Vec<DeviceTreeLeafViewRust> = Vec::with_capacity(tree.leaves().len());
     for leaf in tree.leaves() {
         let dev_proof = tree.proof(leaf).ok_or_else(|| {
             DsmError::internal(
@@ -3760,13 +3743,14 @@ struct PersistedDeviceTreeState {
 /// reproduces the byte-exact root even if the on-disk encoding was
 /// produced by an older SDK that didn't sort + dedup pre-persist.
 fn decode_device_tree_state(bytes: &[u8]) -> Result<PersistedDeviceTreeState, DsmError> {
-    let state = generated::DeviceTreeStateV1::decode(bytes)
-        .map_err(|e| DsmError::serialization_error(
+    let state = generated::DeviceTreeStateV1::decode(bytes).map_err(|e| {
+        DsmError::serialization_error(
             format!("decode DeviceTreeStateV1: {e}"),
             "DeviceTreeStateV1",
             None::<String>,
             Some(e),
-        ))?;
+        )
+    })?;
     let tree = state.tree.ok_or_else(|| {
         DsmError::serialization_error(
             "DeviceTreeStateV1.tree is missing",
@@ -3930,11 +3914,10 @@ mod tests {
     fn add_first_secondary_seeds_with_root_device_and_bumps_version_to_1() {
         let genesis = [0x11u8; 32];
         let new_devid = [0x22u8; 32];
-        let (snapshot, _bytes) =
-            super::apply_device_tree_mutation(&[], genesis, |ids| {
-                ids.push(new_devid);
-            })
-            .expect("first add must succeed");
+        let (snapshot, _bytes) = super::apply_device_tree_mutation(&[], genesis, |ids| {
+            ids.push(new_devid);
+        })
+        .expect("first add must succeed");
 
         // Expect a 2-leaf tree: {genesis (root), new_devid}.
         assert_eq!(snapshot.device_count, 2);
@@ -3971,18 +3954,17 @@ mod tests {
         let dev_a = [0x22u8; 32];
 
         let (_snap1, bytes1) =
-            super::apply_device_tree_mutation(&[], genesis, |ids| ids.push(dev_a))
-                .expect("add A");
+            super::apply_device_tree_mutation(&[], genesis, |ids| ids.push(dev_a)).expect("add A");
 
-        let (snap2, _bytes2) =
-            super::apply_device_tree_mutation(&bytes1, genesis, |ids| ids.retain(|id| id != &dev_a))
-                .expect("remove A");
+        let (snap2, _bytes2) = super::apply_device_tree_mutation(&bytes1, genesis, |ids| {
+            ids.retain(|id| id != &dev_a)
+        })
+        .expect("remove A");
 
         // After removing A we should be back to a single-leaf tree
         // containing only the root device (genesis_hash).
         assert_eq!(snap2.device_count, 1);
-        let expected_root =
-            dsm::common::device_tree::DeviceTree::single(genesis).root();
+        let expected_root = dsm::common::device_tree::DeviceTree::single(genesis).root();
         assert_eq!(snap2.root_hash, expected_root);
         // Two mutations applied, so version_number must be 2.
         assert_eq!(snap2.version_number, 2);
@@ -3995,16 +3977,15 @@ mod tests {
         let dev_b = [0x33u8; 32];
         let dev_c = [0x44u8; 32];
 
-        let (s1, b1) = super::apply_device_tree_mutation(&[], genesis, |ids| ids.push(dev_a))
-            .expect("add A");
-        let (s2, b2) = super::apply_device_tree_mutation(&b1, genesis, |ids| ids.push(dev_b))
-            .expect("add B");
-        let (s3, b3) = super::apply_device_tree_mutation(&b2, genesis, |ids| ids.push(dev_c))
-            .expect("add C");
-        let (s4, _b4) = super::apply_device_tree_mutation(&b3, genesis, |ids| {
-            ids.retain(|id| id != &dev_b)
-        })
-        .expect("remove B");
+        let (s1, b1) =
+            super::apply_device_tree_mutation(&[], genesis, |ids| ids.push(dev_a)).expect("add A");
+        let (s2, b2) =
+            super::apply_device_tree_mutation(&b1, genesis, |ids| ids.push(dev_b)).expect("add B");
+        let (s3, b3) =
+            super::apply_device_tree_mutation(&b2, genesis, |ids| ids.push(dev_c)).expect("add C");
+        let (s4, _b4) =
+            super::apply_device_tree_mutation(&b3, genesis, |ids| ids.retain(|id| id != &dev_b))
+                .expect("remove B");
 
         assert_eq!(s1.version_number, 1);
         assert_eq!(s2.version_number, 2);
@@ -4058,13 +4039,14 @@ mod tests {
     fn malformed_state_bytes_are_rejected_with_serialization_error() {
         let genesis = [0x11u8; 32];
         let garbage = b"this is not a valid DeviceTreeStateV1 proto".to_vec();
-        let err = super::apply_device_tree_mutation(&garbage, genesis, |ids| {
-            ids.push([0x99u8; 32])
-        })
-        .expect_err("garbage prior state must fail decode");
+        let err =
+            super::apply_device_tree_mutation(&garbage, genesis, |ids| ids.push([0x99u8; 32]))
+                .expect_err("garbage prior state must fail decode");
         let msg = format!("{err}");
         assert!(
-            msg.contains("DeviceTreeStateV1") || msg.contains("Serialization") || msg.contains("decode"),
+            msg.contains("DeviceTreeStateV1")
+                || msg.contains("Serialization")
+                || msg.contains("decode"),
             "unexpected error: {msg}"
         );
     }
@@ -4094,8 +4076,8 @@ mod tests {
             device_ids: vec![],
         };
         let bytes = bad_state.encode_to_vec();
-        let err = super::decode_device_tree_state(&bytes)
-            .expect_err("missing tree summary rejected");
+        let err =
+            super::decode_device_tree_state(&bytes).expect_err("missing tree summary rejected");
         let msg = format!("{err}");
         assert!(msg.contains("tree is missing"), "unexpected error: {msg}");
     }
@@ -4145,20 +4127,18 @@ mod tests {
     #[test]
     fn initial_device_tree_payload_has_single_root_leaf() {
         let genesis_hash = [0x77u8; 32];
-        let (snapshot, payload) =
-            StorageNodeSDK::build_initial_device_tree_payload(genesis_hash)
-                .expect("initial payload");
+        let (snapshot, payload) = StorageNodeSDK::build_initial_device_tree_payload(genesis_hash)
+            .expect("initial payload");
 
         assert_eq!(snapshot.device_count, 1);
         assert_eq!(snapshot.version_number, 1);
-        let expected_root =
-            dsm::common::device_tree::DeviceTree::single(genesis_hash).root();
+        let expected_root = dsm::common::device_tree::DeviceTree::single(genesis_hash).root();
         assert_eq!(snapshot.root_hash, expected_root);
 
         // Decode the payload back and confirm the contained state
         // matches the snapshot exactly.
-        let state = generated::DeviceTreeStateV1::decode(payload.as_slice())
-            .expect("decode payload");
+        let state =
+            generated::DeviceTreeStateV1::decode(payload.as_slice()).expect("decode payload");
         let tree = state.tree.expect("tree summary");
         assert_eq!(tree.root_hash, expected_root.to_vec());
         assert_eq!(tree.device_count, 1);
@@ -4176,14 +4156,16 @@ mod tests {
         // and matches list length).
         let genesis_hash = [0xABu8; 32];
         let (_snapshot, payload) =
-            StorageNodeSDK::build_initial_device_tree_payload(genesis_hash)
-                .expect("payload");
+            StorageNodeSDK::build_initial_device_tree_payload(genesis_hash).expect("payload");
 
-        let decoded = generated::DeviceTreeStateV1::decode(payload.as_slice())
-            .expect("decode round-trip");
+        let decoded =
+            generated::DeviceTreeStateV1::decode(payload.as_slice()).expect("decode round-trip");
         let tree = decoded.tree.expect("tree present");
         assert_eq!(tree.root_hash.len(), 32);
-        assert!(tree.root_hash.iter().any(|&b| b != 0), "root_hash must be non-zero");
+        assert!(
+            tree.root_hash.iter().any(|&b| b != 0),
+            "root_hash must be non-zero"
+        );
         assert!(tree.device_count >= 1);
         assert_eq!(tree.device_count as usize, decoded.device_ids.len());
         for id in &decoded.device_ids {
@@ -4206,10 +4188,8 @@ mod tests {
 
     #[test]
     fn initial_device_tree_payloads_differ_across_genesis() {
-        let (s1, p1) =
-            StorageNodeSDK::build_initial_device_tree_payload([0x01u8; 32]).unwrap();
-        let (s2, p2) =
-            StorageNodeSDK::build_initial_device_tree_payload([0x02u8; 32]).unwrap();
+        let (s1, p1) = StorageNodeSDK::build_initial_device_tree_payload([0x01u8; 32]).unwrap();
+        let (s2, p2) = StorageNodeSDK::build_initial_device_tree_payload([0x02u8; 32]).unwrap();
         assert_ne!(s1.root_hash, s2.root_hash);
         assert_ne!(p1, p2);
     }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/util/deterministic_time.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/util/deterministic_time.rs
@@ -44,14 +44,23 @@ pub fn reset() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
+    // These tests read/reset the process-global PROGRESS_CONTEXT. Without
+    // serialization they race other tests in this binary (e.g. SDK-init paths
+    // that call update_progress_context): one test's reset()/init() holds the
+    // write lock while another's tick() does a `try_read()`, which falls back
+    // to 0 on contention — making assertions like reset_is_idempotent flaky.
+    // `#[serial]` runs them in the global serial group, eliminating the race.
     #[test]
+    #[serial]
     fn tick_returns_value() {
         reset();
         let _t = tick();
     }
 
     #[test]
+    #[serial]
     fn tick_index_matches_tick() {
         reset();
         let a = tick();
@@ -63,6 +72,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn clean_tick_index_matches_tick() {
         reset();
         let a = tick();
@@ -71,12 +81,14 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn peek_returns_value() {
         reset();
         let _p = peek();
     }
 
     #[test]
+    #[serial]
     fn reset_is_idempotent() {
         reset();
         let a = tick();

--- a/dsm_storage_node/src/api/identity/devtree.rs
+++ b/dsm_storage_node/src/api/identity/devtree.rs
@@ -131,9 +131,9 @@ impl DevTreeValidationError {
             }
             DevTreeValidationError::RootHashAllZeros => "root_hash must not be all zeros".into(),
             DevTreeValidationError::DeviceCountZero => "device_count must be >= 1".into(),
-            DevTreeValidationError::DeviceCountMismatch { declared, actual } => format!(
-                "device_count {declared} does not match device_ids.len() {actual}"
-            ),
+            DevTreeValidationError::DeviceCountMismatch { declared, actual } => {
+                format!("device_count {declared} does not match device_ids.len() {actual}")
+            }
             DevTreeValidationError::DeviceIdLength { index, actual } => {
                 format!("device_ids[{index}] must be 32 bytes, got {actual}")
             }
@@ -217,8 +217,8 @@ async fn put_root(
         return Err(StatusCode::PAYLOAD_TOO_LARGE);
     }
 
-    let genesis_b = dsm_sdk::util::text_id::decode_base32_crockford(&genesis)
-        .ok_or(StatusCode::BAD_REQUEST)?;
+    let genesis_b =
+        dsm_sdk::util::text_id::decode_base32_crockford(&genesis).ok_or(StatusCode::BAD_REQUEST)?;
     if genesis_b.len() != 32 {
         return Err(StatusCode::BAD_REQUEST);
     }
@@ -241,9 +241,7 @@ async fn put_root(
     let genesis_key = dsm_sdk::util::text_id::encode_base32_crockford(&genesis_b);
 
     // CHECK 4 (monotonic version) is enforced atomically here.
-    let now_tick = state
-        .current_tick
-        .load(std::sync::atomic::Ordering::SeqCst);
+    let now_tick = state.current_tick.load(std::sync::atomic::Ordering::SeqCst);
     let outcome = crate::db::upsert_device_tree_state_if_monotonic(
         &state.db_pool,
         &genesis_key,
@@ -378,10 +376,7 @@ async fn get_proof(
 async fn put_proof_removed() -> impl IntoResponse {
     (
         StatusCode::METHOD_NOT_ALLOWED,
-        [(
-            axum::http::header::ALLOW,
-            HeaderValue::from_static("GET"),
-        )],
+        [(axum::http::header::ALLOW, HeaderValue::from_static("GET"))],
         "PUT /devtree/proof was removed in Phase B.5 (issue #276); \
          inclusion proofs are derived on GET from the persisted \
          DeviceTreeStateV1. See docs/plans/2026-04-24-genesis-mpc-and-device-tree.md.",
@@ -662,7 +657,8 @@ mod tests {
         let v = validate_devtree_state(&bytes).expect("well-formed state must validate");
         assert_eq!(v.version_number, 7);
         assert_eq!(v.device_count, 2);
-        let expected_root = dsm::common::device_tree::DeviceTree::new(vec![[0x11u8; 32], [0x22u8; 32]]).root();
+        let expected_root =
+            dsm::common::device_tree::DeviceTree::new(vec![[0x11u8; 32], [0x22u8; 32]]).root();
         assert_eq!(v.root_hash, expected_root);
     }
 
@@ -764,8 +760,7 @@ mod tests {
             device_ids: vec![vec![0x11u8; 32], vec![0x22u8; 31]], // second is 31 bytes
         };
         let bytes = state.encode_to_vec();
-        let err =
-            validate_devtree_state(&bytes).expect_err("wrong-length device_id must reject");
+        let err = validate_devtree_state(&bytes).expect_err("wrong-length device_id must reject");
         assert!(
             matches!(
                 err,
@@ -794,8 +789,14 @@ mod tests {
             DevTreeValidationError::RootHashLength { actual: 16 },
             DevTreeValidationError::RootHashAllZeros,
             DevTreeValidationError::DeviceCountZero,
-            DevTreeValidationError::DeviceCountMismatch { declared: 3, actual: 2 },
-            DevTreeValidationError::DeviceIdLength { index: 0, actual: 31 },
+            DevTreeValidationError::DeviceCountMismatch {
+                declared: 3,
+                actual: 2,
+            },
+            DevTreeValidationError::DeviceIdLength {
+                index: 0,
+                actual: 31,
+            },
         ] {
             assert_eq!(e.http_status(), StatusCode::BAD_REQUEST);
         }
@@ -890,8 +891,8 @@ mod tests {
 
         for d in &devs {
             let proof_bytes = derive_inclusion_proof(&payload, d).expect("proof");
-            let proof = generated::DeviceInclusionProofV1::decode(proof_bytes.as_slice())
-                .expect("decode");
+            let proof =
+                generated::DeviceInclusionProofV1::decode(proof_bytes.as_slice()).expect("decode");
             assert_eq!(
                 proof.siblings.len(),
                 2,
@@ -908,8 +909,8 @@ mod tests {
         let payload = state.encode_to_vec();
 
         let proof_bytes = derive_inclusion_proof(&payload, &dev_a).expect("proof");
-        let proof = generated::DeviceInclusionProofV1::decode(proof_bytes.as_slice())
-            .expect("decode");
+        let proof =
+            generated::DeviceInclusionProofV1::decode(proof_bytes.as_slice()).expect("decode");
         assert!(proof.siblings.is_empty());
         assert_eq!(proof.path_bits_len, 0);
         // single-leaf: root = hash_leaf(dev)
@@ -919,8 +920,8 @@ mod tests {
 
     #[test]
     fn proof_derivation_rejects_corrupt_state_bytes() {
-        let err = derive_inclusion_proof(b"garbage", &[0x11u8; 32])
-            .expect_err("corrupt state rejected");
+        let err =
+            derive_inclusion_proof(b"garbage", &[0x11u8; 32]).expect_err("corrupt state rejected");
         assert!(matches!(err, DevTreeProofError::CorruptState(_)));
         assert_eq!(err.http_status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
@@ -932,8 +933,8 @@ mod tests {
             device_ids: vec![vec![0x11u8; 32]],
         };
         let payload = state.encode_to_vec();
-        let err = derive_inclusion_proof(&payload, &[0x11u8; 32])
-            .expect_err("missing tree rejected");
+        let err =
+            derive_inclusion_proof(&payload, &[0x11u8; 32]).expect_err("missing tree rejected");
         assert_eq!(err, DevTreeProofError::CorruptStateMissingTree);
     }
 
@@ -972,8 +973,8 @@ mod tests {
         let payload = state.encode_to_vec();
 
         let proof_bytes = derive_inclusion_proof(&payload, &dev_b).expect("proof");
-        let proof = generated::DeviceInclusionProofV1::decode(proof_bytes.as_slice())
-            .expect("decode");
+        let proof =
+            generated::DeviceInclusionProofV1::decode(proof_bytes.as_slice()).expect("decode");
 
         let tree = dsm::common::device_tree::DeviceTree::new(vec![dev_a, dev_b, dev_c]);
         let dev_proof = tree.proof(&dev_b).expect("canonical proof");

--- a/dsm_storage_node/src/api/infra/network_config.rs
+++ b/dsm_storage_node/src/api/infra/network_config.rs
@@ -6,7 +6,6 @@
 //! Discovers the primary listening address and advertises it to peers
 //! during gossip and replication setup.
 
-
 use anyhow::Result;
 use dsm_sdk::util::text_id;
 use log::{debug, info};

--- a/dsm_storage_node/src/api/registry/core.rs
+++ b/dsm_storage_node/src/api/registry/core.rs
@@ -6,7 +6,6 @@
 //! bytes with `Content-Type: application/octet-stream` and returns the
 //! domain-separated BLAKE3 object address in the `x-object-address` header.
 
-
 use axum::{
     body::Bytes,
     extract::{Extension, Path},

--- a/dsm_storage_node/src/auth/mod.rs
+++ b/dsm_storage_node/src/auth/mod.rs
@@ -6,7 +6,6 @@
 //! Validates `Authorization: DSM <device_id>:<token>` headers and enforces
 //! replay protection via `x-dsm-message-id` headers.
 
-
 use axum::{
     body::{to_bytes, Body, Bytes},
     extract::State,

--- a/dsm_storage_node/src/db/pg.rs
+++ b/dsm_storage_node/src/db/pg.rs
@@ -587,9 +587,8 @@ pub async fn upsert_device_tree_state_if_monotonic(
     let new_version_i64 = i64::try_from(new_version)
         .map_err(|_| anyhow::anyhow!("version_number {new_version} does not fit in i64"))?;
     let device_count_i64 = i64::from(device_count);
-    let updated_at_tick_i64 = i64::try_from(updated_at_tick).map_err(|_| {
-        anyhow::anyhow!("updated_at_tick {updated_at_tick} does not fit in i64")
-    })?;
+    let updated_at_tick_i64 = i64::try_from(updated_at_tick)
+        .map_err(|_| anyhow::anyhow!("updated_at_tick {updated_at_tick} does not fit in i64"))?;
 
     let mut client = pool.get().await?;
     let tx = client
@@ -689,10 +688,7 @@ pub async fn get_device_tree_state_payload(
 /// Return only the current `version_number` for a genesis's persisted
 /// Device Tree state, or `None`. Used by tests asserting monotonic
 /// enforcement without re-decoding the full proto.
-pub async fn get_device_tree_state_version(
-    pool: &Pool,
-    genesis_b32: &str,
-) -> Result<Option<u64>> {
+pub async fn get_device_tree_state_version(pool: &Pool, genesis_b32: &str) -> Result<Option<u64>> {
     let client = pool.get().await?;
     let row = client
         .query_opt(

--- a/dsm_storage_node/src/db/sqlite.rs
+++ b/dsm_storage_node/src/db/sqlite.rs
@@ -1614,7 +1614,8 @@ mod tests {
         // Each test gets its own private in-memory DB so they don't
         // collide on shared file state.
         let conn = Connection::open_in_memory().expect("open :memory:");
-        conn.execute_batch("PRAGMA foreign_keys=ON;").expect("pragma");
+        conn.execute_batch("PRAGMA foreign_keys=ON;")
+            .expect("pragma");
         let pool = Arc::new(Mutex::new(conn));
         init_db(&pool).await.expect("init schema");
         pool

--- a/tools/vertical_validation/src/implementation_traces.rs
+++ b/tools/vertical_validation/src/implementation_traces.rs
@@ -2087,12 +2087,30 @@ fn build_djte_transition(
 }
 
 fn build_test_jap(id_byte: u8, nonce_byte: u8) -> JoinActivationProof {
-    let jap = JoinActivationProof {
-        id: [id_byte; 32],
-        gate_proof: vec![id_byte, id_byte.wrapping_add(1), id_byte.wrapping_add(2)],
-        nonce: [nonce_byte; 32],
+    use dsm::emissions::paidk_proof::{PAIDK_FLAT_RATE, PAIDK_K};
+
+    let device_id = [id_byte; 32];
+
+    // issue #186: `gate_proof` is now decoded as a `PaidKGateProofV1` and
+    // structurally verified, so the trace must carry a REAL proof — at least
+    // K receipts bound to the activating device, each at >= FLAT_RATE, across
+    // K distinct operators. A dummy byte string fails decode (buffer underflow).
+    let proof = pb::PaidKGateProofV1 {
+        receipts: (0u8..PAIDK_K as u8)
+            .map(|op| pb::StoragePaymentReceiptV3 {
+                device_id: device_id.to_vec(),
+                operator_node_id: vec![op.wrapping_add(1); 32],
+                amount: PAIDK_FLAT_RATE,
+                receipt_digest: vec![0u8; 32],
+            })
+            .collect(),
     };
-    jap
+
+    JoinActivationProof {
+        id: device_id,
+        gate_proof: proof.encode_to_vec(),
+        nonce: [nonce_byte; 32],
+    }
 }
 
 fn apply_djte_transition(


### PR DESCRIPTION
dtolnay/rust-toolchain@stable resolves to the latest release each run, so a new rustfmt fails 'cargo fmt --all --check' on code that did not change (PR #392 flagged 60+ already-merged files that are clean under released 1.96.0). Pins all four toolchain steps to 1.96.0 for deterministic lint/build/coverage. Bump deliberately and reformat in the same PR.