### PR TITLE
fix(storage-node/admin): fail closed when admin token is unset

### DIFF
--- a/dsm_storage_node/src/api/infra/admin.rs
+++ b/dsm_storage_node/src/api/infra/admin.rs
@@ -23,6 +23,10 @@ use crate::AppState;
 
 const ADMIN_TOKEN_HEADER: &str = "x-dsm-admin-token";
 const ADMIN_TOKEN_ENV: &str = "DSM_ADMIN_TOKEN";
+/// Explicit, opt-in escape hatch for local development only. When the admin
+/// token is unset, auth stays fail-closed unless this is set to `1` in a debug
+/// build.
+const ADMIN_INSECURE_ENV: &str = "DSM_INSECURE_ALLOW_NO_ADMIN_TOKEN";
 
 fn token_matches(provided: &str, expected: &str) -> bool {
     provided.as_bytes().ct_eq(expected.as_bytes()).into()
@@ -31,17 +35,19 @@ fn token_matches(provided: &str, expected: &str) -> bool {
 async fn require_admin_token(headers: HeaderMap) -> Result<(), StatusCode> {
     let expected = env::var(ADMIN_TOKEN_ENV).unwrap_or_default();
     if expected.trim().is_empty() {
-        if cfg!(debug_assertions) {
+        // Fail closed by default — a missing admin token must never silently
+        // authorize destructive endpoints (cleanup deletes objects/spool;
+        // maintenance mutates current_tick and runs replication). Local dev can
+        // explicitly opt out of admin auth by setting ADMIN_INSECURE_ENV=1; a
+        // plain debug build no longer disables auth on its own.
+        if cfg!(debug_assertions) && env::var(ADMIN_INSECURE_ENV).as_deref() == Ok("1") {
             log::warn!(
-                "admin auth disabled: {} not set (debug build)",
-                ADMIN_TOKEN_ENV
+                "admin auth explicitly disabled via {}=1 (debug build)",
+                ADMIN_INSECURE_ENV
             );
             return Ok(());
         }
-        log::error!(
-            "admin auth disabled in release: {} not set",
-            ADMIN_TOKEN_ENV
-        );
+        log::error!("admin auth required but {} not set", ADMIN_TOKEN_ENV);
         return Err(StatusCode::UNAUTHORIZED);
     }
 


### PR DESCRIPTION
## Problem

`require_admin_token` is the middleware guarding the admin router
(`/admin/cleanup`, `/admin/maintenance`). When the `DSM_ADMIN_TOKEN` environment
variable was unset, it returned `Ok(())` on **any** debug build — silently
authorizing every admin request with no token at all. A debug binary deployed
anywhere (a staging box, a container built without `--release`) was therefore a
fully open admin surface.

These endpoints are destructive:
- `/admin/cleanup` → `db::cleanup_expired_objects_and_spool` (deletes objects + spool rows).
- `/admin/maintenance` → stores `current_tick` and runs `replication_manager.maintenance_cycle`.

## Evidence

```rust
// src/api/infra/admin.rs (before)
let expected = env::var(ADMIN_TOKEN_ENV).unwrap_or_default();
if expected.trim().is_empty() {
    if cfg!(debug_assertions) {
        log::warn!("admin auth disabled: {} not set (debug build)", ADMIN_TOKEN_ENV);
        return Ok(());          // <-- fail OPEN on any debug build
    }
    log::error!("admin auth disabled in release: {} not set", ADMIN_TOKEN_ENV);
    return Err(StatusCode::UNAUTHORIZED);
}
```

Release builds already failed closed; only debug builds were open. No in-tree
test or CI path sets `DSM_ADMIN_TOKEN` or exercises these endpoints (confirmed by
grep), so nothing depended on the bypass.

## Fix

Fail closed by default in all build profiles. Keep a **local-dev escape hatch**
that must be opted into explicitly (so the bypass can never be reached by
accident): only when the token is unset, the build is debug, **and**
`DSM_INSECURE_ALLOW_NO_ADMIN_TOKEN=1` is set, do we allow (with a warning).

```rust
const ADMIN_INSECURE_ENV: &str = "DSM_INSECURE_ALLOW_NO_ADMIN_TOKEN";

let expected = env::var(ADMIN_TOKEN_ENV).unwrap_or_default();
if expected.trim().is_empty() {
    if cfg!(debug_assertions) && env::var(ADMIN_INSECURE_ENV).as_deref() == Ok("1") {
        log::warn!("admin auth explicitly disabled via {}=1 (debug build)", ADMIN_INSECURE_ENV);
        return Ok(());
    }
    log::error!("admin auth required but {} not set", ADMIN_TOKEN_ENV);
    return Err(StatusCode::UNAUTHORIZED);
}
```

## Verification

`cargo check` on `dsm_storage_node` is clean. The token-compare path
(`token_matches`, constant-time `ct_eq`) is unchanged. Sibling fix for `/gossip`
is in branch 02 (`fix/sn-gossip-auth-failopen`).

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
