### PR TITLE
fix(core/merkle): reject over-long SMT inclusion proofs (panic/DoS)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/merkle/sparse_merkle_tree.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/merkle/sparse_merkle_tree.rs
@@ -331,6 +331,14 @@ impl SparseMerkleTree {
             None => return false,
         };
 
+        // The SMT is fixed-depth (256 levels), so a valid inclusion proof has at
+        // most 256 siblings. Reject longer proofs up front: otherwise `255 - i`
+        // underflows at i == 256 (debug panic; release wraparound → out-of-bounds
+        // `get_bit` panic), turning an over-long peer-supplied proof into a crash.
+        if proof.siblings.len() > 256 {
+            return false;
+        }
+
         let mut current_hash = hash_smt_leaf(&value);
 
         // Siblings are leaf-to-root order: sibling[0] is at the deepest level (255),


### PR DESCRIPTION
## Problem

`SparseMerkleTree::verify_proof_against_root` folds the proof's siblings from leaf
to root, computing the tree level as `255 - i`:

```rust
// src/merkle/sparse_merkle_tree.rs (before)
for (i, sibling) in proof.siblings.iter().enumerate() {
    let level = 255 - i;                      // <-- underflows when i >= 256
    let bit = get_bit(&proof.key, level);
    ...
}
```

There is no bound on `proof.siblings.len()`. For a peer-supplied proof with more
than 256 siblings, at `i == 256` the expression `255 - i` underflows `usize`
(panic in debug; in release it wraps to a huge value and the subsequent
`get_bit` indexes out of bounds → panic). This is reachable from the BLE
acceptance path: `receipts::deserialize_inclusion_proof` decodes a `u32` sibling
count with no `<= 256` cap and feeds the result here.

## Impact

A malicious peer can crash the verifier (and thus the receiving node/handler)
with a single oversized inclusion proof.

## Fix

The SMT is fixed-depth (256 levels), so a valid inclusion proof has at most 256
siblings. Reject longer proofs before the fold.

```rust
if proof.siblings.len() > 256 {
    return false;
}
```

## Verification

`cargo check -p dsm` clean. Well-formed 256-sibling proofs are unaffected; only
over-long proofs (which could never be valid anyway) are now rejected instead of
panicking.

## Notes

The sibling-cap divergence between the struct's own `from_bytes` and
`receipts::deserialize_inclusion_proof` (two byte-identical decoders) is noted in
the audit; consolidating them is a separate cleanup.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
