### PR TITLE
fix(sdk/smart_commitment): use matching domain tag in verify_commitment

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/smart_commitment_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/smart_commitment_sdk.rs
@@ -282,8 +282,11 @@ impl SmartCommitmentSDK {
                 condition,
                 oracle_id,
             } => {
-                let mut h =
-                    dsm_domain_hasher(dsm::common::domain_tags::TAG_DSM_SMART_COMMIT_CONDITION);
+                // Must match the domain tag used by `create_conditional_commitment`
+                // (TAG_DSM_SMART_COMMIT_HASH). Recomputing under a different tag
+                // (_CONDITION) made `verify_commitment` always return false for a
+                // commitment this SDK produced.
+                let mut h = dsm_domain_hasher(dsm::common::domain_tags::TAG_DSM_SMART_COMMIT_HASH);
                 h.update(&current_state.hash);
                 h.update(commitment.recipient.as_bytes());
                 h.update(&commitment.amount.to_le_bytes());


### PR DESCRIPTION
## Problem

`create_conditional_commitment` and `verify_commitment` hash the **same
preimage** but under **different domain tags**, so `verify_commitment` can never
validate a commitment that this SDK produced.

```rust
// create_conditional_commitment
let mut hasher = dsm_domain_hasher(TAG_DSM_SMART_COMMIT_HASH);      // "DSM/smart-commit-hash"
hasher.update(&current_state.hash); ... // state.hash ‖ recipient ‖ amount_le ‖ "if" ‖ condition ‖ oracle_id

// verify_commitment
let mut h = dsm_domain_hasher(TAG_DSM_SMART_COMMIT_CONDITION);      // "DSM/smart-commit-condition"
h.update(&current_state.hash); ... // identical preimage
Ok(calculated == commitment.commitment_hash)
```

The only difference between produce and verify is the domain tag. Because BLAKE3
is domain-separated, `calculated` never equals the stored `commitment_hash`, so
`verify_commitment` always returns `Ok(false)`.

## Fix

Recompute under the producer's tag, `TAG_DSM_SMART_COMMIT_HASH`.

```rust
let mut h = dsm_domain_hasher(dsm::common::domain_tags::TAG_DSM_SMART_COMMIT_HASH);
```

## Verification

`cargo check -p dsm_sdk` clean. Preimages are byte-identical between the two
functions (state hash, recipient, amount LE, `"if"`, condition, oracle id), so
matching the tag makes verify succeed for genuine commitments.

## Notes

The audit found this SDK's broader surface (`verify`, registry, etc.) has limited
in-tree production use, but the create/verify tag mismatch is a clear correctness
bug regardless and the fix makes the API self-consistent.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
