### PR TITLE
fix(storage-node/gossip): fail closed when gossip token is unset

### DIFF
--- a/dsm_storage_node/src/api/transport/gossip.rs
+++ b/dsm_storage_node/src/api/transport/gossip.rs
@@ -21,6 +21,10 @@ use subtle::ConstantTimeEq;
 
 const GOSSIP_TOKEN_HEADER: &str = "x-dsm-gossip-token";
 const GOSSIP_TOKEN_ENV: &str = "DSM_GOSSIP_TOKEN";
+/// Explicit, opt-in escape hatch for local development only. When the gossip
+/// token is unset, auth stays fail-closed unless this is set to `1` in a debug
+/// build.
+const GOSSIP_INSECURE_ENV: &str = "DSM_INSECURE_ALLOW_NO_GOSSIP_TOKEN";
 
 fn token_matches(provided: &str, expected: &str) -> bool {
     provided.as_bytes().ct_eq(expected.as_bytes()).into()
@@ -29,17 +33,18 @@ fn token_matches(provided: &str, expected: &str) -> bool {
 async fn require_gossip_token(headers: HeaderMap) -> Result<(), StatusCode> {
     let expected = env::var(GOSSIP_TOKEN_ENV).unwrap_or_default();
     if expected.trim().is_empty() {
-        if cfg!(debug_assertions) {
+        // Fail closed by default — a missing gossip token must never silently
+        // authorize /gossip, which mutates current_tick and feeds node-state /
+        // replication. Local dev can explicitly opt out by setting
+        // GOSSIP_INSECURE_ENV=1 (debug builds only).
+        if cfg!(debug_assertions) && env::var(GOSSIP_INSECURE_ENV).as_deref() == Ok("1") {
             log::warn!(
-                "gossip auth disabled: {} not set (debug build)",
-                GOSSIP_TOKEN_ENV
+                "gossip auth explicitly disabled via {}=1 (debug build)",
+                GOSSIP_INSECURE_ENV
             );
             return Ok(());
         }
-        log::error!(
-            "gossip auth disabled in release: {} not set",
-            GOSSIP_TOKEN_ENV
-        );
+        log::error!("gossip auth required but {} not set", GOSSIP_TOKEN_ENV);
         return Err(StatusCode::UNAUTHORIZED);
     }
 


### PR DESCRIPTION
## Problem

`require_gossip_token` guards the `/gossip` and `/gossip/status` routes. Exactly
like the admin guard (branch 01), it returned `Ok(())` on any debug build when
`DSM_GOSSIP_TOKEN` was unset — silently authorizing unauthenticated gossip.

`/gossip` is not read-only: `gossip_receive` advances the node's global
`current_tick` from the (attacker-controllable) `sender_tick` and feeds the
message into `replication_manager.process_gossip`, which mutates node-state /
failure-detection used by replication placement.

## Evidence

```rust
// src/api/transport/gossip.rs (before)
let expected = env::var(GOSSIP_TOKEN_ENV).unwrap_or_default();
if expected.trim().is_empty() {
    if cfg!(debug_assertions) {
        log::warn!("gossip auth disabled: {} not set (debug build)", GOSSIP_TOKEN_ENV);
        return Ok(());          // <-- fail OPEN on any debug build
    }
    ...
    return Err(StatusCode::UNAUTHORIZED);
}
```

No in-tree test/CI path sets `DSM_GOSSIP_TOKEN` or hits these endpoints.

## Fix

Mirror the admin hardening: fail closed by default; allow only with an explicit
debug opt-in `DSM_INSECURE_ALLOW_NO_GOSSIP_TOKEN=1`.

```rust
const GOSSIP_INSECURE_ENV: &str = "DSM_INSECURE_ALLOW_NO_GOSSIP_TOKEN";

if expected.trim().is_empty() {
    if cfg!(debug_assertions) && env::var(GOSSIP_INSECURE_ENV).as_deref() == Ok("1") {
        log::warn!("gossip auth explicitly disabled via {}=1 (debug build)", GOSSIP_INSECURE_ENV);
        return Ok(());
    }
    log::error!("gossip auth required but {} not set", GOSSIP_TOKEN_ENV);
    return Err(StatusCode::UNAUTHORIZED);
}
```

## Verification

`cargo check` clean. Token comparison path unchanged.

## Related

There is a deeper, separate concern (documented under deferred findings, not
fixed here): `gossip_receive` raising `current_tick` to an unauthenticated
`sender_tick` is a tick-advance vector even with auth on. This PR only closes the
no-auth hole.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
