### PR TITLE
docs(core): fix stale comments (doc drift)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/crypto/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/crypto/mod.rs
@@ -14,7 +14,6 @@
 //! | AES-256-GCM | [`aead`] | Symmetric authenticated encryption |
 //! | Salted-BLAKE3 commitments | [`blake3`] (`dsm_domain_hasher`) | Hiding + binding via `BLAKE3("DSM/<purpose>\0" \|\| blinding \|\| value)` (e.g. `dlv_content_commitment` in `vault::limbo_vault`) |
 //! | C-DBRW | [`cdbrw_binding`] | Challenge-seeded DBRW anti-cloning (post-quantum) |
-//! | ChaCha20-Poly1305 / AES-256-GCM | [`aead`] | Authenticated symmetric encryption |
 //!
 //! # Removed: classical group-based commitment module
 //!

--- a/dsm_client/deterministic_state_machine/dsm/src/emissions/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/emissions/mod.rs
@@ -170,7 +170,7 @@ impl EmissionWitness {
 #[derive(Clone, Debug)]
 pub struct JoinActivationProof {
     pub id: [u8; 32],
-    pub gate_proof: Vec<u8>, // Kept as-is; verification lives outside this module today.
+    pub gate_proof: Vec<u8>, // Verified in-module by `verify_emission` via `paidk_proof::verify_paidk_gate_proof`.
     pub nonce: [u8; 32],
 }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/types/error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/error.rs
@@ -994,10 +994,13 @@ impl DsmError {
         DsmError::LockError
     }
 
-    /// Creates a new timeout error
+    /// Creates a new time-related error (used for timeout/clock failures).
+    ///
+    /// Note: returns `DsmError::TimeError`, not the `DsmError::Timeout` variant
+    /// (which is never constructed).
     ///
     /// # Arguments
-    /// * `message` - Description of the timeout error
+    /// * `message` - Description of the error
     pub fn timeout(message: impl Into<String>) -> Self {
         DsmError::TimeError(message.into())
     }


### PR DESCRIPTION
## Problem & fix (3 comment corrections)

1. `src/crypto/mod.rs` — the module-doc primitive table had a row claiming a
   `ChaCha20-Poly1305 / AES-256-GCM | [aead]` AEAD. `aead` implements **only**
   `Aes256Gcm` (`aes_encrypt`/`aes_decrypt`); no ChaCha20-Poly1305 exists, and
   AES-256-GCM is already listed on its own row. Removed the false/duplicate row.

2. `src/types/error.rs` — `timeout()` doc said "Creates a new timeout error", but
   the body returns `DsmError::TimeError`, **not** the (never-constructed)
   `DsmError::Timeout` variant. Updated the doc to state it returns `TimeError`.

3. `src/emissions/mod.rs` — `JoinActivationProof.gate_proof` comment said
   "verification lives outside this module today", but `verify_emission` now
   verifies it in-module via `paidk_proof::verify_paidk_gate_proof`. Updated the
   comment to reflect that.

## Verification

`cargo check -p dsm` clean (comments only).

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
