### PR TITLE
fix(core/verification): bound device-tree path_bits_len and fail closed on Absent SMT proof

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/verification/proof_primitives.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/verification/proof_primitives.rs
@@ -129,9 +129,11 @@ pub fn verify_smt_inclusion_proof_bytes(
         return Ok(false);
     }
 
-    // Require an existing leaf with matching key/value.
+    // Require an existing leaf with matching key/value. This is an INCLUSION
+    // verifier, so a non-inclusion (`Absent`) witness must fail closed —
+    // previously the `Absent` arm returned `true`, accepting an absence proof
+    // as if it proved inclusion of the caller-supplied value.
     let leaf_ok = match &proof.v_path {
-        Some(pb::smt_proof::VPath::Absent(_)) => true,
         Some(pb::smt_proof::VPath::ExistingLeaf(l)) => {
             l.key.len() == 32
                 && l.value.len() == 32
@@ -211,6 +213,16 @@ pub fn verify_device_tree_inclusion_proof_bytes(
         let mut arr = [0u8; 32];
         arr.copy_from_slice(s);
         siblings.push(arr);
+    }
+
+    // `path_bits_len` is an attacker-controlled u32 decoded from protobuf and is
+    // independent of the `MAX_PROOF_BYTES` byte cap (which only bounds the packed
+    // bytes). The canonical device-tree proof carries exactly one path bit per
+    // sibling level, so enforce that invariant before allocating/iterating —
+    // otherwise a tiny proof declaring `path_bits_len = u32::MAX` drives a
+    // multi-billion-entry `Vec::with_capacity` + loop (memory/CPU DoS).
+    if proof.path_bits_len as usize != proof.siblings.len() {
+        return Ok(false);
     }
 
     // Unpack LSB-first bitfield.


### PR DESCRIPTION
## Finding 1 — device-tree `path_bits_len` DoS

`verify_device_tree_inclusion_proof_bytes` unpacks a bitfield whose length is an
attacker-controlled `u32` decoded from protobuf, independent of the
`MAX_PROOF_BYTES` (64 KiB) cap which only bounds the *packed bytes*:

```rust
// (before)
let mut path_bits = Vec::with_capacity(proof.path_bits_len as usize);   // up to ~4.3 billion
let bit_len = proof.path_bits_len as usize;
for i in 0..bit_len { path_bits.push(/* bit from packed.get(i/8) */); }
```

A tiny proof declaring `path_bits_len = u32::MAX` drives a multi-billion-entry
allocation + loop (memory/CPU DoS). The canonical device-tree proof carries
exactly one path bit per sibling level, so enforce that invariant first:

```rust
if proof.path_bits_len as usize != proof.siblings.len() {
    return Ok(false);
}
```

This bounds `path_bits_len` to `siblings.len()`, which is bounded by the byte cap.
The encoder (`common/device_tree.rs`) already sets `path_bits_len == path_bits.len()
== siblings.len()` for valid proofs.

## Finding 2 — SMT inclusion verifier accepted an absence witness

`verify_smt_inclusion_proof_bytes` is an **inclusion** verifier (comment: "Require
an existing leaf with matching key/value"), but the `Absent` arm returned
`leaf_ok = true`:

```rust
// (before)
let leaf_ok = match &proof.v_path {
    Some(pb::smt_proof::VPath::Absent(_)) => true,                 // <-- non-inclusion accepted
    Some(pb::smt_proof::VPath::ExistingLeaf(l)) => { l.key == ... && l.value == ... }
    _ => false,
};
```

A non-inclusion (absence) witness was treated as if it proved inclusion of the
caller-supplied `value`. (The subsequent recomputed-root check makes a successful
forge cryptographically hard, but the variant semantics are inverted and it
should fail closed.) Fix: drop the `Absent` arm so it falls through to `false`;
only an `ExistingLeaf` with matching key/value is accepted.

## Verification

`cargo test -p dsm --lib verification::proof_primitives` passes. No
test/encoder produced an `Absent` proof for this verifier, and the device-tree
encoder sets `path_bits_len == siblings.len()`, so legitimate proofs are
unaffected.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
