### PR TITLE
fix(sdk/dlv_receipt): align DLV partition id with StorageNodeSDK

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/dlv_receipt_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/dlv_receipt_sdk.rs
@@ -332,9 +332,13 @@ impl DlvReceiptSdk {
     async fn put_object(&self, endpoint: &str, obj_key: &str, body: &[u8]) -> Result<(), DsmError> {
         let url = format!("{}/api/v2/object/put", endpoint.trim_end_matches('/'));
 
-        // Compute DLV partition ID (same pattern as StorageNodeSDK::store_data)
+        // Compute DLV partition ID (same pattern as StorageNodeSDK::store_data).
+        // Must use TAG_DSM_DLV_PARTITION (not the _NUL variant): `domain_hash`
+        // already appends the NUL terminator, so passing the pre-terminated
+        // _NUL tag double-appended `\0` and produced a different partition id
+        // than StorageNodeSDK for the same key.
         let dlv_id = dsm::crypto::blake3::domain_hash(
-            dsm::common::domain_tags::TAG_DSM_DLV_PARTITION_NUL,
+            dsm::common::domain_tags::TAG_DSM_DLV_PARTITION,
             obj_key.as_bytes(),
         );
         let dlv_id_b32 = text_id::encode_base32_crockford(dlv_id.as_bytes());


### PR DESCRIPTION
## Problem

Two SDK code paths derive the `x-dlv-id` storage partition key for the **same**
object key, but using **different hash preimages**, so the same logical object
routes to two different partitions on the storage node.

The DSM hash helpers both append a NUL terminator internally:

```rust
// dsm/src/crypto/blake3.rs
pub fn dsm_domain_hasher(tag: &str) -> Hasher { h.update(tag.as_bytes()); h.update(&[0u8]); h }
pub fn domain_hash(tag: &str, data: &[u8]) -> Hash { let mut h = dsm_domain_hasher(tag); h.update(data); h.finalize() }
```

And there are two tag constants:

```rust
// dsm/src/common/domain_tags/dsm/vault_dbtc.rs
pub const TAG_DSM_DLV_PARTITION:     &str = "DSM/dlv-partition";
pub const TAG_DSM_DLV_PARTITION_NUL: &str = "DSM/dlv-partition\0";
```

- `StorageNodeSDK::store_data` / `delete` (storage_node_sdk.rs:518,649):
  `dsm_domain_hasher(TAG_DSM_DLV_PARTITION)` + key →
  preimage `"DSM/dlv-partition\0" || key` (**one** NUL).
- `dlv_receipt_sdk.rs:336` (`put_object`):
  `domain_hash(TAG_DSM_DLV_PARTITION_NUL, key)` → `domain_hash` appends another NUL →
  preimage `"DSM/dlv-partition\0\0" || key` (**double** NUL).

## Evidence

```rust
// src/sdk/dlv_receipt_sdk.rs (before)
// Compute DLV partition ID (same pattern as StorageNodeSDK::store_data)
let dlv_id = dsm::crypto::blake3::domain_hash(
    dsm::common::domain_tags::TAG_DSM_DLV_PARTITION_NUL,   // <-- pre-terminated tag double-appends \0
    obj_key.as_bytes(),
);
```

The comment explicitly claims parity with `StorageNodeSDK::store_data`, so the
intent was the single-NUL preimage; passing the `_NUL` constant to `domain_hash`
was the bug.

## Impact

DLV receipts written via `dlv_receipt_sdk` land under a partition id that differs
from the one `StorageNodeSDK` computes for the same key, so cross-path
store/retrieve for that key diverge.

## Fix

Use `TAG_DSM_DLV_PARTITION` (single NUL) so both paths produce identical
partition ids.

```rust
let dlv_id = dsm::crypto::blake3::domain_hash(
    dsm::common::domain_tags::TAG_DSM_DLV_PARTITION,
    obj_key.as_bytes(),
);
```

## Verification

`cargo check -p dsm_sdk` clean. (Note: the `_NUL` vs non-`_NUL` tag pair is
itself a footgun; a broader cleanup is noted in the deferred docs, but this PR
just corrects the one mismatched call site.)

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
