### PR TITLE
fix(sdk/wallet): stop returning a simulated constant recovery mnemonic

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/wallet_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/wallet_sdk.rs
@@ -13,7 +13,6 @@ use super::identity_sdk::IdentitySDK;
 use super::storage_sync_sdk::{StorageSyncSdk, WalletDisplayData};
 use super::token_sdk::TokenSDK;
 
-use dsm::crypto;
 use dsm::types::error::DsmError;
 use dsm::types::state_types::State;
 use dsm::types::token_types::{Balance, TokenOperation};
@@ -1066,11 +1065,14 @@ impl WalletSDK {
             ));
         }
         self.update_activity_sync();
-        let _entropy = crypto::generate_nonce_32();
-        let mnemonic = "quantum resist secure wallet phrase post entropy example".to_string();
-        self.config.write().recovery_options.mnemonic = Some(mnemonic.clone());
-        log::info!("Generated recovery mnemonic");
-        Ok(mnemonic)
+        // DSM recovery is recovery-capsule based (see `recovery_sdk` /
+        // `crate::recovery`), not BIP39 mnemonic based. This entry point
+        // previously returned a hardcoded constant phrase that recovered
+        // nothing — a dangerous fake seed. Fail explicitly rather than hand a
+        // caller a worthless "recovery" string.
+        Err(DsmError::invalid_operation(
+            "mnemonic-based recovery is not supported; use recovery capsules (recovery_sdk)",
+        ))
     }
 
     pub fn create_backup(&self, path: &Path) -> Result<(), DsmError> {
@@ -1768,18 +1770,13 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_generate_recovery_mnemonic_and_config() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_generate_recovery_mnemonic_is_unsupported() -> Result<(), Box<dyn std::error::Error>> {
         let wallet = WalletSDK::test_wallet()?;
         wallet.unlock("")?;
-        let mnem = wallet.generate_recovery_mnemonic()?;
-        assert!(mnem.contains("quantum"));
-        let cfg = wallet.config.read();
-        let m = cfg
-            .recovery_options
-            .mnemonic
-            .as_ref()
-            .unwrap_or_else(|| panic!("mnemonic not set"));
-        assert_eq!(m, &mnem);
+        // Mnemonic-based recovery is intentionally unsupported (DSM uses
+        // recovery capsules); the call must fail rather than fabricate a seed.
+        assert!(wallet.generate_recovery_mnemonic().is_err());
+        assert!(wallet.config.read().recovery_options.mnemonic.is_none());
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

`WalletSDK::generate_recovery_mnemonic` generated 32 bytes of entropy, **threw it
away**, and returned a hardcoded English phrase, also storing it as the wallet's
recovery mnemonic. Every wallet got the identical string, and that string
recovers nothing — a fake seed that is actively dangerous for any caller (UI)
that treats the return as a real recovery phrase.

## Evidence

```rust
// src/sdk/wallet_sdk.rs (before)
pub fn generate_recovery_mnemonic(&self) -> Result<String, DsmError> {
    if *self.locked.read() { return Err(DsmError::unauthorized("Wallet is locked", None)); }
    self.update_activity_sync();
    let _entropy = crypto::generate_nonce_32();                       // generated then discarded
    let mnemonic = "quantum resist secure wallet phrase post entropy example".to_string();
    self.config.write().recovery_options.mnemonic = Some(mnemonic.clone());
    Ok(mnemonic)
}
```

Reachability: no production callers — only one unit test
(`test_generate_recovery_mnemonic_and_config`). The `recovery_options.mnemonic`
field it set is not read on any production path. DSM recovery is **recovery-capsule
based** (`recovery_sdk` / `crate::recovery`), not BIP39 mnemonic based.

## Fix

Since the function never worked and mnemonic recovery isn't part of the protocol,
fail explicitly instead of fabricating a seed.

```rust
pub fn generate_recovery_mnemonic(&self) -> Result<String, DsmError> {
    if *self.locked.read() { return Err(DsmError::unauthorized("Wallet is locked", None)); }
    self.update_activity_sync();
    // DSM recovery is recovery-capsule based (recovery_sdk / crate::recovery), not BIP39.
    Err(DsmError::invalid_operation(
        "mnemonic-based recovery is not supported; use recovery capsules (recovery_sdk)",
    ))
}
```

- The unit test was updated to assert the call is unsupported (errors) and that
  no mnemonic is stored.
- Removed the now-unused `use dsm::crypto;` import (other uses were fully
  qualified).

## Verification

`cargo check -p dsm_sdk --tests` clean.

## Notes

If genuine mnemonic recovery is ever wanted, it must be implemented properly
(real BIP39 derivation), not a constant — that would be a feature, not this fix.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
