### PR TITLE
fix(sdk/policy_cache): remove no-op background refresh (lost writes + NaN)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/policy_cache.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/policy_cache.rs
@@ -152,34 +152,17 @@ impl TokenPolicyCache {
                         stats.hits += 1;
                     }
 
-                    // Check if we should refresh in the background (close to expiration)
-                    if self.config.auto_refresh {
-                        let ttl_remaining = entry.expires_at.saturating_sub(now);
-                        let total_ttl = entry.expires_at.saturating_sub(entry.cached_at);
-                        let ttl_percentage = ttl_remaining as f32 / total_ttl as f32;
-
-                        if ttl_percentage <= self.config.refresh_threshold {
-                            // Clone what we need for background refresh
-                            let policy_id = policy_id.to_string();
-                            let self_clone = Arc::new(self.clone());
-
-                            // Spawn background refresh
-                            tokio::spawn(async move {
-                                if let Ok(fresh_policy) =
-                                    self_clone.fetch_policy_from_network(&policy_id).await
-                                {
-                                    let _ =
-                                        self_clone.update_cached_policy(&policy_id, fresh_policy);
-
-                                    // Update refresh stats
-                                    {
-                                        let mut stats = self_clone.stats.write();
-                                        stats.refreshes += 1;
-                                    }
-                                }
-                            });
-                        }
-                    }
+                    // NOTE: proactive background refresh-near-expiry is intentionally
+                    // not performed here. The previous implementation spawned a task
+                    // over `Arc::new(self.clone())`, but `Clone` deliberately yields a
+                    // fresh, empty cache (see `cache_clone_has_fresh_cache`), so the
+                    // refreshed policy was written into a throwaway clone and never
+                    // reached this shared cache — a pure no-op that also burned a
+                    // network fetch and (when `default_ttl == 0`) computed a NaN
+                    // refresh ratio. Policies are refreshed lazily on expiry via the
+                    // miss path below. A correct proactive refresh would require
+                    // sharing the cache behind an `Arc` without changing clone
+                    // semantics; that is a separate change.
 
                     // Return cached policy
                     return Ok(PolicyResponse {


### PR DESCRIPTION
## Problem

`TokenPolicyCache::get_policy` attempted a proactive "background refresh" when a
cached entry neared expiry. It spawned a task over `Arc::new(self.clone())` and
wrote the refreshed policy into that clone:

```rust
// (before)
if self.config.auto_refresh {
    let ttl_remaining = entry.expires_at.saturating_sub(now);
    let total_ttl = entry.expires_at.saturating_sub(entry.cached_at);
    let ttl_percentage = ttl_remaining as f32 / total_ttl as f32;     // NaN when total_ttl == 0
    if ttl_percentage <= self.config.refresh_threshold {
        let self_clone = Arc::new(self.clone());
        tokio::spawn(async move {
            if let Ok(fresh) = self_clone.fetch_policy_from_network(&policy_id).await {
                let _ = self_clone.update_cached_policy(&policy_id, fresh);  // writes to throwaway clone
                self_clone.stats.write().refreshes += 1;                    // also discarded
            }
        });
    }
}
```

`TokenPolicyCache::Clone` **deliberately** yields a fresh, empty cache (there is
an explicit test, `cache_clone_has_fresh_cache`, asserting this). So the spawned
task refreshes into a clone whose cache is then dropped — the refreshed policy
**never reaches the shared cache**. Net effects:
- A pure no-op for the cache (refresh result is lost), yet it still performs a
  network fetch and a task spawn each time.
- A `NaN` ratio when `default_ttl == 0` (`x / 0.0`); `NaN <= threshold` is false,
  so it silently never fires anyway.

## Fix

Remove the dead refresh block. Policies refresh **lazily on expiry** via the
existing miss path (which already fetches and inserts into the real cache). This
also removes the wasted fetch/spawn and the NaN computation. (Note: `now` / the
TTL fields here are deterministic `dt::tick()` counters, not wall-clock, so this
stays within DSM's clockless rule — no protocol timestamps are involved.)

A correct *proactive* refresh would require sharing the cache behind an `Arc`
without breaking the documented "fresh cache on clone" invariant — that's a
separate change, noted in the deferred dead-code/refactor backlog.

## Verification

`cargo check -p dsm_sdk` clean (no unused `Arc`/method warnings — those symbols
are used elsewhere). The `cache_clone_has_fresh_cache` invariant is preserved.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
