### PR TITLE
fix(sdk/jni): stop double-0x03-framing bitcoin swap responses

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
@@ -4989,10 +4989,10 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_bitcoinSwapIn
 
             match process_envelope_v3(&env_bytes) {
                 Ok(resp) => {
-                    let mut out = Vec::with_capacity(1 + resp.len());
-                    out.push(0x03);
-                    out.extend_from_slice(&resp);
-                    env.byte_array_from_slice(&out)
+                    // `process_envelope_v3` already returns a 0x03-framed
+                    // FramedEnvelopeV3 (see `processEnvelopeV3`, which returns it
+                    // unmodified). Do not prepend a second framing byte.
+                    env.byte_array_from_slice(&resp)
                         .map(|a| a.into_raw())
                         .unwrap_or_else(|_| empty_byte_array_or_empty(&env).into_raw())
                 }
@@ -5073,10 +5073,10 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_bitcoinSwapCo
 
             match process_envelope_v3(&env_bytes) {
                 Ok(resp) => {
-                    let mut out = Vec::with_capacity(1 + resp.len());
-                    out.push(0x03);
-                    out.extend_from_slice(&resp);
-                    env.byte_array_from_slice(&out)
+                    // `process_envelope_v3` already returns a 0x03-framed
+                    // FramedEnvelopeV3 (see `processEnvelopeV3`, which returns it
+                    // unmodified). Do not prepend a second framing byte.
+                    env.byte_array_from_slice(&resp)
                         .map(|a| a.into_raw())
                         .unwrap_or_else(|_| empty_byte_array_or_empty(&env).into_raw())
                 }
@@ -5157,10 +5157,10 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_bitcoinSwapRe
 
             match process_envelope_v3(&env_bytes) {
                 Ok(resp) => {
-                    let mut out = Vec::with_capacity(1 + resp.len());
-                    out.push(0x03);
-                    out.extend_from_slice(&resp);
-                    env.byte_array_from_slice(&out)
+                    // `process_envelope_v3` already returns a 0x03-framed
+                    // FramedEnvelopeV3 (see `processEnvelopeV3`, which returns it
+                    // unmodified). Do not prepend a second framing byte.
+                    env.byte_array_from_slice(&resp)
                         .map(|a| a.into_raw())
                         .unwrap_or_else(|_| empty_byte_array_or_empty(&env).into_raw())
                 }
@@ -5241,10 +5241,10 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_bitcoinSwapSt
 
             match process_envelope_v3(&env_bytes) {
                 Ok(resp) => {
-                    let mut out = Vec::with_capacity(1 + resp.len());
-                    out.push(0x03);
-                    out.extend_from_slice(&resp);
-                    env.byte_array_from_slice(&out)
+                    // `process_envelope_v3` already returns a 0x03-framed
+                    // FramedEnvelopeV3 (see `processEnvelopeV3`, which returns it
+                    // unmodified). Do not prepend a second framing byte.
+                    env.byte_array_from_slice(&resp)
                         .map(|a| a.into_raw())
                         .unwrap_or_else(|_| empty_byte_array_or_empty(&env).into_raw())
                 }


### PR DESCRIPTION
## Problem

The DSM Envelope wire format is `0x03`-framed (one leading framing byte). The
internal helper `process_envelope_v3` already returns a **fully framed**
FramedEnvelopeV3 — the canonical JNI export `processEnvelopeV3` returns its result
unmodified:

```rust
let resp = process_envelope_v3(&req)?;
env.byte_array_from_slice(&resp)...   // returned as-is (already framed)
```

But the four bitcoin-swap JNI exports prepended a **second** `0x03`:

```rust
// bitcoinSwapInitiate / bitcoinSwapComplete / bitcoinSwapRefund / bitcoinSwapStatus (before)
match process_envelope_v3(&env_bytes) {
    Ok(resp) => {
        let mut out = Vec::with_capacity(1 + resp.len());
        out.push(0x03);                 // <-- second framing byte
        out.extend_from_slice(&resp);   // resp already starts with 0x03
        env.byte_array_from_slice(&out) ...
    }
    ...
}
```

producing `[0x03][0x03][Envelope]`, which `decodeFramedEnvelopeV3` on the Kotlin
side cannot parse.

## Fix

Return `resp` directly (matching every other envelope JNI handler). Applied to
all four handlers:

```rust
// `process_envelope_v3` already returns a 0x03-framed FramedEnvelopeV3
// (see `processEnvelopeV3`, which returns it unmodified). Don't re-frame.
env.byte_array_from_slice(&resp)
```

## Verification

Cannot `cargo check` on this Linux host (android+jni cfg-gated). The edit is a
pure deletion of the extra-framing prelude in 4 identical blocks; `grep` confirms
zero remaining `Vec::with_capacity(1 + resp.len())` sites afterward. **Reviewer
must build the Android target to compile-verify.**

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
