### PR TITLE
fix(sdk): bind inbox apply to signed canonical operation (#446)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -1774,6 +1774,78 @@ impl Operation {
         }
         clone
     }
+
+    /// Return a clone of this operation with the signature field set to `sig`
+    /// for variants that carry a signature. Mirror of [`with_cleared_signature`].
+    ///
+    /// [`with_cleared_signature`]: Operation::with_cleared_signature
+    pub fn with_signature(&self, sig: Vec<u8>) -> Self {
+        let mut clone = self.clone();
+        match &mut clone {
+            Operation::Transfer { signature, .. }
+            | Operation::CreateToken { signature, .. }
+            | Operation::Lock { signature, .. }
+            | Operation::Unlock { signature, .. }
+            | Operation::LockToken { signature, .. }
+            | Operation::UnlockToken { signature, .. }
+            | Operation::Generic { signature, .. }
+            | Operation::DlvCreate { signature, .. }
+            | Operation::DlvUnlock { signature, .. }
+            | Operation::DlvClaim { signature, .. }
+            | Operation::DlvInvalidate { signature, .. } => {
+                *signature = sig;
+            }
+            _ => {}
+        }
+        clone
+    }
+
+    /// §4.2.1 Authoritative binding: decode the sender's signed canonical
+    /// preimage and bind it to the verified signature. This is the SINGLE
+    /// trusted source for an inbound signed operation — callers MUST route
+    /// every value read (amount/token_id/recipient/nonce/message) off the
+    /// returned [`Operation`], never off any parallel structured field that
+    /// traveled alongside the signed bytes.
+    ///
+    /// Steps:
+    /// 1. SPHINCS+ verify `signature` over `canonical_operation_bytes` under
+    ///    `signer_pubkey` (fail fast — never decode unauthenticated bytes).
+    /// 2. [`Operation::from_bytes`] the canonical preimage.
+    /// 3. Enforce canonical re-serialization equality
+    ///    `op.with_cleared_signature().to_bytes() == canonical_operation_bytes`.
+    ///    This rejects trailing garbage and any non-canonical encoding for this
+    ///    path (independent of the global decoder exhaustion guard, issue #450).
+    /// 4. Return the operation with the verified signature re-attached, so the
+    ///    result is byte-identical to the operation the sender signed.
+    pub fn decode_and_bind_signed(
+        canonical_operation_bytes: &[u8],
+        signature: &[u8],
+        signer_pubkey: &[u8],
+    ) -> Result<Operation, DsmError> {
+        match crate::crypto::sphincs::sphincs_verify(
+            signer_pubkey,
+            canonical_operation_bytes,
+            signature,
+        ) {
+            Ok(true) => {}
+            Ok(false) => return Err(DsmError::verification("signed operation signature invalid")),
+            Err(e) => {
+                return Err(DsmError::verification(format!(
+                    "signed operation signature verification error: {e}"
+                )))
+            }
+        }
+
+        let op = Operation::from_bytes(canonical_operation_bytes)?;
+
+        if op.with_cleared_signature().to_bytes() != canonical_operation_bytes {
+            return Err(DsmError::invalid_operation(
+                "non-canonical signed operation bytes (re-serialization mismatch)",
+            ));
+        }
+
+        Ok(op.with_signature(signature.to_vec()))
+    }
 }
 
 impl Ops for Operation {
@@ -2863,6 +2935,95 @@ mod tests {
             .to_bytes();
             *bytes.last_mut().unwrap() = 99;
             assert!(Operation::from_bytes(&bytes).is_err());
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    //  decode_and_bind_signed — authoritative inbound binding (issue #446)
+    // ------------------------------------------------------------------ //
+    mod decode_and_bind {
+        use super::*;
+        use crate::crypto::sphincs::{generate_keypair_from_seed, sphincs_sign, SphincsVariant};
+
+        /// Build a legitimately signed Transfer the way the sender does:
+        /// sign over `signing_op.to_bytes()` with an EMPTY signature field, and
+        /// that exact buffer is the `canonical_operation_bytes` preimage.
+        /// Returns `(canonical_bytes, signature, signer_public_key)`.
+        fn signed_transfer() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+            let kp =
+                generate_keypair_from_seed(SphincsVariant::SPX256f, &[7u8; 32]).expect("keypair");
+            let signing_op = Operation::Transfer {
+                to_device_id: vec![0x11; 32],
+                amount: test_balance(42),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Unilateral,
+                nonce: vec![0xAB; 16],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![0x22; 32],
+                to: vec![0x33; 32],
+                message: "unit".into(),
+                signature: Vec::new(),
+            };
+            let canonical = signing_op.to_bytes();
+            let sig = sphincs_sign(&kp.secret_key, &canonical).expect("sign");
+            (canonical, sig, kp.public_key.clone())
+        }
+
+        #[test]
+        fn clean_accept_binds_canonical_values() {
+            let (canonical, sig, pk) = signed_transfer();
+            let bound = Operation::decode_and_bind_signed(&canonical, &sig, &pk)
+                .expect("bind should accept a clean signed op");
+
+            // The bound op derives SOLELY from the signed canonical bytes — there is
+            // no structured field input to the helper, so a tampered sibling field
+            // (the issue #446 attack) cannot influence these values.
+            assert!(
+                matches!(bound, Operation::Transfer { .. }),
+                "expected Transfer"
+            );
+            if let Operation::Transfer {
+                to_device_id,
+                amount,
+                token_id,
+                nonce,
+                ..
+            } = &bound
+            {
+                assert_eq!(to_device_id, &vec![0x11; 32]);
+                assert_eq!(amount.value(), 42);
+                assert_eq!(token_id, &b"ERA".to_vec());
+                assert_eq!(nonce, &vec![0xAB; 16]);
+            }
+
+            // Signature re-attached, and re-clearing reproduces the exact preimage.
+            assert_eq!(bound.get_signature(), Some(sig));
+            assert_eq!(bound.with_cleared_signature().to_bytes(), canonical);
+        }
+
+        #[test]
+        fn trailing_garbage_rejected() {
+            let kp =
+                generate_keypair_from_seed(SphincsVariant::SPX256f, &[7u8; 32]).expect("keypair");
+            let (canonical, _sig, pk) = signed_transfer();
+            let mut tampered = canonical;
+            tampered.push(0xFF);
+            // Sign the trailing-garbage bytes so the SIGNATURE itself verifies; the
+            // re-serialization equality check must still reject the non-canonical input.
+            let sig = sphincs_sign(&kp.secret_key, &tampered).expect("sign");
+            assert!(Operation::decode_and_bind_signed(&tampered, &sig, &pk).is_err());
+        }
+
+        #[test]
+        fn wrong_signature_rejected() {
+            let (canonical, _sig, pk) = signed_transfer();
+            let other =
+                generate_keypair_from_seed(SphincsVariant::SPX256f, &[9u8; 32]).expect("keypair2");
+            let bad_sig = sphincs_sign(&other.secret_key, &canonical).expect("sign");
+            // Verify under the ORIGINAL signer's key -> signature mismatch -> reject,
+            // before any decoded value is trusted.
+            assert!(Operation::decode_and_bind_signed(&canonical, &bad_sig, &pk).is_err());
         }
     }
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/storage_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/storage_routes.rs
@@ -473,25 +473,75 @@ impl AppRouterImpl {
                                         }
                                     }
 
-                                    if let dsm::types::operations::Operation::Transfer {
-                                        amount,
-                                        token_id: _token_id,
-                                        nonce: _nonce,
-                                        ..
-                                    } = &entry.transaction
+                                    // §4.2.1 (issue #446): `entry.transaction` is a field-by-field
+                                    // reconstruction from UNTRUSTED protobuf and is used here ONLY as
+                                    // a routing hint. Every value-bearing read below derives from the
+                                    // signed canonical operation — decoded from `canonical_operation_bytes`
+                                    // and bound to the verified signature — never from the structured
+                                    // fields a relay could tamper while leaving the signature intact.
+                                    if let dsm::types::operations::Operation::Transfer { .. } =
+                                        &entry.transaction
                                     {
-                                        let amount_val = amount.value();
-                                        if amount_val == 0 {
-                                            log::warn!(
-                                                "[storage.sync] Skipping zero-amount transfer"
+                                        // The signed canonical preimage is mandatory (strict-fail).
+                                        if entry.canonical_operation_bytes.is_empty() {
+                                            log::error!(
+                                                "[storage.sync] ❌ REJECTING tx {}: missing canonical_operation_bytes (§4.2.1 strict-fail)",
+                                                entry.transaction_id
                                             );
+                                            let mut state_guard = batch_state.lock().await;
+                                            state_guard.errors.push(format!(
+                                                "missing canonical_operation_bytes for tx {}",
+                                                entry.transaction_id
+                                            ));
                                             continue;
                                         }
+                                        let signing_bytes = entry.canonical_operation_bytes.clone();
 
-                                        // ============= AF-2 FIX: Canonical Transfer Signature Verification =============
-                                        // Extract transfer details from the Operation
+                                        // Resolve signer key: embedded evidence first, contacts second.
+                                        let (pk, pk_source) = if !entry.sender_signing_public_key.is_empty() {
+                                                    (entry.sender_signing_public_key.clone(), "embedded_evidence")
+                                                } else if let Some(k) = crate::storage::client_db::get_contact_public_key_by_device_id(&entry.sender_device_id) {
+                                                    (k, "contact_book")
+                                                } else {
+                                                    log::warn!("[storage.sync] ❌ No public key for sender {} (tx {}) - REJECTING", entry.sender_device_id, entry.transaction_id);
+                                                    let mut state_guard = batch_state.lock().await;
+                                                    state_guard.errors.push(format!("unknown sender public key for tx {}", entry.transaction_id));
+                                                    continue;
+                                                };
+                                        let pk_hash = dsm::crypto::blake3::domain_hash(
+                                            dsm::common::domain_tags::TAG_DSM_PK_HASH,
+                                            &pk,
+                                        );
+                                        log::info!("[storage.sync] 🔑 signer pk hash(first8)={:?} source={} tx={}", &pk_hash.as_bytes()[..8], pk_source, entry.transaction_id);
+
+                                        // §4.2.1 authoritative binding: verify SPHINCS+ over the
+                                        // canonical bytes, decode the SIGNED operation, enforce
+                                        // canonical re-serialization equality, and re-attach the
+                                        // verified signature. `signed_op` is the ONLY trusted
+                                        // operation for this entry.
+                                        let signed_op = match dsm::types::operations::Operation::decode_and_bind_signed(
+                                            &signing_bytes,
+                                            &entry.signature,
+                                            &pk,
+                                        ) {
+                                            Ok(op) => op,
+                                            Err(e) => {
+                                                log::warn!(
+                                                    "[storage.sync] inbox.pull: signed-operation binding failed for tx {} ({}) — skipping poisoned entry, continuing batch",
+                                                    entry.transaction_id, e
+                                                );
+                                                let mut state_guard = batch_state.lock().await;
+                                                state_guard.errors.push(format!(
+                                                    "inbox.pull: signed-operation binding failed for tx {}: {}",
+                                                    entry.transaction_id, e
+                                                ));
+                                                continue;
+                                            }
+                                        };
+
+                                        // Authoritative transfer fields come ONLY from signed_op.
                                         let (to_device_id, amount_val, token_id, nonce, memo) =
-                                            match &entry.transaction {
+                                            match &signed_op {
                                                 dsm::types::operations::Operation::Transfer {
                                                     to_device_id,
                                                     amount,
@@ -507,10 +557,22 @@ impl AppRouterImpl {
                                                     message.clone(),
                                                 ),
                                                 _ => {
-                                                    log::warn!("[storage.sync] Skipping non-transfer operation");
+                                                    log::warn!("[storage.sync] Skipping tx {}: signed operation is not a Transfer", entry.transaction_id);
+                                                    let mut state_guard = batch_state.lock().await;
+                                                    state_guard.errors.push(format!(
+                                                        "signed op not a Transfer for tx {}",
+                                                        entry.transaction_id
+                                                    ));
                                                     continue;
                                                 }
                                             };
+
+                                        if amount_val == 0 {
+                                            log::warn!(
+                                                "[storage.sync] Skipping zero-amount transfer"
+                                            );
+                                            continue;
+                                        }
 
                                         // Guardrail: ensure this inbox item is actually targeted to the local device.
                                         if let Err(msg) = ensure_inbox_recipient_targets_local(
@@ -613,70 +675,10 @@ impl AppRouterImpl {
                                             continue;
                                         }
 
-                                        // §4.2.1: Use the sender's canonical unsigned Operation bytes
-                                        // directly.  No field-by-field reconstruction — the sender
-                                        // embedded the exact signing preimage in the envelope.
-                                        if entry.canonical_operation_bytes.is_empty() {
-                                            log::error!(
-                                                "[storage.sync] ❌ REJECTING tx {}: missing canonical_operation_bytes (§4.2.1 strict-fail)",
-                                                entry.transaction_id
-                                            );
-                                            let mut state_guard = batch_state.lock().await;
-                                            state_guard.errors.push(format!(
-                                                "missing canonical_operation_bytes for tx {}",
-                                                entry.transaction_id
-                                            ));
-                                            continue;
-                                        }
-                                        let signing_bytes = entry.canonical_operation_bytes.clone();
-
-                                        // Verify SPHINCS+ signature (fail-closed)
-                                        // Prefer embedded sender signing key; fall back to contact book.
-                                        let (pk, pk_source) = if !entry.sender_signing_public_key.is_empty() {
-                                                    (entry.sender_signing_public_key.clone(), "embedded_evidence")
-                                                } else if let Some(k) = crate::storage::client_db::get_contact_public_key_by_device_id(&entry.sender_device_id) {
-                                                    (k, "contact_book")
-                                                } else {
-                                                    log::warn!("[storage.sync] ❌ No public key for sender {} (tx {}) - REJECTING", entry.sender_device_id, entry.transaction_id);
-                                                    let mut state_guard = batch_state.lock().await;
-                                                    state_guard.errors.push(format!("unknown sender public key for tx {}", entry.transaction_id));
-                                                    continue;
-                                                };
-
-                                        // Diagnostic: hash public key for cross-device comparison
-                                        let pk_hash = dsm::crypto::blake3::domain_hash(
-                                            dsm::common::domain_tags::TAG_DSM_PK_HASH,
-                                            &pk,
-                                        );
-                                        log::info!("[storage.sync] 🔑 signer pk hash(first8)={:?} source={} tx={}", &pk_hash.as_bytes()[..8], pk_source, entry.transaction_id);
-
-                                        let valid = match dsm::crypto::sphincs::sphincs_verify(
-                                            &pk,
-                                            &signing_bytes,
-                                            &entry.signature,
-                                        ) {
-                                            Ok(true) => true,
-                                            Ok(false) => false,
-                                            Err(e) => {
-                                                log::warn!("[storage.sync] ❌ Signature verification error for tx {}: {} - REJECTING", entry.transaction_id, e);
-                                                false
-                                            }
-                                        };
-                                        if !valid {
-                                            log::warn!(
-                                                "[storage.sync] inbox.pull: signature verification failed for tx {} — skipping poisoned entry, continuing batch",
-                                                entry.transaction_id
-                                            );
-                                            let mut state_guard = batch_state.lock().await;
-                                            state_guard.errors.push(format!(
-                                                "inbox.pull: signature verification failed for tx {}",
-                                                entry.transaction_id
-                                            ));
-                                            continue;
-                                        }
-
-                                        // Rehydrate and apply the transfer operation (we already hold Operation in the entry)
-                                        let op = entry.transaction.clone();
+                                        // Apply the authoritative signed operation (decoded and bound
+                                        // above from the canonical signed bytes — never the untrusted
+                                        // reconstructed `entry.transaction`).
+                                        let op = signed_op;
                                         let tx_id: TransactionId =
                                             TransactionId::new(entry.transaction_id.clone());
                                         // §S1: receipt_commit is mandatory — §4.3 items 2/3/4 all depend on it.
@@ -718,20 +720,11 @@ impl AppRouterImpl {
                                         // the entry for retry.
                                         // ═══════════════════════════════════════════════════════
                                         {
-                                            let nonce_bytes: Option<&[u8]> = match &entry
-                                                .transaction
-                                            {
-                                                dsm::types::operations::Operation::Transfer {
-                                                    nonce,
-                                                    ..
-                                                } => {
-                                                    if nonce.is_empty() {
-                                                        None
-                                                    } else {
-                                                        Some(nonce.as_slice())
-                                                    }
-                                                }
-                                                _ => None,
+                                            // Authoritative nonce from the signed op (issue #446).
+                                            let nonce_bytes: Option<&[u8]> = if nonce.is_empty() {
+                                                None
+                                            } else {
+                                                Some(nonce.as_slice())
                                             };
                                             if let Some(nb) = nonce_bytes {
                                                 if let Ok(true) =


### PR DESCRIPTION
## What

Closes #446. The online `storage.sync` receive path verified the SPHINCS+ signature over
`canonical_operation_bytes` but applied `entry.transaction` — an `Operation` reconstructed field-by-field
from untrusted protobuf fields by `envelope_to_b0x_entry`. An untrusted storage relay could rewrite the
structured `amount`/`token_id`/`to_device_id` while leaving `canonical_operation_bytes` + `signature`
intact, forging the credited value on the receiver (a valid `amount=1` signature could apply as
`1_000_000`).

## How

- Add `Operation::decode_and_bind_signed(canonical_bytes, signature, signer_pubkey)`: verify SPHINCS+ over
  the canonical bytes, decode the signed preimage, enforce canonical re-serialization equality
  (`op.with_cleared_signature().to_bytes() == canonical_bytes`, which also rejects trailing garbage on this
  path), and re-attach the verified signature. Add `Operation::with_signature` mirroring
  `with_cleared_signature`.
- Restructure the `storage.sync` receive block so the decoded, bound operation is the single source of
  truth for `amount`/`token_id`/`recipient`/`nonce` and the applied op. `entry.transaction` is demoted to a
  non-authoritative routing hint; it stays in `B0xEntry` only for BLE-submit and inbox preview, which are
  unchanged.

## Tests / verification

- `operations::tests::decode_and_bind`: clean-accept (values come solely from canonical bytes, signature
  re-attached), trailing-garbage reject, wrong-signature reject.
- `cargo clippy -p dsm -p dsm_sdk --all-features` clean (denies unwrap/expect/panic).
- `cargo test -p dsm --lib types::operations` — 70 passed.

## Follow-ups (separate issues)

- #453 — bilateral BLE `op_id` binding (sibling of this gap; Medium, proposer signs own debit so self-harm
  not attacker vector).
- #450 — global manual-decoder trailing-byte exhaustion guard.
