### PR TITLE
fix(core/bitcoin): reject SPV proofs with unconsumed leaf-index bits

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/bitcoin/spv.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/bitcoin/spv.rs
@@ -120,7 +120,12 @@ pub fn verify_spv_proof(txid: &[u8; 32], merkle_root: &[u8; 32], proof: &SpvProo
         idx >>= 1;
     }
 
-    current == *merkle_root
+    // After folding `siblings.len()` levels, every bit of the leaf index must
+    // have been consumed. If high bits remain, the index addresses a deeper
+    // tree than the proof provides — reject rather than silently dropping them
+    // (otherwise index `i` and `i + (1 << siblings.len())` verify identically,
+    // a proof-malleability hole).
+    current == *merkle_root && idx == 0
 }
 
 /// Extract the Merkle root from a raw 80-byte Bitcoin block header.


### PR DESCRIPTION
## Problem

`verify_spv_proof` walks the Merkle siblings, consuming one bit of the leaf
`index` per level via `idx >>= 1`, but never checks that all index bits were
consumed:

```rust
// src/bitcoin/spv.rs (before)
let mut idx = proof.index;
for sibling in &proof.siblings {
    if idx & 1 == 0 { current = merkle_parent(&current, sibling); }
    else            { current = merkle_parent(sibling, &current); }
    idx >>= 1;
}
current == *merkle_root          // <-- leftover high bits of idx ignored
```

After folding `siblings.len()` levels, any high bits remaining in `idx` are
silently discarded. So leaf index `i` and `i + (1 << siblings.len())` produce the
same fold and verify against the same root — **proof malleability** (multiple
distinct `index` values accepted for one proof). This contradicts the
canonical-encoding hardening already applied to `SpvProof::from_bytes` (issue
#181 Finding 3), which rejects trailing garbage for exactly this reason.

## Fix

Require `idx == 0` after the fold, so the index must address exactly the tree
depth the proof provides.

```rust
// After folding siblings.len() levels, every index bit must be consumed.
current == *merkle_root && idx == 0
```

A valid Merkle proof's leaf index is `< 2^depth` where `depth == siblings.len()`,
so `idx` shifts down to 0 — legitimate proofs pass. The single-tx (empty
siblings) case correctly requires `index == 0`.

## Verification

`cargo test -p dsm --lib bitcoin::spv` — all 5 tests pass (single-tx, two-tx,
roundtrip, trailing-garbage rejection, header extraction).

## Notes

A related, separate observation (not fixed here): `verify_spv_proof` has no
guard against an interior 64-byte node being passed as a "txid"; in practice the
consumer (`limbo_vault`) independently deserializes the raw tx, so it's covered
there. Left as-is to avoid changing accept behavior.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
