### PR TITLE
docs(sdk): fix stale comments / misleading names (doc drift)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/dlv_receipt_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/dlv_receipt_sdk.rs
@@ -6,7 +6,8 @@
 //! content-addressed data). No dedicated `/api/v2/dlv/receipt` endpoint required.
 //!
 //! - CircuitBreaker for node health
-//! - Quorum writes (K healthy nodes)
+//! - Best-effort writes to healthy nodes (any single success is accepted; no
+//!   K-of-N quorum is enforced — `submit_receipt` succeeds on `success_count > 0`)
 //! - Local SQLite persistence as primary + remote storage as redundant copies
 
 use dsm::types::error::DsmError;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/storage_sync_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/storage_sync_sdk.rs
@@ -131,10 +131,10 @@ impl StorageSyncSdk {
 
         // Replay guard header required by storage-node middleware
         // Canonical: base32 Crockford (0-9,A-H,J-K,M-N,P-T,V-Z with substitutions)
-        let msg_id_hex = crate::util::text_id::encode_base32_crockford(&env.message_id);
+        let msg_id_b32 = crate::util::text_id::encode_base32_crockford(&env.message_id);
         headers.insert(
             HeaderName::from_static("x-dsm-message-id"),
-            HeaderValue::from_str(&msg_id_hex).context("x-dsm-message-id header")?,
+            HeaderValue::from_str(&msg_id_b32).context("x-dsm-message-id header")?,
         );
 
         // Provide recipient routing key: base32 device_id from envelope headers.

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/wallet_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/wallet_sdk.rs
@@ -782,7 +782,6 @@ impl WalletSDK {
         })
     }
 
-    /// Return the canonical C-DBRW-derived signing keypair used by wallet operations.
     /// Return the local Kyber/ML-KEM public key used for vault content encryption.
     pub fn get_kyber_public_key(&self) -> Result<Vec<u8>, DsmError> {
         if *self.locked.read() {


### PR DESCRIPTION
## Problem & fix (3 corrections)

1. `src/sdk/wallet_sdk.rs` — `get_kyber_public_key` had a stray duplicate doc line
   ("Return the canonical C-DBRW-derived signing keypair used by wallet
   operations.") left over from another method, above the correct line. The
   function returns the Kyber/ML-KEM public key. Removed the stray line.

2. `src/sdk/dlv_receipt_sdk.rs` — module doc claimed "Quorum writes (K healthy
   nodes)", but `submit_receipt` accepts any `success_count > 0` and enforces no
   K-of-N quorum. Reworded to "best-effort writes to healthy nodes (any single
   success is accepted; no K-of-N quorum is enforced)".

3. `src/sdk/storage_sync_sdk.rs` — renamed the local `msg_id_hex` →
   `msg_id_b32`; the value is Base32 Crockford (`encode_base32_crockford`), not
   hex (the adjacent comment already said so). Local rename, two lines.

## Verification

`cargo check -p dsm_sdk` clean.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
