### PR TITLE
fix(sdk/cdbrw_verifier): always enforce the gamma-distance gate (fail closed)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/security/cdbrw_verifier.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/security/cdbrw_verifier.rs
@@ -159,7 +159,14 @@ pub fn verify_challenge_response_with_keypair(
     }
     distance = distance.sqrt() / 256.0f32;
 
-    if threshold > 0.0f32 && distance > threshold {
+    // Fail closed: always apply the gamma-distance gate. Previously this was
+    // gated on `threshold > 0.0`, so a request carrying epsilon_intra ==
+    // epsilon_inter == 0 (or negative) skipped the anti-clone tolerance check
+    // entirely and accepted any gamma. Since the thresholds are caller-supplied,
+    // that let a caller disable the biometric tolerance dimension by sending
+    // zeros. A non-positive threshold now only admits an exact-match gamma
+    // (distance == 0); a real enrolled epsilon is always > 0.
+    if distance > threshold {
         return Ok(CdbrwVerificationOutcome::rejected(
             "gamma_distance_exceeded",
             distance,


### PR DESCRIPTION
## Problem

`verify_challenge_response_with_keypair` validates a C-DBRW challenge response in
three steps: ephemeral-key match, signature, then a **gamma-distance** check
(the device/environment (C-DBRW) anti-clone tolerance — an attractor-distance
gate, per DSM's DBRW device/environment binding). The distance gate was guarded
by `threshold > 0.0`:

```rust
let threshold = (request.epsilon_intra + request.epsilon_inter) / 2.0f32;
let mut distance = /* euclidean(gamma, enrollment_anchor) / 256 */;
if threshold > 0.0f32 && distance > threshold {      // <-- skipped entirely when threshold <= 0
    return Ok(rejected("gamma_distance_exceeded", ...));
}
Ok(accepted(distance, threshold))
```

`epsilon_intra` / `epsilon_inter` come from the request (caller-supplied;
`misc_routes.rs:706-707`). A caller sending both as `0` (or negative) makes
`threshold <= 0`, so the distance comparison is skipped and **any** gamma is
accepted — disabling the anti-clone tolerance dimension. (The ephemeral-key and
signature checks still bind K_DBRW, so this isn't a full bypass, but the
device/environment anti-clone tolerance is defeatable.)

## Fix

Remove the `threshold > 0.0` short-circuit so the gate always applies (fail
closed). A non-positive threshold then admits only an exact-match gamma
(`distance == 0`); a genuine enrolled epsilon (P95 of Wasserstein-1 distances) is
always strictly positive, so legitimate verification is unaffected.

```rust
// Fail closed: always apply the gamma-distance gate.
if distance > threshold {
    return Ok(rejected("gamma_distance_exceeded", distance, threshold));
}
```

## Verification

`cargo test -p dsm_sdk --lib security::cdbrw_verifier` — all 3 tests pass. The
accept-path test uses `gamma == enrollment_anchor` (distance 0), so `0 > 0` is
false → still accepted; a non-zero distance under a caller-supplied 0 threshold
now correctly rejects.

## Notes

The deeper design concern — that the verifier trusts request-supplied epsilons
rather than the enrolled values — is separate and not addressed here; this PR
removes the fail-open.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
