### PR TITLE
test(sdk): serialize bilateral_impl tests to fix flaky shared-DB races

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_impl.rs
@@ -605,6 +605,7 @@ mod tests {
     // ── prepare ──────────────────────────────────────────────────────────
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn prepare_rejects_invalid_protobuf() {
         let bi = BiImpl {
             _config: test_config(),
@@ -624,6 +625,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn prepare_rejects_empty_operation_data() {
         let req = pb::BilateralPrepareRequest {
             operation_data: vec![],
@@ -647,6 +649,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn prepare_non_android_computes_commitment() {
         // Initialize global storage dir required by AppState::get_public_key()
         let tmp = std::env::temp_dir().join("dsm_test_bilateral_prepare");
@@ -690,6 +693,7 @@ mod tests {
     // ── accept ───────────────────────────────────────────────────────────
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn accept_rejects_invalid_protobuf() {
         let bi = BiImpl {
             _config: test_config(),
@@ -709,6 +713,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn accept_rejects_missing_commitment_hash() {
         let req = pb::BilateralAcceptRequest {
             commitment_hash: None,
@@ -732,6 +737,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn accept_rejects_wrong_size_commitment_hash() {
         let req = pb::BilateralAcceptRequest {
             commitment_hash: Some(make_hash32(&[0xAA; 16])), // 16 bytes, not 32
@@ -755,6 +761,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn accept_returns_disabled_for_valid_input() {
         let req = pb::BilateralAcceptRequest {
             commitment_hash: Some(valid_hash32()),
@@ -780,6 +787,7 @@ mod tests {
     // ── commit ───────────────────────────────────────────────────────────
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn commit_rejects_invalid_protobuf() {
         let bi = BiImpl {
             _config: test_config(),
@@ -799,6 +807,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn commit_rejects_bad_counterparty_device_id_length() {
         let req = pb::BilateralCommitRequest {
             counterparty_device_id: vec![0u8; 16],
@@ -825,6 +834,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn commit_rejects_missing_commitment_hash() {
         let req = pb::BilateralCommitRequest {
             counterparty_device_id: vec![1u8; 32],
@@ -851,6 +861,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn commit_rejects_missing_local_signature() {
         let req = pb::BilateralCommitRequest {
             counterparty_device_id: vec![1u8; 32],
@@ -877,6 +888,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn commit_rejects_missing_counterparty_sig() {
         let req = pb::BilateralCommitRequest {
             counterparty_device_id: vec![1u8; 32],
@@ -903,6 +915,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn commit_returns_disabled_for_valid_input() {
         let req = pb::BilateralCommitRequest {
             counterparty_device_id: vec![1u8; 32],
@@ -931,6 +944,7 @@ mod tests {
     // ── transfer ─────────────────────────────────────────────────────────
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn transfer_rejects_invalid_protobuf() {
         let bi = BiImpl {
             _config: test_config(),
@@ -950,6 +964,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn transfer_rejects_bad_counterparty_device_id() {
         let req = pb::BilateralTransferRequest {
             counterparty_device_id: vec![0u8; 10],
@@ -978,6 +993,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn transfer_rejects_zero_amount() {
         let req = pb::BilateralTransferRequest {
             counterparty_device_id: vec![1u8; 32],
@@ -1006,6 +1022,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn transfer_rejects_missing_genesis_hash() {
         let req = pb::BilateralTransferRequest {
             counterparty_device_id: vec![1u8; 32],
@@ -1034,6 +1051,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn transfer_returns_disabled_for_fully_valid_input() {
         let req = pb::BilateralTransferRequest {
             counterparty_device_id: vec![1u8; 32],
@@ -1064,6 +1082,7 @@ mod tests {
     // ── get_pending_transactions ─────────────────────────────────────────
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn get_pending_transactions_returns_empty() {
         let bi = BiImpl {
             _config: test_config(),


### PR DESCRIPTION
## Problem

The pre-push hook runs the full workspace test suite. It intermittently failed
on:
```
sdk::wallet_sdk::tests::test_initialize_bilateral_chain_with_empty_initial_hash_uses_zero_state
```
That test passes in isolation, so it is flaky under the **full parallel** run —
not a real regression, and unrelated to any audit branch (the canary branch
that triggered it doesn't touch `wallet_sdk`).

## Root cause

All SDK tests share **process-global** state:
- `storage_utils::STORAGE_BASE_DIR` is a write-once `OnceLock<PathBuf>` — the
  first test to set it wins, and every test in the process then uses that one
  on-disk SQLite client DB.
- `AppState` is a global singleton (`reset_memory_for_testing` /
  `set_identity_info`).

Tests that touch these are marked `#[serial]` to avoid races — **but
`handlers/bilateral_impl.rs` had 19 `#[tokio::test]`s with no `#[serial]`**.
They build `BiImpl`, call `set_storage_base_dir`, and read global `AppState`, so
they ran concurrently against the shared SQLite DB. When one overlapped the
(serial) wallet test, DB contention surfaced as a `?`-propagated error and the
wallet test was reported as failed.

## Fix

Add `#[serial_test::serial]` to all 19 tests in `bilateral_impl.rs`, putting them
in the same default serial mutual-exclusion group as the wallet / AppState / DB
tests. Fully-qualified form (no new `use`), matching the 45 existing
`#[serial_test::serial]` annotations in the crate.

```rust
#[tokio::test]
#[serial_test::serial]   // added to each of the 19 tests
async fn prepare_rejects_invalid_protobuf() { ... }
```

## Verification

`cargo test -p dsm_sdk --lib` run three consecutive times, each:
`test result: ok. 1506 passed; 0 failed; 7 ignored`.

## Notes

This is a pre-existing `main` issue surfaced while preparing to push the audit
branches — it is its own fix, independent of the audit findings. The lighter
`storage_utils.rs` OnceLock tests were left as-is (they don't drive the shared
SQLite DB); if further flakiness appears they can be serialized the same way.

## CI gates & coverage

Full verification for this PR runs in CI — **Rust** (`cargo fmt --check`,
`clippy -D warnings`, workspace tests), **Frontend**, **Android Unit Tests**,
**Coverage**, **SPDX headers**, **CodeQL** (see the PR's Checks tab). The local
check noted above is a subset; the broader mandated gates (full workspace test
suite, codegen/scan, Android, Frontend) run in CI, not locally — none is
silently skipped.
