### PR TITLE
docs(storage-node): fix stale comments (doc drift)

### DIFF
--- a/dsm_storage_node/src/api/registry/core.rs
+++ b/dsm_storage_node/src/api/registry/core.rs
@@ -99,7 +99,7 @@ pub async fn publish_evidence(
 
     // Persist to registry_evidence table. Accept optional headers:
     // - X-DSM-KIND: integer kind code
-    // - X-DSM-DLV-ID: hex-encoded DLV id
+    // - X-DSM-DLV-ID: Base32 Crockford DLV id (no hex; decoded by parse_optional_dlv_id)
     let kind_code: i16 = headers
         .get("X-DSM-KIND")
         .and_then(|v| v.to_str().ok())

--- a/dsm_storage_node/src/main.rs
+++ b/dsm_storage_node/src/main.rs
@@ -5,7 +5,8 @@
 //! Index-only, clockless, signature-free storage node for the DSM network.
 //! Serves protobuf-only HTTP/2 endpoints for genesis anchoring, ByteCommit
 //! mirroring, DLV slot management, unilateral b0x transport, and inter-node
-//! replication. Parameters: N=6, K=3, U_up=0.85, U_down=0.35.
+//! replication. (Capacity/scaling parameters are configured at runtime via the
+//! `[replication]` config section and `ReplicationConfig`, not hardcoded here.)
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;

--- a/dsm_storage_node/src/timing.rs
+++ b/dsm_storage_node/src/timing.rs
@@ -44,7 +44,7 @@ impl ExponentialBackoffTiming {
         }
     }
 
-    /// Calculate exponential backoff delay (replaces bitwise shift logic)
+    /// Calculate exponential backoff delay.
     fn calculate_backoff_delay(&self, attempts: i32) -> i64 {
         if attempts <= 0 {
             return 0;


### PR DESCRIPTION
## Problem & fix (3 comment corrections)

1. `src/api/registry/core.rs` — comment said
   `// - X-DSM-DLV-ID: hex-encoded DLV id`, but the value is decoded via
   `parse_optional_dlv_id` as **Base32 Crockford** (the crate bans hex). Reworded
   to "Base32 Crockford DLV id (no hex; decoded by parse_optional_dlv_id)".

2. `src/main.rs` — module doc asserted
   `Parameters: N=6, K=3, U_up=0.85, U_down=0.35`. These values appear nowhere in
   the code; capacity/scaling parameters are runtime config (`[replication]` /
   `ReplicationConfig`). Reworded to say so rather than assert hardcoded numbers.

3. `src/timing.rs` — dropped the stale historical note
   `/// Calculate exponential backoff delay (replaces bitwise shift logic)` →
   `/// Calculate exponential backoff delay.`

## Verification

`cargo check` clean (comments only).

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
