### PR TITLE
fix(genesis): make G the acyclic §2.5 form; rename genesis_mpc → genesis_session

### DIFF
--- a/.github/instructions/whitepaper.instructions.md
+++ b/.github/instructions/whitepaper.instructions.md
@@ -186,32 +186,35 @@ Device identifier (normative). specific, but deterministic). Then
 Let AttA be the stable device attestation digest (platform-
 DevIDA := BLAKE3-256 "DSM/devid\0" ∥pkA ∥AttA.
 2.5 Genesis State Creation
-Genesis is a structured n-of-n multi-party computation (MPC), not a single flat hash.
-Let {m_1,...,m_t} be the per-participant MPC contributions, π_DBRW the DBRW anti-cloning
-proof (Sec. 12), and the public-key bundle (pk_sign, pk_encap). The genesis commitment is
-computed over a single domain hasher seeded with the parent tag "DSM/genesis\0", into which
-three sub-domain separators are folded so that contributions, binding proof, and key bundle
-occupy disjoint regions of the preimage:
+Genesis is an n-of-n commit-then-reveal entropy aggregation, NOT threshold cryptography.
+The n ≥ 3 storage-node participants each contribute one entropy value b_i, and the device
+contributes its own b_0 = device_id ∥ device_entropy; the contributions are committed, then
+revealed, then folded into a single deterministic hash. "n-of-n" means all n contributions
+are required — there is no t-of-n DKG or Shamir, and "b_1,...,b_n" is index notation for
+"all n contributions".
 
-  "DSM/genesis/keys\0"  — public-key bundle region (signing + encapsulation keys),
-  "DSM/genesis/mpc\0"   — per-participant MPC contribution region,
-  "DSM/genesis/dbrw\0"  — DBRW binding / device-fingerprint region.
-
-Concretely (normative; see genesis_types.rs::recompute_genesis_hash and
-core/identity/genesis_mpc.rs), with H_g := dsm_domain_hasher("DSM/genesis"):
+The genesis hash is computed over a single domain hasher seeded with the parent tag
+"DSM/genesis\0", folding each contribution under the sub-domain separator "DSM/genesis/mpc\0"
+so contribution digests occupy a collision-isolated region of the preimage. Concretely
+(normative; see types/genesis_types.rs::compute_genesis_hash and
+core/identity/genesis_session.rs::compute_genesis_id), with H_g := dsm_domain_hasher("DSM/genesis")
+and H(·) := domain_hash("DSM/genesis/contribution", ·):
 
   G := H_g( device_id
-          ∥ ( "DSM/genesis/mpc\0"  ∥ H(m_i) for each contribution m_i in sorted order )
-          ∥   "DSM/genesis/dbrw\0" ∥ device_fingerprint ∥ verification_hash
-          ∥   "DSM/genesis/keys\0" ∥ pk_sign ∥ pk_encap ∥ key_hash ).
+          ∥ ( "DSM/genesis/mpc\0" ∥ H(b_i)  for each contribution b_i, sorted by H(b_i) ) ).
 
-MPC contributions are hashed in a deterministic sorted order. Wall-clock and mutable
-metadata (e.g. created_at) are explicitly EXCLUDED from the preimage so that genesis is
-clockless and reproducible. K_DBRW is derived post-MPC inside the same genesis session
-(so the genesis_hash exists before K_DBRW); see Sec. 12. The classical flat form
-G = BLAKE3-256("DSM/genesis\0" ∥ b_1 ∥ ··· ∥ b_t ∥ A) (3) is the conceptual single-party
-degenerate case; the structured MPC construction above is the implemented normative form,
-and §12's "n-of-n MPC genesis from §2.5" refers to it.
+Contributions are folded in deterministic sorted order so transport-time ordering cannot
+change G. The public-key bundle (pk_sign, pk_encap) and the DBRW anti-cloning binding
+K_DBRW (Sec. 12) are deliberately EXCLUDED from G: they are *derived from* G
+(keys ← S_master ← K_DBRW ← G, §11.1), so folding them back into G's preimage would be
+circular. They bind to genesis by derivation, not by inclusion — a clone with identical
+public inputs derives a different K_DBRW and hence different keys (Sec. 12), so inclusion
+buys nothing. Wall-clock and mutable metadata (e.g. created_at) are likewise EXCLUDED,
+keeping G clockless and publicly recomputable from device_id plus the revealed contributions
+alone. K_DBRW is derived post-genesis inside the same session (so G exists before K_DBRW);
+see Sec. 12. The classical flat form G = BLAKE3-256("DSM/genesis\0" ∥ b_1 ∥ ··· ∥ b_n ∥ A)
+(3) is the conceptual presentation; the domain-separated, sorted construction above is the
+implemented normative form, and §12's "n-of-n genesis from §2.5" refers to it.
 3 Two Merkle Structures: Storage and Replication
 Device Tree (standard Merkle). The Device Tree (leaves = device IDs) is fully replicated
 across storage nodes and across all devices under G. Adding a device is an online event: a
@@ -1573,7 +1576,7 @@ Per-step key derivation is specified in Sec. 11.1 and Sec. 12. In summary:
 • Device-bound secret KDBRW derives from hardware and environment (DBRW) and is never
 serialized, logged, or committed.
 • Master seed Smaster derives via RFC-5869 HKDF over BLAKE3 from (G,DevID,KDBRW,s0).
-This is the one genuinely-HKDF derivation in DSM (crypto/hkdf.rs, genesis_mpc.rs).
+This is the one genuinely-HKDF derivation in DSM (crypto/hkdf.rs, genesis_session.rs).
 • For each parent hn and pre-commit Cpre, a per-step seed En+1 derives via plain
 domain-separated keyed BLAKE3 (NOT HKDF) from (hn,Cpre,kstep,KDBRW), where kstep is
 derived from ML-KEM-768 shared-secret material.

--- a/dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis.rs
@@ -3,7 +3,8 @@
 // File: dsm/src/core/identity/genesis.rs
 //! DSM Genesis (STRICT, bytes-first)
 //!
-//! - Enforces MPC security invariants in-core (threshold ≥3; participants ≥3).
+//! - n-of-n commit-then-reveal entropy aggregation (participants ≥3); NOT
+//!   threshold cryptography — every participant's contribution is required.
 //! - DBRW is a local, optional anti-cloning signal; it must not be required for
 //!   genesis / identity creation and is not part of genesis binding.
 //! - No system wall-clock dependence.
@@ -179,22 +180,6 @@ impl KyberKey {
 
 // -------------------- Core hashing --------------------
 
-/// Recompute the genesis hash from a flat contribution list.
-///
-/// Retained for verifying replayed/imported genesis records: callers
-/// reconstruct the contribution list and compare against a stored hash.
-/// New flows should consume `session.genesis_id` directly (computed per
-/// whitepaper §2.5 in `genesis_mpc::compute_genesis_id`).
-#[allow(dead_code)]
-fn calculate_genesis_hash(contributions: &[Vec<u8>], anchor: &[u8]) -> Result<[u8; 32], DsmError> {
-    let mut hasher = dsm_domain_hasher("DSM/genesis-replay");
-    hasher.update(anchor);
-    for contrib in contributions {
-        hasher.update(contrib);
-    }
-    Ok(*hasher.finalize().as_bytes())
-}
-
 /// Per-genesis initial entropy seed (distinct sub-domain so the value
 /// is independent of the genesis hash even when inputs partially overlap).
 fn calculate_initial_entropy(
@@ -325,41 +310,53 @@ pub fn process_invalidation(identity: &Identity, request: &[u8]) -> Result<bool,
 
 // -------------------- Verification --------------------
 
-/// Structural sanity check on a `GenesisState`.
+/// Strict §2.5 verification of a `GenesisState`.
 ///
-/// Byte-exact spec-conformant recomputation of `G` requires the full
-/// public input tuple `(device_id, sorted participants, device_entropy,
-/// mpc_entropies, metadata)` — that lives on `GenesisSession`, not on
-/// the post-conversion `GenesisState`.  This check therefore validates
-/// only the structural invariants:
-///   - ≥3 MPC contributions (whitepaper §2.5 floor; n-of-n).
-///   - Genesis hash and initial-entropy fields are non-zero.
-///   - Initial entropy matches the deterministic re-derivation from
-///     `(genesis_hash, contributions)` under the
-///     `"DSM/genesis-initial-entropy"` sub-domain.
-///
-/// For full §2.5 byte-recompute, see
-/// `genesis_mpc::tests::genesis_id_is_recomputable_from_public_inputs`,
-/// which operates on a `GenesisSession` where the inputs are still
-/// available.
+/// Because the canonical genesis hash `G` is acyclic and publicly
+/// recomputable (it folds only `device_id` and `H(contribution_i)`), the
+/// post-conversion `GenesisState` carries everything needed to recompute it.
+/// This check therefore strict-fails unless:
+///   - there are ≥3 contributions (whitepaper §2.5 floor; n-of-n),
+///   - `hash`, `initial_entropy`, and `device_id` are present/non-zero,
+///   - the canonical `G` recomputed from `(device_id, contributions)` equals
+///     the stored `hash` (the substantive §2.5 check), and
+///   - the initial-entropy seed re-derives from `(hash, contributions)` under
+///     the `"DSM/genesis-initial-entropy"` sub-domain (defense in depth).
 pub fn verify_genesis_state(genesis: &GenesisState) -> Result<bool, DsmError> {
+    use crate::types::genesis_types::{compute_genesis_hash, hash_contribution, MPCContribution};
+
     if genesis.contributions.len() < 3 {
         return Ok(false);
     }
-    if genesis.hash == [0u8; 32] {
+    if genesis.hash == [0u8; 32] || genesis.initial_entropy == [0u8; 32] {
         return Ok(false);
     }
-    if genesis.initial_entropy == [0u8; 32] {
+    let device_id = match genesis.device_id {
+        Some(d) => d,
+        None => return Ok(false),
+    };
+
+    // Substantive §2.5 check: recompute the canonical genesis hash `G` from the
+    // public inputs and strict-fail on mismatch. `contributor_id` is irrelevant
+    // to `G` (sort tie-breaker only), so the empty id used here reproduces the
+    // session's hash exactly.
+    let contributions: Vec<MPCContribution> = genesis
+        .contributions
+        .iter()
+        .map(|c| MPCContribution::new(String::new(), hash_contribution(&c.data), Vec::new(), 0))
+        .collect();
+    if compute_genesis_hash(&device_id, &contributions) != genesis.hash {
         return Ok(false);
     }
 
+    // Defense in depth: the initial-entropy seed must re-derive from the same
+    // `(hash, contributions)` tuple.
     let contribs: Vec<Vec<u8>> = genesis
         .contributions
         .iter()
         .map(|c| c.data.clone())
         .collect();
-    let calc_entropy = calculate_initial_entropy(&genesis.hash, &contribs)?;
-    if calc_entropy != genesis.initial_entropy {
+    if calculate_initial_entropy(&genesis.hash, &contribs)? != genesis.initial_entropy {
         return Ok(false);
     }
 
@@ -375,7 +372,7 @@ pub async fn create_genesis_via_blind_mpc(
     env_fingerprint: Vec<u8>,
     metadata: Option<Vec<u8>>,
 ) -> Result<GenesisState, DsmError> {
-    let session = crate::core::identity::genesis_mpc::create_mpc_genesis(
+    let session = crate::core::identity::genesis_session::create_genesis(
         device_id,
         storage_nodes,
         hw_entropy,
@@ -404,7 +401,7 @@ pub fn create_genesis_via_blind_mpc_with_contributors(
 ) -> Result<GenesisState, DsmError> {
     let metadata = metadata.unwrap_or_else(|| b"DSMv2|bytes|no-wallclock".to_vec());
 
-    let mut session = crate::core::identity::genesis_mpc::GenesisSession::new(metadata)?;
+    let mut session = crate::core::identity::genesis_session::GenesisSession::new(metadata)?;
     session.initialize_mpc(device_id, storage_nodes)?;
     session.set_entropies(device_entropy, mpc_entropies)?;
     session.set_silicon_inputs(hw_entropy, env_fingerprint)?;
@@ -469,38 +466,25 @@ impl std::fmt::Display for GenesisState {
 // -------------------- Session compatibility --------------------
 
 pub fn convert_session_to_genesis_state_compat(
-    session: &crate::core::identity::genesis_mpc::GenesisSession,
+    session: &crate::core::identity::genesis_session::GenesisSession,
 ) -> Result<GenesisState, DsmError> {
-    // Build deterministic contribution set from the session (bytes-only)
-    let mut contribs: Vec<Vec<u8>> = Vec::new();
-
-    // Device contribution = device_id || device_entropy
-    let mut dev = Vec::with_capacity(64);
-    dev.extend_from_slice(&session.device_id);
-    dev.extend_from_slice(&session.device_entropy);
-    contribs.push(dev);
-
-    // NOTE: DBRW is record-only; do not bind genesis to it.
-
-    // MPC entropies
-    for m in &session.mpc_entropies {
-        contribs.push(m.to_vec());
-    }
-
-    // Include metadata to stabilize derivation
-    contribs.push(session.metadata.clone());
+    // Canonical contribution materials `[device_id ∥ device_entropy, b_1, …, b_n]`
+    // — exactly the bytes the session hashed into `G`. Metadata and DBRW are
+    // NOT contributions and are excluded (they don't bind `G`).
+    let contribs: Vec<Vec<u8>> = session.canonical_contribution_materials();
 
     // Use the session's genesis_id directly (computed per whitepaper §2.5 in
-    // genesis_mpc::compute_genesis_id) so the value the caller sees matches
+    // genesis_session::compute_genesis_id) so the value the caller sees matches
     // the value the session validated.  This closes Issue #252's sub-bug 3
-    // (caller-returned hash differing from session-level hash).
+    // (caller-returned hash differing from session-level hash) and is exactly
+    // what `verify_genesis_state` recomputes from these stored contributions.
     let hash = session.genesis_id;
     let initial_entropy = calculate_initial_entropy(&hash, &contribs)?;
 
     // Silicon-bound master keypair per whitepaper §11.1 eq.13.  K_DBRW
     // is folded into S_master and both keypairs are deterministic given
-    // (device_id, participants, metadata, contributions, K_DBRW).  The
-    // genesis_mpc derivation zeroises its IKM/seed buffers internally.
+    // (device_id, contributions, K_DBRW).  The genesis_session derivation
+    // zeroises its IKM/seed buffers internally.
     let mk = session.derive_silicon_bound_keypair()?;
     let signing_key = SigningKey {
         public_key: mk.sphincs_public.clone(),
@@ -661,7 +645,9 @@ mod tests {
         )
         .expect("provided contributors should build a valid genesis state");
 
-        assert_eq!(genesis.contributions.len(), 1 + node_entropies.len() + 1);
+        // Canonical materials: device contribution + one per node. Metadata is
+        // NOT a contribution and is excluded from `G`.
+        assert_eq!(genesis.contributions.len(), 1 + node_entropies.len());
 
         let mut expected_device_contribution = Vec::with_capacity(64);
         expected_device_contribution.extend_from_slice(&device_id);
@@ -670,7 +656,9 @@ mod tests {
         assert_eq!(genesis.contributions[1].data, node_entropies[0].to_vec());
         assert_eq!(genesis.contributions[2].data, node_entropies[1].to_vec());
         assert_eq!(genesis.contributions[3].data, node_entropies[2].to_vec());
-        assert_eq!(genesis.contributions[4].data, metadata);
+
+        // The produced hash must strictly re-verify (canonical §2.5 recompute).
+        assert!(verify_genesis_state(&genesis).expect("verify is callable"));
     }
 
     #[tokio::test]

--- a/dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis_session.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis_session.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// File: dsm/src/core/identity/genesis_mpc.rs
-//! DSM Genesis MPC Protocol Implementation (STRICT, bytes-only)
+// File: dsm/src/core/identity/genesis_session.rs
+//! DSM Genesis session (STRICT, bytes-only) — commit-then-reveal entropy aggregation.
 //!
 //! Invariants:
 //! - No wall-clock APIs. Use deterministic ticks (u64) from utils::deterministic_time.
@@ -11,9 +11,10 @@
 //!   notation for "all n contributions"; there is no t-of-n DKG or Shamir.
 //! - Storage/publishing is trait-only (SDK implements I/O).
 //!
-//! This module implements the MPC genesis creation protocol with commitment–reveal,
-//! optional DBRW binding (record-only; not part of genesis binding), SPHINCS+ signing
-//! keygen and Kyber KEM keygen hooks.
+//! This module drives the genesis session: per-participant commitment–reveal,
+//! the canonical genesis hash `G` (computed by `crate::types::genesis_types`),
+//! the post-genesis K_DBRW binding (record-only; not part of `G`), and the
+//! silicon-bound SPHINCS+/Kyber keypair derivation (whitepaper §11.1).
 
 use crate::crypto::blake3::dsm_domain_hasher;
 
@@ -23,6 +24,7 @@ use std::io::Read;
 use crate::crypto::kyber;
 use crate::crypto::sphincs;
 use crate::types::error::DsmError;
+use crate::types::genesis_types::{compute_genesis_hash, hash_contribution, MPCContribution};
 use crate::types::identifiers::NodeId;
 use crate::utils::deterministic_time;
 
@@ -57,12 +59,12 @@ pub trait GenesisStorage {
     async fn get(&self, genesis_hash: &[u8; 32]) -> Result<Vec<u8>, DsmError>;
 }
 
-/// Optional network transport for real MPC collection.
+/// Optional network transport for real contribution collection.
 ///
-/// This is NOT required by the core convenience entrypoint (`create_mpc_genesis`),
+/// This is NOT required by the core convenience entrypoint (`create_genesis`),
 /// but is provided for SDK integration.
 #[async_trait]
-pub trait GenesisMpcTransport {
+pub trait GenesisTransport {
     async fn collect_node_entropy(
         &self,
         node: &NodeId,
@@ -152,8 +154,9 @@ pub struct GenesisSession {
     pub commitments: Vec<[u8; 32]>,
     /// Reveals: exact contribution materials used for each commitment
     pub reveals: Vec<Vec<u8>>,
-    /// Genesis hash per whitepaper §2.5:
-    /// G = BLAKE3("DSM/genesis\0" || device_entropy || mpc_i... || A)
+    /// Canonical genesis hash `G` per whitepaper §2.5 (acyclic form):
+    /// `G = H_g("DSM/genesis" ∥ device_id ∥ sorted H(contribution_i))`,
+    /// computed by `crate::types::genesis_types::compute_genesis_hash`.
     pub genesis_id: [u8; 32],
     /// Participants
     pub storage_nodes: Vec<NodeId>,
@@ -170,7 +173,7 @@ impl GenesisSession {
     /// Create a new session with random session_id; other fields zero/empty.
     /// `dbrw_binding` MUST be set via `set_dbrw_binding` before
     /// `compute_genesis_id` finalises (or, for end-to-end production,
-    /// is supplied to `create_mpc_genesis*` and routed through here).
+    /// is supplied to `create_genesis*` and routed through here).
     pub fn new(metadata: Vec<u8>) -> Result<Self, DsmError> {
         let mut sid = [0u8; 32];
         crate::crypto::rng::random_bytes(32)
@@ -332,38 +335,70 @@ impl GenesisSession {
         true
     }
 
-    /// Compute genesis id per whitepaper §2.5:
+    /// Canonical ordered contribution materials — the raw byte-strings that
+    /// get hashed into `G`:
     ///
     /// ```text
-    /// G = BLAKE3("DSM/genesis\0" ‖ b_1 ‖ ... ‖ b_n ‖ A)
+    /// [ device_id ∥ device_entropy,  b_1,  …,  b_n ]
     /// ```
     ///
-    /// where `b_1 = device_entropy`, `b_2..b_n = mpc_entropies` (n-of-n),
-    /// and `A` is the contextual binding parameters: device_id ‖ sorted
-    /// participants ‖ metadata.  The participant ordering is the
-    /// canonical lex-sort of NodeId bytes so the hash is independent of
-    /// transport-time order.
-    ///
-    /// `K_DBRW` is intentionally NOT part of `A` — silicon binding
-    /// happens one layer down at master-seed derivation (whitepaper
-    /// §11.1 eq.13), not at the genesis hash.
-    pub fn compute_genesis_id(&mut self) {
-        let mut h = dsm_domain_hasher("DSM/genesis");
-        // b_1 = device_entropy
-        h.update(&self.device_entropy);
-        // b_2..b_n = mpc_entropies (n-of-n contributions)
+    /// i.e. the device's own contribution followed by each storage node's
+    /// revealed entropy (n-of-n).  Metadata is NOT a contribution and is
+    /// excluded from `G` (whitepaper §2.5: `G` is publicly recomputable from
+    /// `device_id` + the revealed contributions, nothing else).
+    pub fn canonical_contribution_materials(&self) -> Vec<Vec<u8>> {
+        let mut materials = Vec::with_capacity(1 + self.mpc_entropies.len());
+
+        let mut device = Vec::with_capacity(self.device_id.len() + self.device_entropy.len());
+        device.extend_from_slice(&self.device_id);
+        device.extend_from_slice(&self.device_entropy);
+        materials.push(device);
+
         for m in &self.mpc_entropies {
-            h.update(m);
+            materials.push(m.to_vec());
         }
-        // A = contextual binding parameters
-        h.update(&canonical_a(
-            &self.device_id,
-            &self.storage_nodes,
-            &self.metadata,
-        ));
-        let mut out = [0u8; 32];
-        out.copy_from_slice(h.finalize().as_bytes());
-        self.genesis_id = out;
+        materials
+    }
+
+    /// Canonical contribution records for `G`: `H(m_i)` per material, paired
+    /// with a deterministic `contributor_id` (empty for the device
+    /// contribution; the storage node id for each node contribution).
+    /// `contributor_id` is a sort tie-breaker only and is never folded into
+    /// `G`, so the verifier — which lacks node ids post-conversion — recomputes
+    /// the identical hash from the materials alone.
+    fn canonical_contributions(&self) -> Vec<MPCContribution> {
+        self.canonical_contribution_materials()
+            .iter()
+            .enumerate()
+            .map(|(i, material)| {
+                let contributor_id = match i.checked_sub(1) {
+                    None => String::new(), // device contribution
+                    Some(node_idx) => self
+                        .storage_nodes
+                        .get(node_idx)
+                        .map(|n| String::from_utf8_lossy(n.as_bytes()).into_owned())
+                        .unwrap_or_default(),
+                };
+                MPCContribution::new(contributor_id, hash_contribution(material), Vec::new(), 0)
+            })
+            .collect()
+    }
+
+    /// Compute the canonical genesis hash `G` per whitepaper §2.5 (acyclic
+    /// form) and store it on the session:
+    ///
+    /// ```text
+    /// G := H_g("DSM/genesis" ∥ device_id ∥ ⟦ "DSM/genesis/mpc\0" ∥ H(m_i) ⟧ sorted )
+    /// ```
+    ///
+    /// Contributions are `[device_id ∥ device_entropy, b_1, …, b_n]`, sorted by
+    /// contribution hash so transport-time order cannot change `G`.  The
+    /// public-key bundle and `K_DBRW` are NOT folded in: they bind to genesis
+    /// by being *derived from* `G` (`keys ← S_master ← K_DBRW ← G`); folding
+    /// them back would be circular.  Silicon binding happens one layer down at
+    /// master-seed derivation (whitepaper §11.1 eq.13), not at the genesis hash.
+    pub fn compute_genesis_id(&mut self) {
+        self.genesis_id = compute_genesis_hash(&self.device_id, &self.canonical_contributions());
     }
 
     /// Validate full session.  Requires DBRW binding (K_DBRW) to be set
@@ -489,55 +524,6 @@ impl Drop for GenesisSession {
 
 // -------------------- Helpers --------------------
 
-#[inline]
-#[allow(dead_code)]
-fn to_arr32(v: &[u8]) -> Result<[u8; 32], DsmError> {
-    if v.len() != 32 {
-        return Err(DsmError::invalid_parameter("expected 32 bytes"));
-    }
-    let mut a = [0u8; 32];
-    a.copy_from_slice(v);
-    Ok(a)
-}
-
-/// Canonical encoding of the contextual binding parameters `A` from
-/// whitepaper §2.5.  Bytes-only, length-prefixed, deterministic given
-/// the same inputs regardless of transport-time NodeId ordering.
-///
-/// Layout:
-/// ```text
-/// device_id           : 32 bytes
-/// participant_count   : u32 little-endian
-/// for each participant (lex-sorted by raw NodeId bytes):
-///   length            : u32 little-endian
-///   bytes
-/// metadata_length     : u32 little-endian
-/// metadata            : bytes
-/// ```
-fn canonical_a(device_id: &[u8; 32], storage_nodes: &[NodeId], metadata: &[u8]) -> Vec<u8> {
-    let mut sorted: Vec<&[u8]> = storage_nodes.iter().map(|n| n.as_bytes()).collect();
-    sorted.sort();
-
-    let participant_bytes_total: usize = sorted.iter().map(|p| p.len() + 4).sum();
-    let mut a = Vec::with_capacity(32 + 4 + participant_bytes_total + 4 + metadata.len());
-
-    // device_id
-    a.extend_from_slice(device_id);
-
-    // sorted participants (canonical lex order on raw bytes)
-    a.extend_from_slice(&(sorted.len() as u32).to_le_bytes());
-    for p in &sorted {
-        a.extend_from_slice(&(p.len() as u32).to_le_bytes());
-        a.extend_from_slice(p);
-    }
-
-    // metadata
-    a.extend_from_slice(&(metadata.len() as u32).to_le_bytes());
-    a.extend_from_slice(metadata);
-
-    a
-}
-
 /// Per-genesis step-salt: `s_0 = BLAKE3("DSM/step-salt\0" || G)` per
 /// storage-nodes spec §5.  Mixed into the master-seed IKM (whitepaper
 /// §11.1 eq.13) at keypair derivation time.
@@ -604,14 +590,14 @@ pub fn generate_device_entropy(device_id: &[u8; 32]) -> [u8; 32] {
     out
 }
 
-// -------------------- High-level MPC creation (no I/O) --------------------
+// -------------------- High-level genesis creation (no I/O) --------------------
 
-/// Production DSM MPC Creation (bytes-only).
+/// Production DSM genesis creation (bytes-only).
 ///
-/// This entrypoint is the core, no-I/O version: it models the MPC entropies
+/// This entrypoint is the core, no-I/O version: it models the node entropies
 /// without performing network collection. SDK integrations should use
-/// `create_mpc_genesis_with_transport`.
-pub async fn create_mpc_genesis(
+/// `create_genesis_with_transport`.
+pub async fn create_genesis(
     device_id: [u8; 32],
     storage_nodes: Vec<NodeId>,
     hw_entropy: Vec<u8>,
@@ -664,7 +650,7 @@ pub async fn create_mpc_genesis(
     Ok(session)
 }
 
-/// SDK-integrated MPC Creation using a transport for node entropy collection.
+/// SDK-integrated genesis creation using a transport for node entropy collection.
 ///
 /// Silicon-binding inputs `(hw_entropy, env_fingerprint)` are mandatory
 /// — they feed the canonical K_DBRW derivation (whitepaper Definition 3,
@@ -672,7 +658,7 @@ pub async fn create_mpc_genesis(
 ///         LP(hw) || LP(env))`) once `genesis_id` is computed, which is
 /// then mixed into `S_master` IKM (whitepaper §11.1 eq.13) for the
 /// SPHINCS+/Kyber keypair derivation.
-pub async fn create_mpc_genesis_with_transport<T: GenesisMpcTransport + Sync>(
+pub async fn create_genesis_with_transport<T: GenesisTransport + Sync>(
     device_id: [u8; 32],
     storage_nodes: Vec<NodeId>,
     hw_entropy: Vec<u8>,
@@ -860,31 +846,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_mpc_genesis_path() {
+    async fn test_create_genesis_path() {
         let dev = id32(0xAA);
         let nodes = vec![NodeId::new("n1"), NodeId::new("n2"), NodeId::new("n3")];
         let hw = vec![0xCC; 32];
         let env = vec![0xDD; 32];
-        let s = create_mpc_genesis(dev, nodes, hw, env, Some(b"DSMv2|test".to_vec())).await;
+        let s = create_genesis(dev, nodes, hw, env, Some(b"DSMv2|test".to_vec())).await;
 
         let sess = match s {
             Ok(sess) => sess,
-            Err(e) => panic!("create_mpc_genesis should succeed: {e:?}"),
+            Err(e) => panic!("create_genesis should succeed: {e:?}"),
         };
         assert_ne!(sess.genesis_id, [0u8; 32]);
         assert!(sess.verify_commitments());
         assert_eq!(sess.mpc_entropies.len(), sess.storage_nodes.len());
     }
 
-    /// Whitepaper §2.5 conformance: an external verifier with the same
-    /// public inputs (device_id, participants, metadata, contributions)
-    /// must independently recompute the genesis hash byte-for-byte.
+    /// Independently recompute `G` from the canonical materials
+    /// `[device_id ∥ device_entropy, b_1, …, b_n]` per whitepaper §2.5
+    /// (acyclic form), folding `H(m_i)` in sorted order with the
+    /// `DSM/genesis` domain. Mirrors what the verifier does from the public
+    /// inputs alone.
+    fn recompute_g(device_id: &[u8; 32], device_entropy: &[u8; 32], mpc: &[[u8; 32]]) -> [u8; 32] {
+        let mut materials: Vec<Vec<u8>> = Vec::new();
+        let mut dev = Vec::new();
+        dev.extend_from_slice(device_id);
+        dev.extend_from_slice(device_entropy);
+        materials.push(dev);
+        for m in mpc {
+            materials.push(m.to_vec());
+        }
+        let contribs: Vec<MPCContribution> = materials
+            .iter()
+            .map(|m| MPCContribution::new(String::new(), hash_contribution(m), Vec::new(), 0))
+            .collect();
+        compute_genesis_hash(device_id, &contribs)
+    }
+
+    /// Whitepaper §2.5 conformance: an external verifier with the same public
+    /// inputs (device_id + revealed contributions) must independently recompute
+    /// `G` byte-for-byte, and transport-time participant order must not change it.
     #[test]
     fn genesis_id_is_recomputable_from_public_inputs() {
         let mut s = GenesisSession::new(b"meta".to_vec()).unwrap();
-        // Deliberately scramble the participant order on input — the
-        // canonical_a() helper sorts internally, so order at call time
-        // must not change the hash.
+        // Deliberately scramble the participant order on input — `G` folds the
+        // contribution hashes in sorted order, so call-time order must not
+        // change the result.
         let nodes = vec![
             NodeId::new("zeta"),
             NodeId::new("alpha"),
@@ -896,30 +903,16 @@ mod tests {
         s.compute_commitments();
         s.compute_genesis_id();
 
-        // Independent recomputation following whitepaper §2.5 exactly.
-        let expected = {
-            let mut h = dsm_domain_hasher("DSM/genesis");
-            h.update(&s.device_entropy);
-            for m in &s.mpc_entropies {
-                h.update(m);
-            }
-            h.update(&canonical_a(&s.device_id, &s.storage_nodes, &s.metadata));
-            let mut out = [0u8; 32];
-            out.copy_from_slice(h.finalize().as_bytes());
-            out
-        };
+        let expected = recompute_g(&s.device_id, &s.device_entropy, &s.mpc_entropies);
         assert_eq!(s.genesis_id, expected);
 
-        // Permuting the participant order at the call site must NOT
-        // change the hash (canonical_a sorts).
+        // Permuting the participant order at the call site must NOT change `G`.
         let mut s2 = GenesisSession::new(b"meta".to_vec()).unwrap();
         let permuted = vec![
             NodeId::new("middle"),
             NodeId::new("zeta"),
             NodeId::new("alpha"),
         ];
-        // Same session_id needs the same metadata + device_id, but
-        // session_id is random so we copy from s.
         s2.session_id = s.session_id;
         s2.initialize_mpc(id32(0x42), permuted).unwrap();
         s2.device_entropy = id32(0xD0);
@@ -938,9 +931,9 @@ mod tests {
         let nodes = vec![NodeId::new("n1"), NodeId::new("n2"), NodeId::new("n3")];
         let hw = vec![0xCC; 32];
         let env = vec![0xDD; 32];
-        let session = create_mpc_genesis(dev, nodes, hw, env, Some(b"meta".to_vec()))
+        let session = create_genesis(dev, nodes, hw, env, Some(b"meta".to_vec()))
             .await
-            .expect("create_mpc_genesis succeeds");
+            .expect("create_genesis succeeds");
 
         let gs = convert_session_to_genesis_state_compat(&session).expect("convert succeeds");
 
@@ -1152,7 +1145,7 @@ mod tests {
         );
     }
 
-    /// Mock GenesisMpcTransport for Issue #252 regression tests:
+    /// Mock GenesisTransport for Issue #252 regression tests:
     /// returns a pre-set entropy byte-pattern per node and records
     /// every call so tests can assert no node was skipped (sub-bug 2:
     /// prefix-bias from `threshold_count` truncation).
@@ -1178,7 +1171,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl GenesisMpcTransport for FixedEntropyTransport {
+    impl GenesisTransport for FixedEntropyTransport {
         async fn collect_node_entropy(
             &self,
             node: &NodeId,
@@ -1209,7 +1202,7 @@ mod tests {
         let transport = FixedEntropyTransport::new(&map);
         let hw = vec![0xCC; 32];
         let env = vec![0xDD; 32];
-        let session = create_mpc_genesis_with_transport(
+        let session = create_genesis_with_transport(
             device_id,
             nodes.clone(),
             hw,
@@ -1227,21 +1220,14 @@ mod tests {
         assert_eq!(session.mpc_entropies[1], id32(0xA2));
         assert_eq!(session.mpc_entropies[2], id32(0xA3));
 
-        // Independent recomputation of G per whitepaper §2.5.  The
-        // device_entropy is sampled locally inside
-        // `create_mpc_genesis_with_transport`, so we read it back.
-        let mut h = dsm_domain_hasher("DSM/genesis");
-        h.update(&session.device_entropy);
-        for m in &session.mpc_entropies {
-            h.update(m);
-        }
-        h.update(&canonical_a(
+        // Independent recomputation of G per whitepaper §2.5 (acyclic form).
+        // The device_entropy is sampled locally inside
+        // `create_genesis_with_transport`, so we read it back.
+        let expected = recompute_g(
             &session.device_id,
-            &session.storage_nodes,
-            &session.metadata,
-        ));
-        let mut expected = [0u8; 32];
-        expected.copy_from_slice(h.finalize().as_bytes());
+            &session.device_entropy,
+            &session.mpc_entropies,
+        );
         assert_eq!(
             session.genesis_id, expected,
             "transport-supplied entropy bytes did not survive the call path"
@@ -1273,7 +1259,7 @@ mod tests {
         let hw = vec![0xCC; 32];
         let env = vec![0xDD; 32];
         let session =
-            create_mpc_genesis_with_transport(device_id, nodes.clone(), hw, env, None, &transport)
+            create_genesis_with_transport(device_id, nodes.clone(), hw, env, None, &transport)
                 .await
                 .expect("5-node genesis should succeed");
 
@@ -1318,7 +1304,7 @@ mod tests {
         let transport = FixedEntropyTransport::new(&map);
         let hw = vec![0xCC; 32];
         let env = vec![0xDD; 32];
-        let session = create_mpc_genesis_with_transport(
+        let session = create_genesis_with_transport(
             device_id,
             nodes,
             hw,

--- a/dsm_client/deterministic_state_machine/dsm/src/core/identity/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/identity/mod.rs
@@ -26,7 +26,7 @@ const _: () = assert!(
 );
 
 pub mod genesis;
-pub mod genesis_mpc;
+pub mod genesis_session;
 // hierarchical_device_management deleted: 1180-line module with zero external
 // callers. Its own doc comment noted "DO NOT use this Merkle implementation for
 // π_dev" — it's legacy superseded by crate::common::device_tree (§5 Device Tree)
@@ -45,8 +45,8 @@ use blake3;
 use tracing;
 use zeroize::Zeroize;
 
-// Import MPC types
-use crate::core::identity::genesis_mpc::{create_mpc_genesis, GenesisSession};
+// Import genesis-session types
+use crate::core::identity::genesis_session::{create_genesis, GenesisSession};
 // Re-export GenesisState for other modules
 pub use crate::core::identity::genesis::{verify_genesis_state, GenesisState};
 
@@ -196,7 +196,7 @@ impl TrustlessGenesisArtifacts {
 /// threshold cryptography.  All `storage_nodes` participate; the `≥3`
 /// floor is enforced (per spec invariant; resists 2-collusion-only).
 pub async fn create_trustless_genesis<
-    S: crate::core::identity::genesis_mpc::GenesisStorage + Sync + Send,
+    S: crate::core::identity::genesis_session::GenesisStorage + Sync + Send,
 >(
     device_id: String,
     storage_nodes: Vec<NodeId>,
@@ -223,7 +223,7 @@ pub async fn create_trustless_genesis<
     // Deterministic 32B device hash label for MPC inputs
     let device_id_bytes: [u8; 32] = *domain_hash("DSM/device-id", device_id.as_bytes()).as_bytes();
 
-    let session = create_mpc_genesis(
+    let session = create_genesis(
         device_id_bytes,
         storage_nodes,
         hw_entropy,
@@ -406,7 +406,7 @@ impl IdentityStore {
 
     /// Create a new identity with MANDATORY MPC genesis creation
     pub async fn create_identity<
-        S: crate::core::identity::genesis_mpc::GenesisStorage + Sync + Send,
+        S: crate::core::identity::genesis_session::GenesisStorage + Sync + Send,
     >(
         &self,
         name: &str,
@@ -489,7 +489,7 @@ impl IdentityStore {
     /// Per whitepaper §2.5 the MPC is n-of-n; all storage nodes contribute.
     /// No threshold parameter — `≥3` floor enforced.
     pub async fn create_identity_with_storage_nodes<
-        S: crate::core::identity::genesis_mpc::GenesisStorage + Sync + Send,
+        S: crate::core::identity::genesis_session::GenesisStorage + Sync + Send,
     >(
         &self,
         name: &str,

--- a/dsm_client/deterministic_state_machine/dsm/src/lib.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/lib.rs
@@ -166,7 +166,7 @@ fn get_enabled_features() -> Vec<String> {
 /// the MPC session from `(genesis_id, device_id = genesis_id, hw, env)`
 /// per `crate::crypto::cdbrw_binding::derive_cdbrw_binding_key`.
 pub async fn create_trustless_genesis<
-    S: crate::core::identity::genesis_mpc::GenesisStorage + Sync + Send,
+    S: crate::core::identity::genesis_session::GenesisStorage + Sync + Send,
 >(
     device_id: String,
     storage_nodes: Vec<crate::types::identifiers::NodeId>,

--- a/dsm_client/deterministic_state_machine/dsm/src/types/genesis_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/genesis_types.rs
@@ -1,213 +1,60 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Genesis Types - DSM Genesis State Structures (binary-only digests).
+//! Genesis hashing — the canonical DSM genesis hash `G` (binary-only).
 //!
-//! Deterministic, protobuf-first core types for Genesis state creation,
-//! verification, and integrity checks. Canonical hashing uses BLAKE3 with
-//! explicit domain separators. No hex/json/base64/serde anywhere.
+//! Deterministic, BLAKE3 domain-separated computation of the genesis hash per
+//! whitepaper §2.5. Genesis is an n-of-n commit-then-reveal entropy aggregation
+//! (≥3 storage nodes each contribute `b_i`, revealed and folded into one hash) —
+//! NOT threshold cryptography; `b_1, …, b_n` is index notation for "all n
+//! contributions", with no t-of-n DKG or Shamir. This module is the single
+//! source of truth for `G`, used by both the genesis session (producer) and
+//! `verify_genesis_state` (verifier).
 //!
-//! IMPORTANT: `created_at` is *non-canonical* and intentionally excluded from
-//! the Genesis hash to preserve determinism and our "no wall clock in protocol"
-//! rule. Treat it as UI/ops metadata only.
-
-use std::collections::HashMap;
+//! Acyclic form (whitepaper §2.5):
+//!
+//! ```text
+//! G := H_g("DSM/genesis"
+//!          ∥ device_id
+//!          ∥ ( "DSM/genesis/mpc\0" ∥ H(m_i)  for each contribution, sorted ))
+//! ```
+//!
+//! The public-key bundle and the K_DBRW anti-cloning binding are deliberately
+//! EXCLUDED from `G`: keys and K_DBRW are *derived from* `G`
+//! (`keys ← S_master ← K_DBRW ← G`), so folding them back into the preimage
+//! would be circular. They bind to genesis by derivation, not by inclusion;
+//! anti-cloning is enforced downstream by K_DBRW (a clone derives a different
+//! K_DBRW, hence different keys). Wall-clock and mutable metadata are likewise
+//! excluded, keeping `G` clockless and publicly recomputable from the public
+//! `device_id` plus the revealed contributions. No hex/json/base64/serde here.
 
 use crate::crypto::blake3::{domain_hash, dsm_domain_hasher};
-
-use crate::types::error::DsmError;
 
 /// Fixed-length digest (BLAKE3).
 pub type Digest32 = [u8; 32];
 
-/// Sub-domain separators for intra-hash field isolation within `recompute_genesis_hash`.
-/// These are fed as data delimiters inside an already domain-separated hasher
-/// (`dsm_domain_hasher("DSM/genesis")`), preventing cross-field collisions.
-const DOMAIN_KEYS: &[u8] = b"DSM/genesis/keys\0";
+/// Sub-domain separator isolating each per-contribution digest inside the
+/// already domain-separated genesis hasher (`dsm_domain_hasher("DSM/genesis")`),
+/// so contribution folds cannot collide with any other region of the preimage.
 const DOMAIN_MPC: &[u8] = b"DSM/genesis/mpc\0";
-const DOMAIN_DBRW: &[u8] = b"DSM/genesis/dbrw\0";
 
-/// Genesis state structure
-#[derive(Clone, Debug)]
-pub struct GenesisState {
-    /// Device ID that owns this Genesis state
-    pub device_id: [u8; 32],
-    /// Genesis hash (canonical BLAKE3 over canonical fields)
-    pub genesis_hash: Digest32,
-    /// MPC contributions used in Genesis creation
-    pub mpc_contributions: Vec<MPCContribution>,
-    /// DBRW proof for device binding
-    pub dbrw_proof: DBRWProof,
-    /// Public keys associated with this Genesis
-    pub public_keys: GenesisPublicKeys,
-    /// Non-canonical creation time (UI/ops only; NOT used in hashing)
-    pub created_at: u64,
-    /// Arbitrary metadata (UI/ops only; NOT used in hashing)
-    pub metadata: HashMap<String, String>,
-}
-
-/// MPC contribution in Genesis creation
+/// A single genesis contribution: one storage node's revealed entropy, or the
+/// device's own contribution. Only `contribution_hash` is folded into `G`;
+/// `contributor_id` is a deterministic tie-breaker for the canonical sort and
+/// is never part of the preimage.
 #[derive(Clone, Debug)]
 pub struct MPCContribution {
-    /// ID of the contributing party (storage node or client)
+    /// ID of the contributing party (storage node or device). Tie-breaker only.
     pub contributor_id: String,
-    /// Cryptographic contribution (32-byte digest)
+    /// Canonical 32-byte digest of the contribution material, `H(m_i)`.
     pub contribution_hash: Digest32,
-    /// Signature over the contribution (verification handled upstream)
+    /// Signature over the contribution (verified upstream; not folded into `G`).
     pub signature: Vec<u8>,
-    /// Non-canonical tick of contribution (UI/ops only)
+    /// Non-canonical tick of contribution (UI/ops only; not folded into `G`).
     pub tick: u64,
 }
 
-/// DBRW (Dual-Binding Random Walk) proof
-#[derive(Clone, Debug)]
-pub struct DBRWProof {
-    /// Device fingerprint used in DBRW. Binds to the device's silicon via
-    /// C-DBRW's *observed* statistical signature — the 32-byte `AC_D`
-    /// attractor commitment produced by live orbit enrollment
-    /// (`dsm_sdk::security::cdbrw_enrollment_writer`). DSM is deliberately
-    /// enclave-free: this field is NOT sourced from TPM / TEE / StrongBox /
-    /// Secure Enclave or any sealed-module attestation chain. Anti-clone
-    /// enforcement is provided by the live re-prove gate
-    /// (`dsm_sdk::security::cdbrw_reprove`), which zeroes the in-memory
-    /// K_DBRW slot when a live orbit drifts outside the enrollment envelope.
-    pub device_fingerprint: Vec<u8>,
-    /// Environmental state hash (`domain_hash("DSM/genesis/dbrw-env", proof_data)`)
-    pub env_state_hash: Digest32,
-    /// Raw random-walk proof bytes (large; not included directly in genesis hash)
-    pub proof_data: Vec<u8>,
-    /// DBRW verification hash (compact attestation result)
-    pub verification_hash: Digest32,
-}
-
-/// Public keys in Genesis state
-#[derive(Clone, Debug)]
-pub struct GenesisPublicKeys {
-    /// Signing public key (SPHINCS+)
-    pub signing_key: Vec<u8>,
-    /// Key encapsulation public key (Kyber/ML-KEM)
-    pub encapsulation_key: Vec<u8>,
-    /// Canonical hash of the key bundle (BLAKE3)
-    pub key_hash: Digest32,
-}
-
-impl GenesisState {
-    /// Create a new Genesis state (does NOT auto-compute `genesis_hash`).
-    /// Call `recompute_genesis_hash()` and set it on the struct in your constructor flow.
-    pub fn new(
-        device_id: [u8; 32],
-        genesis_hash: Digest32,
-        mpc_contributions: Vec<MPCContribution>,
-        dbrw_proof: DBRWProof,
-        public_keys: GenesisPublicKeys,
-        created_at: u64,
-    ) -> Self {
-        Self {
-            device_id,
-            genesis_hash,
-            mpc_contributions,
-            dbrw_proof,
-            public_keys,
-            created_at,
-            metadata: HashMap::new(),
-        }
-    }
-
-    /// Verify Genesis state integrity with deterministic rules only.
-    ///
-    /// Checks performed:
-    /// - Non-empty MPC set and keys present
-    /// - DBRW env hash matches proof_data
-    /// - Key bundle hash matches `key_hash`
-    /// - Canonical recomputed genesis hash equals stored `genesis_hash`
-    ///
-    /// Returns:
-    /// - Ok(true)  => passes all checks
-    /// - Ok(false) => any check fails (deterministic fail; no partial passes)
-    pub fn verify_integrity(&self) -> Result<bool, DsmError> {
-        // Basic presence checks
-        if self.mpc_contributions.is_empty() {
-            return Ok(false);
-        }
-        if self.public_keys.signing_key.is_empty() || self.public_keys.encapsulation_key.is_empty()
-        {
-            return Ok(false);
-        }
-        if self.dbrw_proof.device_fingerprint.is_empty() {
-            return Ok(false);
-        }
-
-        // DBRW env hash must be domain-separated BLAKE3(proof_data)
-        let env_calc = domain_hash("DSM/genesis/dbrw-env", &self.dbrw_proof.proof_data);
-        if !ct_eq(env_calc.as_bytes(), &self.dbrw_proof.env_state_hash) {
-            return Ok(false);
-        }
-
-        // Public key bundle hash must match
-        let expected_key_hash = GenesisPublicKeys::compute_key_hash(
-            &self.public_keys.signing_key,
-            &self.public_keys.encapsulation_key,
-        );
-        if !ct_eq(&expected_key_hash, &self.public_keys.key_hash) {
-            return Ok(false);
-        }
-
-        // Canonical Genesis hash must match
-        let computed = self.recompute_genesis_hash()?;
-        if !ct_eq(&computed, &self.genesis_hash) {
-            return Ok(false);
-        }
-
-        Ok(true)
-    }
-
-    /// Recompute the canonical Genesis hash (BLAKE3 -> 32 bytes).
-    ///
-    /// Canonical inputs (in order):
-    /// - Domain prefix via `dsm_domain_hasher("DSM/genesis")`
-    /// - device_id (UTF-8 bytes)
-    /// - MPC contributions (sorted by `contribution_hash`, then contributor_id)
-    ///   Each contribution folded as: DOMAIN_MPC || contribution_hash (32 bytes)
-    /// - DBRW fold: DOMAIN_DBRW || device_fingerprint || verification_hash (32 bytes)
-    /// - Keys fold: DOMAIN_KEYS || signing_key || encapsulation_key || key_hash (32 bytes)
-    ///
-    /// Excluded: `created_at`, `metadata`, `DBRW.proof_data`, `DBRW.env_state_hash`
-    pub fn recompute_genesis_hash(&self) -> Result<Digest32, DsmError> {
-        let mut h = dsm_domain_hasher("DSM/genesis");
-        h.update(&self.device_id);
-
-        // MPC contributions: deterministic order by (contribution_hash, contributor_id)
-        let mut contributions = self.mpc_contributions.clone();
-        contributions.sort_by(|a, b| {
-            let hcmp = a.contribution_hash.cmp(&b.contribution_hash);
-            if hcmp == std::cmp::Ordering::Equal {
-                a.contributor_id.cmp(&b.contributor_id)
-            } else {
-                hcmp
-            }
-        });
-        for c in &contributions {
-            h.update(DOMAIN_MPC);
-            h.update(&c.contribution_hash);
-        }
-
-        // DBRW (compact attestation only)
-        h.update(DOMAIN_DBRW);
-        h.update(&self.dbrw_proof.device_fingerprint);
-        h.update(&self.dbrw_proof.verification_hash);
-
-        // Keys (include key_hash for belt-and-suspenders binding)
-        h.update(DOMAIN_KEYS);
-        h.update(&self.public_keys.signing_key);
-        h.update(&self.public_keys.encapsulation_key);
-        h.update(&self.public_keys.key_hash);
-
-        let digest = h.finalize();
-        Ok(*digest.as_bytes())
-    }
-}
-
 impl MPCContribution {
-    /// Create a new MPC contribution (does not verify signature content here).
+    /// Create a new contribution record (does not verify signature content).
     pub fn new(
         contributor_id: String,
         contribution_hash: Digest32,
@@ -223,273 +70,126 @@ impl MPCContribution {
     }
 }
 
-impl DBRWProof {
-    /// Create a new DBRW proof. `env_state_hash` must equal `domain_hash("DSM/genesis/dbrw-env", proof_data)`.
-    pub fn new(
-        device_fingerprint: Vec<u8>,
-        env_state_hash: Digest32,
-        proof_data: Vec<u8>,
-        verification_hash: Digest32,
-    ) -> Self {
-        Self {
-            device_fingerprint,
-            env_state_hash,
-            proof_data,
-            verification_hash,
-        }
-    }
+/// Canonical digest of one contribution's raw material, `H(m_i)`.
+///
+/// Domain-separated so contribution digests cannot collide with any other
+/// BLAKE3 use, and so variable-length materials (the device contribution is
+/// `device_id ∥ device_entropy`; node contributions are 32-byte entropies) all
+/// normalise to a uniform 32-byte fold input.
+pub fn hash_contribution(material: &[u8]) -> Digest32 {
+    *domain_hash("DSM/genesis/contribution", material).as_bytes()
 }
 
-impl GenesisPublicKeys {
-    /// Create new Genesis public keys; computes and sets `key_hash` deterministically.
-    pub fn new(signing_key: Vec<u8>, encapsulation_key: Vec<u8>) -> Self {
-        let key_hash = Self::compute_key_hash(&signing_key, &encapsulation_key);
-        Self {
-            signing_key,
-            encapsulation_key,
-            key_hash,
-        }
+/// Compute the canonical genesis hash `G` (whitepaper §2.5, acyclic form).
+///
+/// ```text
+/// G := H_g("DSM/genesis" ∥ device_id ∥ ⟦ "DSM/genesis/mpc\0" ∥ H(m_i) ⟧ sorted )
+/// ```
+///
+/// Contributions are folded in canonical order — sorted by
+/// `(contribution_hash, contributor_id)` — so transport-time ordering cannot
+/// change `G`. Only `contribution_hash` enters the preimage; `contributor_id`
+/// breaks ties solely in the (cryptographically unreachable) event of equal
+/// contribution hashes, where the folded bytes are identical regardless.
+///
+/// `G` is acyclic and publicly recomputable: it depends only on `device_id`
+/// and the revealed contributions, never on values derived from `G` (keys,
+/// K_DBRW), which bind to genesis by being derived from it.
+pub fn compute_genesis_hash(device_id: &[u8; 32], contributions: &[MPCContribution]) -> Digest32 {
+    let mut h = dsm_domain_hasher("DSM/genesis");
+    h.update(device_id);
+
+    let mut ordered: Vec<&MPCContribution> = contributions.iter().collect();
+    ordered.sort_by(|a, b| {
+        a.contribution_hash
+            .cmp(&b.contribution_hash)
+            .then_with(|| a.contributor_id.cmp(&b.contributor_id))
+    });
+    for c in &ordered {
+        h.update(DOMAIN_MPC);
+        h.update(&c.contribution_hash);
     }
 
-    /// Deterministic key bundle hash (BLAKE3 -> 32 bytes).
-    #[inline]
-    pub fn compute_key_hash(signing_key: &[u8], encapsulation_key: &[u8]) -> Digest32 {
-        let mut h = dsm_domain_hasher("DSM/genesis/keys");
-        h.update(signing_key);
-        h.update(encapsulation_key);
-        *h.finalize().as_bytes()
-    }
-}
-
-/// Constant-time byte equality (branchless XOR-accumulate).
-#[inline]
-fn ct_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut acc: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        acc |= x ^ y;
-    }
-    acc == 0
+    *h.finalize().as_bytes()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn key_hash_is_stable() {
-        let pk = GenesisPublicKeys::new(b"sign".to_vec(), b"kem".to_vec());
-        let expected = GenesisPublicKeys::compute_key_hash(b"sign", b"kem");
-        assert!(ct_eq(&pk.key_hash, &expected));
+    fn contrib(id: &str, material: &[u8]) -> MPCContribution {
+        MPCContribution::new(id.to_string(), hash_contribution(material), Vec::new(), 0)
     }
 
     #[test]
-    fn genesis_hash_excludes_created_at() {
-        let keys = GenesisPublicKeys::new(b"S+".to_vec(), b"KEM".to_vec());
-
-        let proof_data = b"walk".to_vec();
-        let env = blake3::hash(&proof_data);
-        let dbrw = DBRWProof::new(
-            vec![1, 2, 3],
-            *env.as_bytes(),
-            proof_data,
-            *blake3::hash(b"att").as_bytes(),
-        );
-
-        let mpc = vec![
-            MPCContribution::new("n1".into(), *blake3::hash(b"aa").as_bytes(), vec![9], 0),
-            MPCContribution::new("n2".into(), *blake3::hash(b"ab").as_bytes(), vec![9], 0),
+    fn genesis_hash_is_order_independent() {
+        let did = [0x42u8; 32];
+        let ab = vec![
+            contrib("a", b"c1"),
+            contrib("b", b"c2"),
+            contrib("c", b"c3"),
         ];
-
-        let device_id = blake3::hash(b"dev").into();
-
-        let s1 = GenesisState::new(
-            device_id,
-            [0u8; 32],
-            mpc.clone(),
-            dbrw.clone(),
-            keys.clone(),
-            1,
-        );
-        let h1 = s1.recompute_genesis_hash().unwrap();
-
-        let s2 = GenesisState::new(device_id, [0u8; 32], mpc, dbrw, keys, 9_999_999);
-        let h2 = s2.recompute_genesis_hash().unwrap();
-
-        assert!(ct_eq(&h1, &h2), "created_at must not affect canonical hash");
-    }
-
-    #[test]
-    fn integrity_verifies_when_consistent() {
-        use crate::crypto::blake3::domain_hash as dh;
-        let keys = GenesisPublicKeys::new(b"S+".to_vec(), b"KEM".to_vec());
-        let proof_data = b"walk".to_vec();
-        let env_hash = *dh("DSM/genesis/dbrw-env", &proof_data).as_bytes();
-        let dbrw = DBRWProof::new(
-            vec![7, 7, 7],
-            env_hash,
-            proof_data,
-            *blake3::hash(b"attest").as_bytes(),
-        );
-        let mpc = vec![
-            MPCContribution::new("a".into(), *blake3::hash(b"01").as_bytes(), vec![1], 0),
-            MPCContribution::new("b".into(), *blake3::hash(b"02").as_bytes(), vec![2], 0),
+        let ba = vec![
+            contrib("c", b"c3"),
+            contrib("a", b"c1"),
+            contrib("b", b"c2"),
         ];
-
-        let device_id = blake3::hash(b"devX").into();
-        let mut gs = GenesisState::new(device_id, [0u8; 32], mpc, dbrw, keys, 0);
-        let computed = gs.recompute_genesis_hash().unwrap();
-        gs.genesis_hash = computed;
-
-        assert!(gs.verify_integrity().unwrap());
-    }
-
-    fn make_valid_genesis() -> GenesisState {
-        use crate::crypto::blake3::domain_hash as dh;
-        let keys = GenesisPublicKeys::new(b"sign-key".to_vec(), b"kem-key".to_vec());
-        let proof_data = b"random-walk-data".to_vec();
-        let env_hash = *dh("DSM/genesis/dbrw-env", &proof_data).as_bytes();
-        let dbrw = DBRWProof::new(
-            vec![0xDE, 0xAD],
-            env_hash,
-            proof_data,
-            *blake3::hash(b"attestation").as_bytes(),
-        );
-        let mpc = vec![MPCContribution::new(
-            "node1".into(),
-            *blake3::hash(b"contrib1").as_bytes(),
-            vec![1, 2, 3],
-            0,
-        )];
-        let device_id: [u8; 32] = *blake3::hash(b"device").as_bytes();
-        let mut gs = GenesisState::new(device_id, [0u8; 32], mpc, dbrw, keys, 42);
-        gs.genesis_hash = gs.recompute_genesis_hash().unwrap();
-        gs
-    }
-
-    #[test]
-    fn integrity_fails_with_empty_mpc() {
-        let mut gs = make_valid_genesis();
-        gs.mpc_contributions.clear();
-        assert!(!gs.verify_integrity().unwrap());
-    }
-
-    #[test]
-    fn integrity_fails_with_empty_signing_key() {
-        let mut gs = make_valid_genesis();
-        gs.public_keys.signing_key.clear();
-        assert!(!gs.verify_integrity().unwrap());
-    }
-
-    #[test]
-    fn integrity_fails_with_empty_encapsulation_key() {
-        let mut gs = make_valid_genesis();
-        gs.public_keys.encapsulation_key.clear();
-        assert!(!gs.verify_integrity().unwrap());
-    }
-
-    #[test]
-    fn integrity_fails_with_empty_device_fingerprint() {
-        let mut gs = make_valid_genesis();
-        gs.dbrw_proof.device_fingerprint.clear();
-        assert!(!gs.verify_integrity().unwrap());
-    }
-
-    #[test]
-    fn integrity_fails_with_wrong_env_hash() {
-        let mut gs = make_valid_genesis();
-        gs.dbrw_proof.env_state_hash = [0xFFu8; 32];
-        assert!(!gs.verify_integrity().unwrap());
-    }
-
-    #[test]
-    fn integrity_fails_with_wrong_key_hash() {
-        let mut gs = make_valid_genesis();
-        gs.public_keys.key_hash = [0xFFu8; 32];
-        assert!(!gs.verify_integrity().unwrap());
-    }
-
-    #[test]
-    fn integrity_fails_with_wrong_genesis_hash() {
-        let mut gs = make_valid_genesis();
-        gs.genesis_hash = [0xFFu8; 32];
-        assert!(!gs.verify_integrity().unwrap());
-    }
-
-    #[test]
-    fn mpc_order_does_not_affect_genesis_hash() {
-        let h1 = *blake3::hash(b"c1").as_bytes();
-        let h2 = *blake3::hash(b"c2").as_bytes();
-        let keys = GenesisPublicKeys::new(b"S".to_vec(), b"K".to_vec());
-        let pd = b"pdata".to_vec();
-        let env = *domain_hash("DSM/genesis/dbrw-env", &pd).as_bytes();
-        let dbrw = DBRWProof::new(vec![1], env, pd, *blake3::hash(b"v").as_bytes());
-        let did: [u8; 32] = *blake3::hash(b"d").as_bytes();
-
-        let mpc_ab = vec![
-            MPCContribution::new("a".into(), h1, vec![], 0),
-            MPCContribution::new("b".into(), h2, vec![], 0),
-        ];
-        let mpc_ba = vec![
-            MPCContribution::new("b".into(), h2, vec![], 0),
-            MPCContribution::new("a".into(), h1, vec![], 0),
-        ];
-
-        let gs1 = GenesisState::new(did, [0u8; 32], mpc_ab, dbrw.clone(), keys.clone(), 0);
-        let gs2 = GenesisState::new(did, [0u8; 32], mpc_ba, dbrw, keys, 0);
         assert_eq!(
-            gs1.recompute_genesis_hash().unwrap(),
-            gs2.recompute_genesis_hash().unwrap(),
-            "MPC contribution order must not affect canonical hash"
+            compute_genesis_hash(&did, &ab),
+            compute_genesis_hash(&did, &ba),
+            "contribution order must not affect canonical G"
         );
     }
 
     #[test]
-    fn genesis_state_new_metadata_is_empty() {
-        let gs = make_valid_genesis();
-        assert!(gs.metadata.is_empty());
-    }
-
-    #[test]
-    fn ct_eq_with_different_lengths() {
-        assert!(!ct_eq(&[1, 2], &[1, 2, 3]));
-    }
-
-    #[test]
-    fn ct_eq_with_equal_bytes() {
-        assert!(ct_eq(&[0xAB; 32], &[0xAB; 32]));
-    }
-
-    #[test]
-    fn ct_eq_with_single_bit_difference() {
-        let a = [0u8; 32];
-        let mut b = [0u8; 32];
-        b[31] = 1;
-        assert!(!ct_eq(&a, &b));
-    }
-
-    #[test]
-    fn different_device_ids_produce_different_hashes() {
-        let keys = GenesisPublicKeys::new(b"S".to_vec(), b"K".to_vec());
-        let pd = b"p".to_vec();
-        let env = *domain_hash("DSM/genesis/dbrw-env", &pd).as_bytes();
-        let dbrw = DBRWProof::new(vec![1], env, pd, [0u8; 32]);
-        let mpc = vec![MPCContribution::new("n".into(), [0u8; 32], vec![], 0)];
-
-        let gs1 = GenesisState::new(
-            [1u8; 32],
-            [0u8; 32],
-            mpc.clone(),
-            dbrw.clone(),
-            keys.clone(),
-            0,
-        );
-        let gs2 = GenesisState::new([2u8; 32], [0u8; 32], mpc, dbrw, keys, 0);
+    fn genesis_hash_depends_on_device_id() {
+        let c = vec![contrib("a", b"x"), contrib("b", b"y")];
         assert_ne!(
-            gs1.recompute_genesis_hash().unwrap(),
-            gs2.recompute_genesis_hash().unwrap()
+            compute_genesis_hash(&[1u8; 32], &c),
+            compute_genesis_hash(&[2u8; 32], &c),
+            "device_id must bind into G"
         );
+    }
+
+    #[test]
+    fn genesis_hash_depends_on_contributions() {
+        let did = [7u8; 32];
+        let base = vec![contrib("a", b"x"), contrib("b", b"y")];
+        let changed = vec![contrib("a", b"x"), contrib("b", b"z")];
+        assert_ne!(
+            compute_genesis_hash(&did, &base),
+            compute_genesis_hash(&did, &changed),
+            "changing any contribution must change G"
+        );
+    }
+
+    #[test]
+    fn genesis_hash_excludes_contributor_id() {
+        // Same contribution hashes, different contributor ids ⇒ identical G:
+        // contributor_id is a sort tie-breaker only, never folded in.
+        let did = [9u8; 32];
+        let h1 = hash_contribution(b"m1");
+        let h2 = hash_contribution(b"m2");
+        let a = vec![
+            MPCContribution::new("alpha".into(), h1, Vec::new(), 0),
+            MPCContribution::new("bravo".into(), h2, Vec::new(), 0),
+        ];
+        let b = vec![
+            MPCContribution::new("zulu".into(), h1, Vec::new(), 9),
+            MPCContribution::new("yankee".into(), h2, Vec::new(), 9),
+        ];
+        assert_eq!(
+            compute_genesis_hash(&did, &a),
+            compute_genesis_hash(&did, &b),
+            "contributor_id must not affect G"
+        );
+    }
+
+    #[test]
+    fn hash_contribution_is_deterministic_and_domain_separated() {
+        let m = b"some-contribution-material";
+        assert_eq!(hash_contribution(m), hash_contribution(m));
+        // Domain-separated: not equal to a raw BLAKE3 of the same bytes.
+        assert_ne!(hash_contribution(m), *blake3::hash(m).as_bytes());
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/mod.rs
@@ -11,7 +11,7 @@
 //! - [`identifiers`] — Type-safe wrappers: [`NodeId`], [`VaultId`], [`SessionId`], [`TransactionId`], etc.
 //! - [`operations`] — Operation trait hierarchy: [`Ops`], [`TokenOps`], [`IdOps`], [`SmartCommitOps`]
 //! - [`identity`] — [`IdentityAnchor`] and [`IdentityClaim`] for device identity
-//! - [`genesis_types`] — Genesis state and MPC genesis artifacts
+//! - [`genesis_types`] — Canonical genesis hash `G` (§2.5) and the contribution type
 //! - [`policy_types`] — [`TokenPolicy`], [`PolicyAnchor`], [`PolicyFile`] for CPTA
 //! - [`receipt_types`] — Stitched receipts and verification contexts
 //! - [`contact_types`] — Verified contact information

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
@@ -4305,12 +4305,12 @@ pub extern "system" fn Java_com_dsm_native_DsmNative_getBilateralPollTelemetry(
 MPC shim (matches handler call-site; stays fail-closed until enabled)
 ============================================================================= */
 
-pub fn create_genesis_mpc<A, B, C>(
+pub fn create_genesis<A, B, C>(
     _locale: &A,
     _network_id: &B,
     _entropy: &C,
 ) -> Result<pb::Envelope, String> {
-    Err("MPC-over-JNI is disabled in Unified Bridge".to_string())
+    Err("genesis-over-JNI is disabled in Unified Bridge".to_string())
 }
 
 /* =============================================================================

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 
 use dsm::core::identity::genesis::create_genesis_via_blind_mpc_with_contributors;
-use dsm::core::identity::genesis_mpc::generate_device_entropy;
+use dsm::core::identity::genesis_session::generate_device_entropy;
 use dsm::core::state_machine::StateMachine;
 use dsm::core::token::policy::TokenPolicySystem;
 use dsm::types::error::DsmError;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/genesis_publisher.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/genesis_publisher.rs
@@ -2,13 +2,13 @@
 
 //! # Genesis Publisher
 //!
-//! Implements the [`GenesisPublisher`](dsm::core::identity::genesis_mpc::GenesisPublisher)
+//! Implements the [`GenesisPublisher`](dsm::core::identity::genesis_session::GenesisPublisher)
 //! trait to publish sanitized genesis payloads to storage nodes via the
-//! `StorageNodeSDK`. Used during MPC-based genesis creation to anchor the
-//! new device identity across storage nodes.
+//! `StorageNodeSDK`. Used during genesis creation to anchor the new device
+//! identity across storage nodes.
 
 use async_trait::async_trait;
-use dsm::core::identity::genesis_mpc::{GenesisPublisher, SanitizedGenesisPayload};
+use dsm::core::identity::genesis_session::{GenesisPublisher, SanitizedGenesisPayload};
 use dsm::types::error::DsmError;
 use dsm::types::identifiers::NodeId;
 use crate::sdk::storage_node_sdk::StorageNodeSDK;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/identity_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/identity_sdk.rs
@@ -38,7 +38,7 @@ use crate::sdk::storage_node_sdk::StorageNodeSDK;
 #[cfg(feature = "storage")]
 use crate::sdk::genesis_publisher::SdkGenesisPublisher;
 #[cfg(feature = "storage")]
-use dsm::core::identity::genesis_mpc::{GenesisPublisher, SanitizedGenesisPayload};
+use dsm::core::identity::genesis_session::{GenesisPublisher, SanitizedGenesisPayload};
 use crate::util::text_id;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/token_mpc_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/token_mpc_sdk.rs
@@ -1517,7 +1517,7 @@ mod tests {
     use super::*;
 
     #[cfg(all(test, target_os = "android"))]
-    use crate::jni::unified_protobuf_bridge::create_genesis_mpc;
+    use crate::jni::unified_protobuf_bridge::create_genesis;
 
     #[cfg(feature = "local-mpc")]
     #[tokio::test]
@@ -1673,7 +1673,7 @@ mod tests {
         println!("   Device Entropy: {} bytes", device_entropy.len());
 
         // Create genesis
-        let genesis_result = create_genesis_mpc(locale, network_id, device_entropy)?;
+        let genesis_result = create_genesis(locale, network_id, device_entropy)?;
 
         println!("✅ Genesis creation successful!");
         println!("📋 Genesis Details:");


### PR DESCRIPTION
## The bug

Production emitted the wrong genesis hash. The session computed the flat degenerate form (which §2.5 itself labels the single-party degenerate case), and `verify_genesis_state` never recomputed the hash. The spec's structured form was worse: it folded the public-key bundle and DBRW proof into G, but those derive from G (keys ← S_master ← K_DBRW ← G) — circular. That circularity is why production quietly fell back to the flat form.

## The fix — one acyclic, publicly-recomputable construction (code + §2.5 spec aligned)

```
G := H_g("DSM/genesis" ∥ device_id ∥ sorted( "DSM/genesis/mpc\0" ∥ H(b_i) ))
```

Contributions are [device_id ∥ device_entropy, b_1…b_n] (n-of-n commit-then-reveal, not threshold), folded by contribution hash in sorted order so transport order can't change G. Keys and K_DBRW are excluded — they bind to genesis by being derived from it; anti-cloning is enforced downstream by K_DBRW. G stays clockless and recomputable from device_id + the revealed contributions alone.

## Changes
- `types/genesis_types.rs`: single source of truth for G (`compute_genesis_hash` + `hash_contribution`); dead `GenesisState`/`DBRWProof`/`GenesisPublicKeys` deleted.
- `genesis_session.rs` (renamed from `genesis_mpc.rs`): canonical `compute_genesis_id`; flat form + `canonical_a` + dead `to_arr32` deleted; `Mpc`-named identity symbols renamed (`create_mpc_genesis`→`create_genesis`, `GenesisMpcTransport`→`GenesisTransport`).
- `genesis.rs`: `verify_genesis_state` now recomputes G and strict-fails; convert stores exactly the hashed materials; dead `calculate_genesis_hash` deleted.
- All refs updated (`mod.rs`, `lib.rs`, SDK, JNI shim); whitepaper §2.5 + file citations corrected.

## Verification
Builds clean; clippy `-D warnings` clean; 1528 dsm + 51 dsm_sdk genesis tests pass, including the §2.5 public-recompute KAT and the unchanged cdbrw KAT. Genesis hash value changes; pre-beta, no users, no migration needed.

Supersedes #398 (which built a traditional interactive MPC ceremony — the wrong model).