### PR TITLE
fix(sdk/recovery): verify tombstone signature before acting on it

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/recovery_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/recovery_routes.rs
@@ -693,6 +693,31 @@ impl AppRouterImpl {
                                     let mut sender_arr = [0u8; 32];
                                     sender_arr.copy_from_slice(&sender_device_id_bytes);
 
+                                    // Verify the tombstone signature against the
+                                    // sender's known contact signing key BEFORE acting
+                                    // on it. The notification arrives at a storage key
+                                    // any party can write, so an unverified receipt must
+                                    // never tombstone a device or emit an ACK.
+                                    let sender_pubkey =
+                                        crate::storage::client_db::get_contact_by_device_id(
+                                            &sender_arr,
+                                        )
+                                        .ok()
+                                        .flatten()
+                                        .map(|c| c.public_key)
+                                        .unwrap_or_default();
+                                    if sender_pubkey.is_empty()
+                                        || !dsm::recovery::tombstone::verify_tombstone(
+                                            &receipt,
+                                            &sender_pubkey,
+                                        )
+                                        .unwrap_or(false)
+                                    {
+                                        return err(
+                                            "Tombstone signature verification failed".into()
+                                        );
+                                    }
+
                                     // Store as tombstoned device
                                     let tick = crate::util::deterministic_time::tick();
                                     if let Err(e) =


### PR DESCRIPTION
## Problem

The `recovery.checkTombstones` handler reads a tombstone notification from a
storage key (`BLAKE3("DSM/tombstone-notify\0" || our_device_id)`), parses it, and
then **immediately** stores the sender as a tombstoned device and writes an ACK —
with **no signature verification**. The inline comment claims it "Look[s] up the
sender's public key from contacts," but no such lookup happens.

Anyone who can write that notify storage key can forge a tombstone receipt and
induce the recipient to (a) mark an arbitrary device tombstoned and (b) emit a
signed ACK.

## Evidence

```rust
// src/handlers/recovery_routes.rs (before) — "recovery.checkTombstones"
Ok(receipt) => {
    // Look up the sender's public key from contacts   <-- comment only; no lookup
    let sender_device_id_bytes = decode_base32_crockford(&receipt.device_id).unwrap_or_default();
    if sender_device_id_bytes.len() == 32 {
        let mut sender_arr = [0u8; 32]; sender_arr.copy_from_slice(&sender_device_id_bytes);
        // Store as tombstoned device  <-- acts immediately, no signature check
        store_tombstoned_device(&sender_arr, &receipt.tombstone_hash, tick) ...
        // write ACK ...
    }
}
```

The verification primitive already exists:
`dsm::recovery::tombstone::verify_tombstone(receipt, public_key)` rebinds
`tombstone_hash == compute_hash()` and then checks the SPHINCS+ signature.
Contact signing keys are available via
`storage::client_db::get_contact_by_device_id(..) -> ContactRecord { public_key, .. }`.

## Fix

Look up the sender's contact signing key and require `verify_tombstone` to
succeed before storing the tombstone or emitting the ACK. Unknown contact /
missing key / bad signature now returns an error.

```rust
let sender_pubkey = crate::storage::client_db::get_contact_by_device_id(&sender_arr)
    .ok().flatten().map(|c| c.public_key).unwrap_or_default();
if sender_pubkey.is_empty()
    || !dsm::recovery::tombstone::verify_tombstone(&receipt, &sender_pubkey).unwrap_or(false)
{
    return err("Tombstone signature verification failed".into());
}
// ... only now store_tombstoned_device + write ACK
```

## Verification

`cargo check -p dsm_sdk` clean. `verify_tombstone` was confirmed to rebind the
hash (`tombstone_hash != compute_hash()` → false) before signature check, so the
gate also rejects a receipt whose signed `tombstone_hash` doesn't match its
fields.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
