### PR TITLE
fix(core): reject trailing bytes in manual decoders (#450)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/merkle/sparse_merkle_tree.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/merkle/sparse_merkle_tree.rs
@@ -508,6 +508,11 @@ impl SmtInclusionProof {
             s.copy_from_slice(&data[offset + i * 32..offset + (i + 1) * 32]);
             siblings.push(s);
         }
+        // Canonical decode requires full byte exhaustion: reject trailing bytes
+        // so a proof has exactly one byte encoding. (issue #450)
+        if offset + count * 32 != data.len() {
+            return None;
+        }
         Some(SmtInclusionProof {
             key,
             value,
@@ -528,6 +533,20 @@ mod tests {
     fn zero_leaf_is_32_zero_bytes() {
         assert_eq!(ZERO_LEAF, [0u8; 32]);
         assert_eq!(empty_leaf(), ZERO_LEAF);
+    }
+
+    #[test]
+    fn inclusion_proof_trailing_bytes_rejected() {
+        let proof = SmtInclusionProof {
+            key: [1u8; 32],
+            value: Some([2u8; 32]),
+            siblings: vec![[3u8; 32], [4u8; 32]],
+        };
+        let mut bytes = proof.to_bytes();
+        // Exact bytes decode fine; trailing bytes are non-canonical (issue #450).
+        assert!(SmtInclusionProof::from_bytes(&bytes).is_some());
+        bytes.push(0x00);
+        assert!(SmtInclusionProof::from_bytes(&bytes).is_none());
     }
 
     #[test]

--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -1648,6 +1648,16 @@ impl Operation {
             }
             _ => return Err(DsmError::invalid_operation("unknown op tag")),
         };
+        // Canonical decode requires full byte exhaustion: a valid operation must
+        // consume its entire input. Trailing bytes are non-canonical — a distinct
+        // wire string that decodes to the same operation — and are rejected so a
+        // signed operation has exactly one byte encoding. (issue #450)
+        if !input.is_empty() {
+            return Err(DsmError::invalid_operation(format!(
+                "trailing bytes after operation: {} leftover",
+                input.len()
+            )));
+        }
         Ok(op)
     }
 
@@ -2862,6 +2872,45 @@ mod tests {
             }
             .to_bytes();
             *bytes.last_mut().unwrap() = 99;
+            assert!(Operation::from_bytes(&bytes).is_err());
+        }
+
+        #[test]
+        fn trailing_bytes_after_transfer_rejected() {
+            let mut bytes = Operation::Transfer {
+                to_device_id: vec![0x01; 32],
+                amount: test_balance(100),
+                token_id: b"ERA".to_vec(),
+                mode: TransactionMode::Unilateral,
+                nonce: vec![0xFF; 16],
+                verification: VerificationType::Standard,
+                pre_commit: None,
+                recipient: vec![0x02; 32],
+                to: vec![0x03; 32],
+                message: "x".into(),
+                signature: vec![0xAA; 32],
+            }
+            .to_bytes();
+            // Exact bytes decode fine; one trailing byte is non-canonical.
+            assert!(Operation::from_bytes(&bytes).is_ok());
+            bytes.push(0x00);
+            assert!(Operation::from_bytes(&bytes).is_err());
+        }
+
+        #[test]
+        fn trailing_bytes_after_create_rejected() {
+            let mut bytes = Operation::Create {
+                message: "hello".into(),
+                identity_data: vec![1, 2, 3],
+                public_key: vec![4, 5],
+                metadata: vec![],
+                commitment: vec![],
+                proof: vec![],
+                mode: TransactionMode::Bilateral,
+            }
+            .to_bytes();
+            assert!(Operation::from_bytes(&bytes).is_ok());
+            bytes.extend_from_slice(&[0xFF, 0xFF]);
             assert!(Operation::from_bytes(&bytes).is_err());
         }
     }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/state_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/state_types.rs
@@ -1161,6 +1161,18 @@ mod tests {
     }
 
     #[test]
+    fn serializable_merkle_proof_trailing_bytes_rejected() {
+        let root = vec![1, 2, 3, 4, 5];
+        let proof = vec![vec![10, 20], vec![30, 40, 50]];
+        let smp = SerializableMerkleProof::new(root, proof);
+        let mut bytes = smp.serialize();
+        // Exact bytes decode fine; trailing bytes are non-canonical (issue #450).
+        assert!(SerializableMerkleProof::from_bytes(&bytes).is_some());
+        bytes.push(0x00);
+        assert!(SerializableMerkleProof::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
     fn serializable_merkle_proof_verify_valid_path() {
         use crate::crypto::blake3::dsm_domain_hasher;
 
@@ -1533,6 +1545,11 @@ impl SerializableMerkleProof {
             crate::common::domain_tags::TAG_DSM_PROOF_ROOT,
             &root,
         ));
+        // Canonical decode requires full byte exhaustion: reject trailing bytes
+        // so a proof has exactly one byte encoding. (issue #450)
+        if off != data.len() {
+            return None;
+        }
         Some(Self {
             root,
             proof,


### PR DESCRIPTION
## What

Closes #450. Three hand-rolled decoders parsed a valid prefix and returned success while silently ignoring
trailing bytes, breaking canonicalization: two distinct wire byte strings could decode to the same value,
enabling signature/representation malleability (a signature verified over a re-derived canonical form would
accept both encodings).

## How

Require full byte exhaustion in each decoder:

- `Operation::from_bytes` — returns `Err` if any input remains after a complete parse.
- `SerializableMerkleProof::from_bytes` — returns `None` unless the cursor consumed the entire buffer.
- `SmtInclusionProof::from_bytes` — returns `None` unless `offset + count * 32 == data.len()`.

## Safety audit

Swept every `from_bytes`/decode in `dsm/src` and every call site of the three decoders across `dsm`,
`dsm_sdk`, the JNI bridge, and storage:

- All callers pass exactly-sized buffers (protobuf bytes fields, `to_bytes()` output, or length-prefixed
  reads), so enforcing exhaustion breaks no caller. Sub-operation decodes are length-delimited, so no inner
  exhaustion check fires.
- All other hand-rolled decoders already exhaust (spv, device_tree, kyber, capsule, smt_replace_witness,
  GenesisHash) or are protobuf/fixed-width (tombstone, policy).
- `SmtInclusionProof::from_bytes` has no production callers — only unit + integration tests, both passing
  exact `to_bytes()` output.

## Tests / verification

- New trailing-byte rejection tests for all three decoders.
- `cargo test -p dsm --lib` — 1437 passed.
- `cargo test -p dsm_sdk --lib` (single-threaded) — 1506 passed.
- `cargo test -p dsm --test smt_tripwire_vectors` — 25 passed.
- `cargo clippy -p dsm -p dsm_sdk --all-features` — clean.

## Related

- #446 (signed-byte binding, PR #454) — the inbox fix's per-call canonical equality check already closed
  trailing-byte malleability on that path; this PR closes it globally for all consumers.
- #453 — bilateral BLE `op_id` binding (separate track).
