### PR TITLE
fix(storage-node/device_api): return 404 for unknown device on token reissue

### DIFF
--- a/dsm_storage_node/src/api/identity/device_api.rs
+++ b/dsm_storage_node/src/api/identity/device_api.rs
@@ -35,6 +35,7 @@ pub enum RegisterError {
     InvalidPubkey,
     InvalidGenesisHash,
     DeviceAlreadyExists,
+    DeviceNotFound,
     DatabaseError(String),
 }
 
@@ -49,6 +50,7 @@ impl IntoResponse for RegisterError {
             RegisterError::DeviceAlreadyExists => {
                 (StatusCode::CONFLICT, "Device already registered")
             }
+            RegisterError::DeviceNotFound => (StatusCode::NOT_FOUND, "Device not found"),
             RegisterError::DatabaseError(e) => {
                 log::error!("Database error during device registration: {}", e);
                 (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
@@ -201,7 +203,7 @@ pub async fn reissue_token(
     let (stored_genesis, stored_pubkey) = crate::db::get_device(&state.db_pool, &device_id_b32)
         .await
         .map_err(|e| RegisterError::DatabaseError(e.to_string()))?
-        .ok_or(RegisterError::DeviceAlreadyExists)?;
+        .ok_or(RegisterError::DeviceNotFound)?;
 
     if stored_genesis != req.genesis_hash || stored_pubkey != req.pubkey {
         // Provided identity doesn't match stored device


### PR DESCRIPTION
## Problem

`reissue_token` (`POST /api/v2/device/token`) looks up an existing device to
re-issue its auth token. The not-found case was mapped to the **opposite** error:
a missing device returned HTTP 409 "Device already registered" instead of 404.

## Evidence

```rust
// src/api/identity/device_api.rs (before)
let (stored_genesis, stored_pubkey) = crate::db::get_device(&state.db_pool, &device_id_b32)
    .await
    .map_err(|e| RegisterError::DatabaseError(e.to_string()))?
    .ok_or(RegisterError::DeviceAlreadyExists)?;   // <-- None (not found) -> 409 "already registered"
```

`RegisterError` had no not-found variant; `DeviceAlreadyExists` maps to
`StatusCode::CONFLICT`.

## Impact

A client requesting a token reissue for a device that does not exist receives a
409 "Device already registered" — the inverse of reality, which misleads callers
and any retry/branching logic keyed on status codes. (The register path's
`rows_affected == 0` → `DeviceAlreadyExists` is correct and unchanged.)

## Fix

Add a `DeviceNotFound` variant mapped to 404 and use it for the `None` lookup
result.

```rust
pub enum RegisterError {
    InvalidDeviceId, InvalidPubkey, InvalidGenesisHash,
    DeviceAlreadyExists,
    DeviceNotFound,              // new
    DatabaseError(String),
}
// IntoResponse:
RegisterError::DeviceNotFound => (StatusCode::NOT_FOUND, "Device not found"),
// reissue_token:
    .ok_or(RegisterError::DeviceNotFound)?;
```

The matched/mismatched-identity branches (`InvalidDeviceId` on pubkey/genesis
mismatch) are unchanged.

## Verification

`cargo check` clean.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
