### PR TITLE
feat(core): balance conservation + signed policy_commit binding (#448, §9.5)

### DIFF
--- a/.github/instructions/token-policy-readiness.instructions.md
+++ b/.github/instructions/token-policy-readiness.instructions.md
@@ -1,0 +1,165 @@
+---
+applyTo: '**'
+---
+
+# Custom-Token Policy Validity and Per-Transfer Readiness
+
+Normative doctrine for how a DSM device installs a token policy and how a token
+transfer is authorized with respect to that policy. This governs all fungible and
+non-fungible custom (CPTA) tokens in addition to the builtin tokens (ERA, dBTC).
+
+Each clause is marked **Layer A** (normative and realized in the current
+implementation) or **Layer B** (normative design intent, NOT yet shipped — tracked
+by the referenced issue; MUST NOT be relied upon as an acceptance criterion until
+that issue closes). See the Enforcement Surfaces table at the end.
+
+A DSM token policy MUST NEVER be absorbed from a counterparty, a transaction
+envelope, an inbox sync, a contact sync, an offline exchange, or arbitrary
+peer-supplied bytes. Peer-supplied data may help *locate* a policy; it is never
+*authority*.
+
+## 1. Policy commitment (CPTA) — Layer A
+
+The canonical policy commitment is the domain-separated BLAKE3 hash of the
+canonical CPTA bytes:
+
+    policy_commit = BLAKE3-256("DSM/cpta\0" || canonical_cpta_bytes)
+
+`canonical_cpta_bytes` is the deterministic Protobuf serialization of the policy
+object (Envelope wire v3), implemented as the Rust core `TokenPolicy` / `PolicyFile`
+hashed via `PolicyAnchor::from_policy`. If sender and recipient do not hold the exact
+same canonical policy bytes, their `policy_commit` values differ, every digest that
+binds `policy_commit` changes, and verification fails.
+
+## 2. Local policy installation — authoritative source only
+
+Installation is **one time per device per token policy**. A device MAY populate a
+token policy for itself ONLY from the authoritative source of truth — the original
+CPTA / root anchor / issuer-or-root-signed policy anchor / canonical policy source
+path. The policy bytes MUST be fetched independently, verified against the official
+anchor path, and hashed under the §1 rule.
+
+A token is locally installed only if all hold:
+
+1. The policy bytes were obtained from the authoritative source of truth.
+2. The policy anchor or issuer/root signature verifies. *(Issuer/root-signature
+   verification is **Layer B**; current anchors are content-addressed only.)*
+3. The canonical policy bytes hash exactly to `policy_commit`.
+4. The policy is stored locally as an installed policy record.
+5. The token namespace, token genesis, balance bucket, and `policy_commit` are
+   bound together locally.
+
+Policy bytes MUST NOT be sourced from: an offline peer, an online sender, a
+transaction envelope, an inbox sync, a contact sync, arbitrary storage bytes, a
+retrieval hint without anchor verification, or peer-supplied policy metadata.
+
+**Layer A:** install/verify(content-address)/cache exists (`TokenPolicySystem`,
+`PolicyCache` token_id→anchor, filesystem `PolicyStore`, CPTA fetch-verify-cache).
+**Layer B:** issuer/root-signature verification of the anchor.
+
+## 3. No automatic absorption
+
+An incoming transfer (online object, offline exchange, inbox/contact sync) MUST NOT
+automatically add, accept, credit, install, or display a token policy. Such an object
+may carry a `policy_commit` or retrieval hint, but that neither populates the token
+nor grants authority. The recipient MUST independently resolve the policy through the
+authoritative source of truth and verify it before crediting balance, creating a
+balance bucket, applying the transfer, or treating the token as installed. If the
+recipient cannot verify the incoming reference against the authoritative source, the
+object MUST fail closed (or remain quarantined) and MUST NOT mutate balances.
+
+**Layer A** (online): the receiver resolves `policy_commit` from its own installed
+policy and fails closed on an unresolved custom token; the operation carries only
+`token_id`, so a peer cannot inject a `policy_commit`. **This branch** makes the
+bilateral path consistent (was: silent skip).
+
+## 4. policy_commit bound in every transfer — Layer A (§9.5)
+
+Per whitepaper §9.5: *"All TokenOps MUST include `policy_commit`; verifiers reject if
+it differs from the token's creation `policy_commit`."* Every transfer / precommit /
+send digest MUST bind `policy_commit`. The full policy bytes need not be carried; the
+compact `policy_commit` MUST be bound every time.
+
+A transfer/precommit/send object MUST bind at least: `token_id` (or token_genesis),
+`policy_commit`, sender identity, recipient identity, amount, parent_tip /
+relationship context, session nonce / send context, and (Layer B) the counterparty
+readiness digest.
+
+**This branch** adds the required `policy_commit` field to the signed
+`Operation::Transfer` and rejects on missing/mismatched commit at receive; balance
+buckets are bound to `policy_commit` at the mutation chokepoint.
+
+## 5. Per-transfer counterparty readiness — Layer B
+
+Local installation is NOT sufficient to send or receive. For EVERY transfer, each
+side MUST verify that the other side operates under the same exact canonical
+`policy_commit P`. A valid transfer is bound to one exact `P`:
+
+    Sender local policy hash == P
+    Recipient local policy hash == P
+    Counterparty readiness proof binds P
+    Transfer precommit/send digest binds P
+
+Readiness is **per transfer**, not a one-time approval, and is **mode-separated**:
+online readiness does not satisfy offline readiness, and vice versa.
+
+- **Online (b0x):** before creating the send object, the sender fetches the
+  recipient's published readiness object from the recipient's online
+  identity/storage/inbox surface and verifies it: recipient-signed, references the
+  exact `policy_commit`, traces to the authoritative anchor, matches recipient
+  identity, valid for the current send context. Only then is the send object created,
+  binding the recipient readiness digest. The recipient independently re-verifies on
+  ingest.
+- **Offline (direct):** both devices already hold the source-of-truth-installed
+  policy and exchange direct per-transfer readiness attestations binding token,
+  `policy_commit`, identities, relationship context, parent_tip, session nonce, and
+  the local install-record digest. Each verifies the other before any precommit
+  exists.
+
+All of §5 is **Layer B** (tracked — see table); no per-transfer policy-readiness
+attestation exists today.
+
+## 6. Hard validity rule
+
+    CanTransferToken(A, B, token_id, policy_commit, mode) ==
+        SourceTruthPolicyInstalled(A, policy_commit)
+        && SourceTruthPolicyInstalled(B, policy_commit)
+        && CounterpartyReadinessVerifiedForThisTransfer(A, B, policy_commit, mode)
+        && CounterpartyReadinessVerifiedForThisTransfer(B, A, policy_commit, mode)
+        && TransferDigestBinds(policy_commit)
+        && BalanceBucketBoundToPolicy(token_id, policy_commit)
+
+If any conjunct is false, the transfer fails closed before balance mutation. The
+`SourceTruthPolicyInstalled`, `TransferDigestBinds`, and `BalanceBucketBoundToPolicy`
+conjuncts are realized incrementally (this branch + issues below); the
+`CounterpartyReadinessVerifiedForThisTransfer` conjuncts are Layer B.
+
+## 7. Security properties
+
+This doctrine prevents: fake-token injection, policy spoofing, ticker/alias and
+namespace confusion, peer-supplied policy absorption, contact-sync and inbox-sync
+poisoning, arbitrary balance-bucket creation, accepting a transfer under a policy the
+counterparty does not actually hold, and accepting a transfer where sender and
+recipient are not bound to the same canonical policy.
+
+## Enforcement Surfaces (status)
+
+| Surface | Status | Tracking |
+|---|---|---|
+| CPTA commit rule `policy_commit = H("DSM/cpta\0" \|\| bytes)` | Layer A | shipped (§9.3) |
+| Local install / content-address verify / cache | Layer A | shipped |
+| Issuer/root-signed anchor verification | Layer B | #466 |
+| No auto-absorption, fail-closed (online) | Layer A | shipped |
+| No auto-absorption, fail-closed (bilateral) | Layer A | **this branch** |
+| `policy_commit` bound in signed `Operation::Transfer` + reject on mismatch | Layer A | **this branch** (#467) |
+| By-construction balance conservation at `DeviceState::advance` | Layer A | **this branch** (#448) |
+| Receiver-side local policy-install verification before apply | Layer B | #468 |
+| Sender-side readiness preflight before online send | Layer B | #469 |
+| Online recipient published readiness object/proof | Layer B | #470 |
+| Offline direct per-transfer readiness exchange | Layer B | #471 |
+| Fail-closed test matrix (missing/mismatched/stale/peer-supplied) | Layer B | #472 |
+| Extend `policy_commit` binding to Mint/Burn/CreateToken (§9.5) | Layer B | #473 |
+
+**Custom-token transfer readiness is INCOMPLETE** until the Layer-B issues above
+close. Until then, custom-token transfers enforce policy_commit binding +
+conservation + fail-closed, but NOT full per-transfer counterparty readiness.

--- a/dsm_client/deterministic_state_machine/dsm/src/commitments/deterministic.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/commitments/deterministic.rs
@@ -279,6 +279,7 @@ mod tests {
         let (_pk, sk) = generate_sphincs_keypair().expect("keypair");
 
         let mut op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: b"recipient123".to_vec(),
             verification: crate::types::operations::VerificationType::Standard,
             token_id: b"token123".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm/src/commitments/parameter_comparison.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/commitments/parameter_comparison.rs
@@ -613,6 +613,7 @@ mod tests {
         let mut balance = Balance::zero();
         balance.update_add(100);
         let mut op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             mode: TransactionMode::Bilateral,
             nonce: vec![1, 2, 3],
             verification: VerificationType::Standard,

--- a/dsm_client/deterministic_state_machine/dsm/src/commitments/smart_commitment.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/commitments/smart_commitment.rs
@@ -352,6 +352,8 @@ impl SmartCommitment {
             amount: Balance::zero(),
             recipient: recipient.clone(),
             token_id: Vec::new(),
+            // Placeholder commitment scaffolding op (empty token, zero amount).
+            policy_commit: [0u8; 32],
             to: recipient.clone(),
             message: String::new(),
             mode: TransactionMode::Bilateral,
@@ -428,6 +430,8 @@ impl SmartCommitment {
             amount: Balance::zero(),
             recipient: recipient.clone(),
             token_id: Vec::new(),
+            // Placeholder commitment scaffolding op (empty token, zero amount).
+            policy_commit: [0u8; 32],
             to: recipient.clone(),
             message: String::new(),
             mode: TransactionMode::Bilateral,
@@ -495,6 +499,8 @@ impl SmartCommitment {
             amount: Balance::zero(),
             recipient: recipient.clone(),
             token_id: Vec::new(),
+            // Placeholder commitment scaffolding op (empty token, zero amount).
+            policy_commit: [0u8; 32],
             to: recipient.clone(),
             message: String::new(),
             mode: TransactionMode::Bilateral,
@@ -1556,6 +1562,7 @@ mod tests {
     fn test_smart_commitment_creation_types_compile() {
         let (_pk, sk) = crate::crypto::sphincs::generate_sphincs_keypair().expect("keypair");
         let mut op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: b"recipient".to_vec(),
             amount: Balance::from_state(100, [0u8; 32]),
             recipient: b"abcd".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm/src/core/bilateral_transaction_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/bilateral_transaction_manager.rs
@@ -1671,6 +1671,7 @@ mod tests {
 
     fn signed_transfer_op(kp: &SignatureKeyPair, message: &str, nonce: u8) -> Operation {
         let mut op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             token_id: b"ERA".to_vec(),
             to_device_id: vec![9u8; 32],
             amount: Balance::from_state(1, [0u8; 32]),

--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/mod.rs
@@ -405,6 +405,7 @@ mod state_machine_tests {
         message: &str,
     ) -> Operation {
         let mut op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             token_id: b"ERA".to_vec(),
             to_device_id: vec![9u8; 32],
             amount: Balance::from_state(10, current_state.hash),

--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/mod.rs
@@ -495,14 +495,17 @@ mod state_machine_tests {
 
     #[test]
     fn test_first_post_genesis_transition_is_allowed() -> Result<(), DsmError> {
-        let (genesis_state, _pk, sk) = create_test_genesis_state_with_keypair();
+        let (genesis_state, _pk, _sk) = create_test_genesis_state_with_keypair();
         let device_id = genesis_state.device_info.device_id;
-        let op = signed_transfer(
-            &sk,
-            &genesis_state,
-            vec![0u8; 8],
-            "first post-genesis transfer",
-        );
+        // SMT-advance mechanics test: a non-balance op carries no deltas. The
+        // conservation guard requires Transfer/Mint/Burn deltas to match the op;
+        // balance-bearing advances are covered by the device_state guard tests.
+        let op = Operation::Generic {
+            operation_type: b"test.post-genesis".to_vec(),
+            data: vec![],
+            message: "first post-genesis transition".to_string(),
+            signature: vec![],
+        };
 
         let mut state_machine = StateMachine::new();
         state_machine.set_state(genesis_state);
@@ -523,14 +526,17 @@ mod state_machine_tests {
     #[test]
     fn test_state_machine_advance_relationship() -> Result<(), DsmError> {
         let mut machine = StateMachine::new();
-        let (initial_state, _pk, sk) = create_test_genesis_state_with_keypair();
+        let (initial_state, _pk, _sk) = create_test_genesis_state_with_keypair();
         let dev_id = initial_state.device_info.device_id;
         machine.set_state(initial_state);
 
-        let cur = machine
-            .current_state()
-            .ok_or_else(|| DsmError::state_machine("no state"))?;
-        let op = signed_transfer(&sk, &cur, vec![1u8; 8], "Test transfer");
+        // SMT-advance mechanics test: non-balance op, no deltas (see conservation guard).
+        let op = Operation::Generic {
+            operation_type: b"test.advance".to_vec(),
+            data: vec![],
+            message: "Test transfer".to_string(),
+            signature: vec![],
+        };
 
         let rel_key = crate::core::bilateral_transaction_manager::compute_smt_key(&dev_id, &dev_id);
         let init_tip =

--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/transition.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/transition.rs
@@ -1512,6 +1512,7 @@ mod tests {
         amount: u64,
     ) -> Operation {
         let mut op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             amount: Balance::from_state(amount, state_hash),
             token_id: token_id.as_bytes().to_vec(),
             to_device_id: b"recipient".to_vec(),
@@ -1924,6 +1925,7 @@ mod tests {
         });
 
         let transfer_op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             amount: Balance::from_state(50, prev_state.hash),
             token_id: b"token1".to_vec(),
             to_device_id: TEST_DEVICE_ID.to_vec(),
@@ -1985,6 +1987,7 @@ mod tests {
         let current_state = create_test_state(1);
 
         let operation = Operation::Transfer {
+            policy_commit: [0u8; 32],
             amount: Balance::from_state(10, current_state.hash),
             token_id: b"ERA".to_vec(),
             to_device_id: TEST_DEVICE_ID.to_vec(),
@@ -2036,6 +2039,7 @@ mod tests {
         );
 
         let operation = Operation::Transfer {
+            policy_commit: [0u8; 32],
             amount: Balance::from_state(10, current_state.hash),
             token_id: b"ERA".to_vec(),
             to_device_id: recipient_device_id.to_vec(),
@@ -2048,6 +2052,7 @@ mod tests {
             to: b"recipient".to_vec(),
             signature: {
                 let unsigned = Operation::Transfer {
+                    policy_commit: [0u8; 32],
                     amount: Balance::from_state(10, current_state.hash),
                     token_id: b"ERA".to_vec(),
                     to_device_id: recipient_device_id.to_vec(),
@@ -2295,6 +2300,7 @@ mod tests {
 
         // Build a Transfer with a deliberately invalid UTF-8 token_id.
         let mut op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             amount: Balance::from_state(5, state.hash),
             token_id: vec![0xFF, 0xFE],
             to_device_id: b"recipient".to_vec(),
@@ -2335,6 +2341,7 @@ mod tests {
         let entropy = vec![1, 2, 3, 4];
 
         let mut transfer_op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             amount: {
                 let mut balance = Balance::zero();
                 balance.update_add(25);
@@ -2388,6 +2395,7 @@ mod tests {
         let entropy = vec![4, 5, 6, 7];
 
         let mut transfer_op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             amount: {
                 let mut balance = Balance::zero();
                 balance.update_add(10);
@@ -2442,6 +2450,7 @@ mod tests {
             .insert(sender_key, Balance::from_state(100, current_state.hash));
 
         let mut op_unsigned = Operation::Transfer {
+            policy_commit: [0u8; 32],
             token_id: b"ERA".to_vec(),
             to_device_id: vec![9u8; 32],
             amount: Balance::from_state(10, current_state.hash),
@@ -2486,6 +2495,7 @@ mod tests {
             .insert(sender_key, Balance::from_state(100, current_state.hash));
 
         let op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             token_id: b"ERA".to_vec(),
             to_device_id: vec![9u8; 32],
             amount: Balance::from_state(10, current_state.hash),

--- a/dsm_client/deterministic_state_machine/dsm/src/cpta/README.md
+++ b/dsm_client/deterministic_state_machine/dsm/src/cpta/README.md
@@ -104,3 +104,20 @@ let token = create_token_from_genesis(&genesis, "creator_id", metadata, balance)
 - **Global Discoverability**: All policy anchors are globally discoverable
 - **Caching**: Policies are cached after verification for efficiency
 - **Rejection Guarantee**: Tokens with invalid or unverifiable CTPAs are treated as non-existent
+
+## Custom-Token Transfer Readiness — INCOMPLETE
+
+Per the token-policy + per-transfer readiness doctrine
+(`.github/instructions/token-policy-readiness.instructions.md`), custom-token
+transfer readiness is **not yet complete**. Shipped today (Layer A): `policy_commit`
+is bound into the signed `Operation::Transfer` and rejected on mismatch (§9.5),
+balance conservation is enforced by construction at `DeviceState::advance`, and both
+online and bilateral receive paths fail closed with no peer-policy absorption.
+
+Still tracked (Layer B): receiver-side installed-policy verification (#468),
+sender-side readiness preflight (#469), online published readiness object (#470),
+offline direct readiness exchange (#471), the fail-closed test matrix (#472),
+extending `policy_commit` binding to Mint/Burn/CreateToken (#473), and
+issuer/root-signed anchor verification (#466). Until these close, custom-token
+transfers enforce binding + conservation + fail-closed but NOT full per-transfer
+counterparty readiness.

--- a/dsm_client/deterministic_state_machine/dsm/src/types/device_state.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/device_state.rs
@@ -860,12 +860,10 @@ mod tests {
         assert!(validate_conservation(&me, &xfer(other, 5, pcx), &[credit(5, pcx)]).is_err());
         assert!(validate_conservation(&me, &xfer(me, 5, pcx), &[credit(5, pc(0xEE))]).is_err());
         assert!(validate_conservation(&me, &xfer(me, 5, pcx), &[]).is_err());
-        assert!(validate_conservation(
-            &me,
-            &xfer(me, 5, pcx),
-            &[credit(5, pcx), credit(5, pcx)]
-        )
-        .is_err());
+        assert!(
+            validate_conservation(&me, &xfer(me, 5, pcx), &[credit(5, pcx), credit(5, pcx)])
+                .is_err()
+        );
         // Mint: one credit==amount; Burn: one debit==amount.
         assert!(validate_conservation(&me, &mint_op(9), &[credit(9, pcx)]).is_ok());
         assert!(validate_conservation(&me, &mint_op(9), &[debit(9, pcx)]).is_err());

--- a/dsm_client/deterministic_state_machine/dsm/src/types/device_state.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/device_state.rs
@@ -246,6 +246,96 @@ pub enum BalanceDirection {
     Debit,
 }
 
+/// By-construction balance-conservation guard for [`DeviceState::advance`].
+///
+/// Validates that `deltas` exactly realize `operation` for the device identified
+/// by `local_devid`, so a caller cannot apply a balance mutation that diverges
+/// from the (authenticated) signed operation. Mirrors the reference semantics of
+/// `core::state_machine::transition::verify_token_balance_consistency`, lifted to
+/// operate on `&[BalanceDelta]` (code correspondence: lean4
+/// `DSMOfflineFinality.lean` `commitTransfer` / `commit_conservation`).
+///
+/// - `Transfer`: exactly one delta, `amount == op.amount`, direction is `Credit`
+///   iff this device is the recipient (`op.to_device_id == local_devid`) else
+///   `Debit`, and `policy_commit == op.policy_commit` (§9.5 token binding).
+/// - `Mint`: exactly one `Credit` delta of `amount`.
+/// - `Burn`: exactly one `Debit` delta of `amount`.
+/// - Every other operation: no balance deltas.
+fn validate_conservation(
+    local_devid: &[u8; 32],
+    operation: &Operation,
+    deltas: &[BalanceDelta],
+) -> Result<(), DsmError> {
+    match operation {
+        Operation::Transfer {
+            to_device_id,
+            amount,
+            policy_commit,
+            ..
+        } => {
+            if deltas.len() != 1 {
+                return Err(DsmError::invalid_operation(
+                    "conservation: transfer must apply exactly one balance delta",
+                ));
+            }
+            let d = &deltas[0];
+            if d.amount != amount.value() {
+                return Err(DsmError::invalid_operation(
+                    "conservation: transfer delta amount != operation amount",
+                ));
+            }
+            let is_recipient =
+                to_device_id.len() == 32 && to_device_id.as_slice() == local_devid.as_slice();
+            let expected = if is_recipient {
+                BalanceDirection::Credit
+            } else {
+                BalanceDirection::Debit
+            };
+            if d.direction != expected {
+                return Err(DsmError::invalid_operation(
+                    "conservation: transfer delta direction does not match sender/recipient role",
+                ));
+            }
+            if &d.policy_commit != policy_commit {
+                return Err(DsmError::invalid_operation(
+                    "conservation: transfer delta policy_commit != operation policy_commit",
+                ));
+            }
+            Ok(())
+        }
+        Operation::Mint { amount, .. } => {
+            if deltas.len() != 1
+                || deltas[0].direction != BalanceDirection::Credit
+                || deltas[0].amount != amount.value()
+            {
+                return Err(DsmError::invalid_operation(
+                    "conservation: mint must apply exactly one credit delta of the mint amount",
+                ));
+            }
+            Ok(())
+        }
+        Operation::Burn { amount, .. } => {
+            if deltas.len() != 1
+                || deltas[0].direction != BalanceDirection::Debit
+                || deltas[0].amount != amount.value()
+            {
+                return Err(DsmError::invalid_operation(
+                    "conservation: burn must apply exactly one debit delta of the burn amount",
+                ));
+            }
+            Ok(())
+        }
+        _ => {
+            if !deltas.is_empty() {
+                return Err(DsmError::invalid_operation(
+                    "conservation: non-balance operation must not apply balance deltas",
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
 /// Result of a successful [`DeviceState::advance`] build.
 ///
 /// The caller must CAS-swap the device head from `parent_r_a` to
@@ -485,6 +575,15 @@ impl DeviceState {
             }
         };
 
+        // §9.5 + balance conservation (token-policy doctrine §4; code
+        // correspondence: lean4 DSMOfflineFinality.lean commit_conservation /
+        // commitTransfer): the supplied deltas MUST exactly realize the signed
+        // operation — one delta of op.amount, role-correct direction, bound to the
+        // op's policy_commit. This is the by-construction guard at the sole
+        // balance-mutation chokepoint; it rejects value creation/substitution
+        // regardless of caller.
+        validate_conservation(&self.devid, &operation, deltas)?;
+
         // Apply deltas to a working copy. Failures leave self untouched.
         let mut new_balances = self.balances.clone();
         for d in deltas {
@@ -687,6 +786,97 @@ mod tests {
         }
     }
 
+    fn bal(amount: u64) -> crate::types::token_types::Balance {
+        crate::types::token_types::Balance::from_state(amount, [0u8; 32])
+    }
+
+    /// A Mint op carrying one credit of `amount` — satisfies the conservation
+    /// guard for a single Credit `BalanceDelta` of the same amount.
+    fn mint_op(amount: u64) -> Operation {
+        Operation::Mint {
+            amount: bal(amount),
+            token_id: b"ERA".to_vec(),
+            authorized_by: vec![],
+            proof_of_authorization: vec![],
+            message: String::new(),
+        }
+    }
+
+    /// A Burn op carrying one debit of `amount` — satisfies the conservation
+    /// guard for a single Debit `BalanceDelta` of the same amount.
+    fn burn_op(amount: u64) -> Operation {
+        Operation::Burn {
+            amount: bal(amount),
+            token_id: b"ERA".to_vec(),
+            proof_of_ownership: vec![],
+            message: String::new(),
+        }
+    }
+
+    /// Value op matching a delta's direction/amount for conservation-guard tests.
+    fn value_op(dir: BalanceDirection, amount: u64) -> Operation {
+        match dir {
+            BalanceDirection::Credit => mint_op(amount),
+            BalanceDirection::Debit => burn_op(amount),
+        }
+    }
+
+    #[test]
+    fn conservation_guard_rules() {
+        let me = devid(0xAA);
+        let other = devid(0xBB);
+        let pcx = pc(0xCC);
+        let xfer = |to: [u8; 32], amt: u64, pcv: [u8; 32]| Operation::Transfer {
+            to_device_id: to.to_vec(),
+            amount: bal(amt),
+            token_id: b"ERA".to_vec(),
+            policy_commit: pcv,
+            mode: crate::types::operations::TransactionMode::Unilateral,
+            nonce: vec![],
+            verification: crate::types::operations::VerificationType::Standard,
+            pre_commit: None,
+            recipient: vec![],
+            to: vec![],
+            message: String::new(),
+            signature: vec![],
+        };
+        let credit = |amt: u64, pcv: [u8; 32]| BalanceDelta {
+            policy_commit: pcv,
+            direction: BalanceDirection::Credit,
+            amount: amt,
+        };
+        let debit = |amt: u64, pcv: [u8; 32]| BalanceDelta {
+            policy_commit: pcv,
+            direction: BalanceDirection::Debit,
+            amount: amt,
+        };
+
+        // Transfer: recipient credits, sender debits — accepted.
+        assert!(validate_conservation(&me, &xfer(me, 5, pcx), &[credit(5, pcx)]).is_ok());
+        assert!(validate_conservation(&me, &xfer(other, 5, pcx), &[debit(5, pcx)]).is_ok());
+        // Wrong amount / direction / token / count — rejected.
+        assert!(validate_conservation(&me, &xfer(me, 5, pcx), &[credit(6, pcx)]).is_err());
+        assert!(validate_conservation(&me, &xfer(me, 5, pcx), &[debit(5, pcx)]).is_err());
+        assert!(validate_conservation(&me, &xfer(other, 5, pcx), &[credit(5, pcx)]).is_err());
+        assert!(validate_conservation(&me, &xfer(me, 5, pcx), &[credit(5, pc(0xEE))]).is_err());
+        assert!(validate_conservation(&me, &xfer(me, 5, pcx), &[]).is_err());
+        assert!(validate_conservation(
+            &me,
+            &xfer(me, 5, pcx),
+            &[credit(5, pcx), credit(5, pcx)]
+        )
+        .is_err());
+        // Mint: one credit==amount; Burn: one debit==amount.
+        assert!(validate_conservation(&me, &mint_op(9), &[credit(9, pcx)]).is_ok());
+        assert!(validate_conservation(&me, &mint_op(9), &[debit(9, pcx)]).is_err());
+        assert!(validate_conservation(&me, &mint_op(9), &[credit(8, pcx)]).is_err());
+        assert!(validate_conservation(&me, &burn_op(9), &[debit(9, pcx)]).is_ok());
+        assert!(validate_conservation(&me, &burn_op(9), &[credit(9, pcx)]).is_err());
+        // Non-balance op must carry no deltas.
+        assert!(validate_conservation(&me, &op(), &[]).is_ok());
+        assert!(validate_conservation(&me, &op(), &[credit(1, pcx)]).is_err());
+    }
+
     fn entropy(seed: u8) -> Vec<u8> {
         let mut h = crate::crypto::blake3::dsm_domain_hasher(
             crate::common::domain_tags::TAG_DSM_TEST_ENTROPY,
@@ -725,7 +915,7 @@ mod tests {
             .advance(
                 rk_self,
                 bob.devid,
-                op(),
+                mint_op(50),
                 entropy(42),
                 None,
                 &[BalanceDelta {
@@ -784,7 +974,7 @@ mod tests {
             .advance(
                 rk_bob,
                 bob,
-                op(),
+                burn_op(30),
                 entropy(1),
                 None,
                 &[BalanceDelta {
@@ -808,7 +998,7 @@ mod tests {
             .advance(
                 rk_chrl,
                 charlie,
-                op(),
+                burn_op(50),
                 entropy(2),
                 None,
                 &[BalanceDelta {
@@ -866,7 +1056,7 @@ mod tests {
             .advance(
                 rk_bob,
                 bob,
-                op(),
+                burn_op(10),
                 entropy(1),
                 None,
                 &[BalanceDelta {
@@ -882,7 +1072,7 @@ mod tests {
             .advance(
                 rk_chrl,
                 charlie,
-                op(),
+                burn_op(20),
                 entropy(2),
                 None,
                 &[BalanceDelta {
@@ -933,7 +1123,7 @@ mod tests {
             .advance(
                 rk,
                 bob,
-                op(),
+                burn_op(10),
                 entropy(1),
                 None,
                 &[BalanceDelta {
@@ -949,7 +1139,7 @@ mod tests {
             .advance(
                 rk,
                 bob,
-                op(),
+                burn_op(20),
                 entropy(2),
                 None,
                 &[BalanceDelta {
@@ -994,7 +1184,7 @@ mod tests {
         let r = dev.advance(
             rk,
             bob,
-            op(),
+            burn_op(10),
             entropy(1),
             None,
             &[BalanceDelta {
@@ -1027,7 +1217,7 @@ mod tests {
         let r = dev.advance(
             rk,
             bob,
-            op(),
+            mint_op(1),
             entropy(1),
             None,
             &[BalanceDelta {
@@ -1076,7 +1266,7 @@ mod tests {
                 .advance(
                     rk,
                     *party,
-                    op(),
+                    value_op(dir, amt),
                     entropy(i as u8),
                     None,
                     &[BalanceDelta {

--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -184,6 +184,11 @@ pub enum Operation {
         amount: Balance,
         /// Binary identifier of the token type being transferred.
         token_id: Vec<u8>,
+        /// CPTA policy commitment (32B) binding this transfer to the token's
+        /// canonical policy (§9.5: "All TokenOps MUST include policy_commit;
+        /// verifiers reject if it differs from the token's creation
+        /// policy_commit"). See token-policy-readiness doctrine §4.
+        policy_commit: [u8; 32],
         /// Bilateral (3-phase commit) or unilateral execution mode.
         mode: TransactionMode,
         /// Unique nonce preventing replay of this transfer.
@@ -624,6 +629,7 @@ impl Operation {
                 to_device_id,
                 amount,
                 token_id,
+                policy_commit,
                 mode,
                 nonce,
                 verification,
@@ -639,6 +645,8 @@ impl Operation {
                 let bal = amount.to_le_bytes();
                 put_bytes(&mut out, &bal);
                 put_bytes(&mut out, token_id);
+                // CPTA policy commitment (§9.5) — bound into the signed bytes.
+                put_bytes(&mut out, policy_commit);
                 put_mode(&mut out, mode);
                 put_bytes(&mut out, nonce);
                 put_verification(&mut out, verification);
@@ -1212,6 +1220,11 @@ impl Operation {
                 let to_device_id = get_bytes(&mut input)?;
                 let amount = dec_balance(&mut input)?;
                 let token_id = get_bytes(&mut input)?;
+                // CPTA policy commitment (§9.5) — required, exactly 32 bytes.
+                let policy_commit: [u8; 32] =
+                    get_bytes(&mut input)?.as_slice().try_into().map_err(|_| {
+                        DsmError::invalid_operation("transfer policy_commit must be 32 bytes")
+                    })?;
                 let mode = dec_mode(&mut input)?;
                 let nonce = get_bytes(&mut input)?;
                 let verification = dec_verification(&mut input)?;
@@ -1233,6 +1246,7 @@ impl Operation {
                     to_device_id,
                     amount,
                     token_id,
+                    policy_commit,
                     mode,
                     nonce,
                     verification,
@@ -2122,6 +2136,7 @@ mod tests {
         #[test]
         fn transfer_no_precommit() {
             roundtrip(&Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(500),
                 token_id: b"ERA".to_vec(),
@@ -2147,6 +2162,7 @@ mod tests {
                 security_params: SecurityParameters::default(),
             };
             roundtrip(&Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(1000),
                 token_id: b"TKN".to_vec(),
@@ -2164,6 +2180,7 @@ mod tests {
         #[test]
         fn transfer_custom_verification() {
             roundtrip(&Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(42),
                 token_id: b"ERA".to_vec(),
@@ -2481,6 +2498,7 @@ mod tests {
             ];
             for vt in types {
                 roundtrip(&Operation::Transfer {
+                    policy_commit: [0u8; 32],
                     to_device_id: vec![0x01; 32],
                     amount: test_balance(1),
                     token_id: b"ERA".to_vec(),
@@ -2506,6 +2524,7 @@ mod tests {
         #[test]
         fn validate_transfer_zero_amount() {
             let op = Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(0),
                 token_id: b"ERA".to_vec(),
@@ -2524,6 +2543,7 @@ mod tests {
         #[test]
         fn validate_transfer_positive_amount() {
             let op = Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(100),
                 token_id: b"ERA".to_vec(),
@@ -2642,6 +2662,7 @@ mod tests {
             assert_eq!(Operation::Noop.get_operation_type(), "noop");
 
             let transfer = Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![],
                 amount: test_balance(1),
                 token_id: vec![],
@@ -2744,6 +2765,7 @@ mod tests {
         #[test]
         fn clears_transfer_signature() {
             let op = Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(100),
                 token_id: b"ERA".to_vec(),
@@ -2875,6 +2897,7 @@ mod tests {
         #[test]
         fn is_valid_transfer_positive() {
             let op = Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(100),
                 token_id: b"ERA".to_vec(),
@@ -2893,6 +2916,7 @@ mod tests {
         #[test]
         fn is_valid_transfer_zero() {
             let op = Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(0),
                 token_id: b"ERA".to_vec(),
@@ -2947,6 +2971,7 @@ mod tests {
         fn has_expired_returns_false() {
             assert!(!TokenOps::has_expired(&Operation::Genesis));
             let transfer = Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![],
                 amount: test_balance(1),
                 token_id: vec![],
@@ -3089,6 +3114,7 @@ mod tests {
         #[test]
         fn encoding_is_deterministic() {
             let op = Operation::Transfer {
+                policy_commit: [0u8; 32],
                 to_device_id: vec![0x01; 32],
                 amount: test_balance(42),
                 token_id: b"ERA".to_vec(),
@@ -3114,6 +3140,7 @@ mod tests {
                     fixed.insert(k.to_string(), v.clone());
                 }
                 Operation::Transfer {
+                    policy_commit: [0u8; 32],
                     to_device_id: vec![],
                     amount: test_balance(1),
                     token_id: vec![],

--- a/dsm_client/deterministic_state_machine/dsm/tests/bilateral_transaction_integration_tests.rs
+++ b/dsm_client/deterministic_state_machine/dsm/tests/bilateral_transaction_integration_tests.rs
@@ -149,6 +149,7 @@ async fn test_complete_bilateral_transaction_flow() {
     // 3) Pre-commitment creation
     let to_label = label_for(&bob_device_id);
     let mut transfer_operation = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: to_label.clone().into_bytes(),
         amount: {
             let mut b = Balance::zero();
@@ -350,6 +351,7 @@ async fn test_bilateral_relationship_anchor_generation() {
 #[test]
 fn test_operation_serialization() {
     let op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: b"recipient_123".to_vec(),
         amount: {
             let mut b = Balance::zero();

--- a/dsm_client/deterministic_state_machine/dsm/tests/smt_tripwire_theorem.rs
+++ b/dsm_client/deterministic_state_machine/dsm/tests/smt_tripwire_theorem.rs
@@ -93,6 +93,7 @@ fn compute_initial_chain_tip(
 /// Build a minimal Transfer operation and its canonical bytes.
 fn make_transfer_op(recipient: &[u8; 32], amount: u64) -> (Operation, Vec<u8>) {
     let op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: recipient.to_vec(),
         amount: Balance::from_state(amount, [0u8; 32]),
         token_id: b"ERA".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/examples/b0x_e2e.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/examples/b0x_e2e.rs
@@ -51,6 +51,7 @@ async fn main() {
     let balance_anchor =
         dsm::crypto::blake3::domain_hash(dsm::common::domain_tags::TAG_DSM_BALANCE_ANCHOR, &[]);
     let op = dsm::types::operations::Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: to_device_id.clone(),
         amount: dsm::types::token_types::Balance::from_state(1u64, *balance_anchor.as_bytes()),
         token_id: b"ERA".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/examples/bilateral_transaction_example.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/examples/bilateral_transaction_example.rs
@@ -240,6 +240,7 @@ impl BilateralTransactionExample {
         amount.update_add(100);
 
         let transfer = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: to_id.clone().into_bytes(),
             amount,
             token_id: b"DSM_TOKEN".to_vec(),
@@ -292,6 +293,7 @@ impl BilateralTransactionExample {
         amount.update_add(100);
 
         let op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: to_id.clone().into_bytes(),
             amount,
             token_id: b"DSM_TOKEN".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -3210,7 +3210,8 @@ impl BilateralBleHandler {
             } => {
                 // §9.5: independently resolve the sender's installed policy_commit;
                 // unresolved -> empty deltas -> conservation guard rejects (fail closed).
-                match crate::bridge::app_router().map(|r| r.resolve_policy_commit_strict(token_id)) {
+                match crate::bridge::app_router().map(|r| r.resolve_policy_commit_strict(token_id))
+                {
                     Some(Ok(pc)) => vec![dsm::types::device_state::BalanceDelta {
                         policy_commit: pc,
                         direction: dsm::types::device_state::BalanceDirection::Debit,
@@ -4097,7 +4098,8 @@ impl BilateralBleHandler {
                 // §9.5: independently resolve the receiver's installed policy_commit.
                 // Unresolved/uninstalled -> empty deltas -> the conservation guard
                 // rejects the Transfer (fail closed). Never absorb the peer's commit.
-                match crate::bridge::app_router().map(|r| r.resolve_policy_commit_strict(token_id)) {
+                match crate::bridge::app_router().map(|r| r.resolve_policy_commit_strict(token_id))
+                {
                     Some(Ok(pc)) => vec![dsm::types::device_state::BalanceDelta {
                         policy_commit: pc,
                         direction: dsm::types::device_state::BalanceDirection::Credit,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -5682,6 +5682,7 @@ mod tests {
         }
 
         let stale_op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: counterparty_device_id.to_vec(),
             amount: Balance::from_state(1, [1u8; 32]),
             token_id: b"ERA".to_vec(),
@@ -5695,6 +5696,7 @@ mod tests {
             signature: Vec::new(),
         };
         let next_op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: counterparty_device_id.to_vec(),
             amount: Balance::from_state(1, [1u8; 32]),
             token_id: b"ERA".to_vec(),
@@ -5800,6 +5802,7 @@ mod tests {
         }
 
         let accepted_op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: counterparty_device_id.to_vec(),
             amount: Balance::from_state(1, [1u8; 32]),
             token_id: b"ERA".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -3208,22 +3208,20 @@ impl BilateralBleHandler {
             dsm::types::operations::Operation::Transfer {
                 amount, token_id, ..
             } => {
-                let tid = std::str::from_utf8(token_id).unwrap_or("");
-                if tid.is_empty() {
-                    Vec::new()
-                } else {
-                    match dsm::core::token::token_state_manager::resolve_policy_commit(tid) {
-                        Ok(pc) => vec![dsm::types::device_state::BalanceDelta {
-                            policy_commit: pc,
-                            direction: dsm::types::device_state::BalanceDirection::Debit,
-                            amount: amount.value(),
-                        }],
-                        Err(e) => {
-                            log::warn!(
-                                "[bilateral_ble] skipping delta projection for unresolved token_id={tid}: {e}"
-                            );
-                            Vec::new()
-                        }
+                // §9.5: independently resolve the sender's installed policy_commit;
+                // unresolved -> empty deltas -> conservation guard rejects (fail closed).
+                match crate::bridge::app_router().map(|r| r.resolve_policy_commit_strict(token_id)) {
+                    Some(Ok(pc)) => vec![dsm::types::device_state::BalanceDelta {
+                        policy_commit: pc,
+                        direction: dsm::types::device_state::BalanceDirection::Debit,
+                        amount: amount.value(),
+                    }],
+                    _ => {
+                        log::warn!(
+                            "[bilateral_ble] sender delta: policy_commit unresolved (fail closed) token={}",
+                            String::from_utf8_lossy(token_id)
+                        );
+                        Vec::new()
                     }
                 }
             }
@@ -4096,22 +4094,21 @@ impl BilateralBleHandler {
             Operation::Transfer {
                 amount, token_id, ..
             } => {
-                let tid = std::str::from_utf8(token_id).unwrap_or("");
-                if tid.is_empty() {
-                    Vec::new()
-                } else {
-                    match dsm::core::token::token_state_manager::resolve_policy_commit(tid) {
-                        Ok(pc) => vec![dsm::types::device_state::BalanceDelta {
-                            policy_commit: pc,
-                            direction: dsm::types::device_state::BalanceDirection::Credit,
-                            amount: amount.value(),
-                        }],
-                        Err(e) => {
-                            log::warn!(
-                                "[bilateral_ble] skipping delta projection for unresolved token_id={tid}: {e}"
-                            );
-                            Vec::new()
-                        }
+                // §9.5: independently resolve the receiver's installed policy_commit.
+                // Unresolved/uninstalled -> empty deltas -> the conservation guard
+                // rejects the Transfer (fail closed). Never absorb the peer's commit.
+                match crate::bridge::app_router().map(|r| r.resolve_policy_commit_strict(token_id)) {
+                    Some(Ok(pc)) => vec![dsm::types::device_state::BalanceDelta {
+                        policy_commit: pc,
+                        direction: dsm::types::device_state::BalanceDirection::Credit,
+                        amount: amount.value(),
+                    }],
+                    _ => {
+                        log::warn!(
+                            "[bilateral_ble] receiver delta: policy_commit unresolved (fail closed) token={}",
+                            String::from_utf8_lossy(token_id)
+                        );
+                        Vec::new()
                     }
                 }
             }
@@ -4667,23 +4664,23 @@ impl BilateralBleHandler {
                     Operation::Transfer {
                         amount, token_id, ..
                     } => {
-                        let tid = std::str::from_utf8(token_id).unwrap_or("");
-                        if tid.is_empty() {
-                            Vec::new()
-                        } else {
-                            match dsm::core::token::token_state_manager::resolve_policy_commit(tid)
-                            {
-                                Ok(pc) => vec![dsm::types::device_state::BalanceDelta {
-                                    policy_commit: pc,
-                                    direction: dsm::types::device_state::BalanceDirection::Debit,
-                                    amount: amount.value(),
-                                }],
-                                Err(e) => {
-                                    log::warn!(
-                                        "[bilateral_ble] skipping delta projection for unresolved token_id={tid}: {e}"
-                                    );
-                                    Vec::new()
-                                }
+                        // §9.5: independently resolve the sender's installed
+                        // policy_commit; unresolved -> empty deltas -> conservation
+                        // guard rejects (fail closed).
+                        match crate::bridge::app_router()
+                            .map(|r| r.resolve_policy_commit_strict(token_id))
+                        {
+                            Some(Ok(pc)) => vec![dsm::types::device_state::BalanceDelta {
+                                policy_commit: pc,
+                                direction: dsm::types::device_state::BalanceDirection::Debit,
+                                amount: amount.value(),
+                            }],
+                            _ => {
+                                log::warn!(
+                                    "[bilateral_ble] sender delta: policy_commit unresolved (fail closed) token={}",
+                                    String::from_utf8_lossy(token_id)
+                                );
+                                Vec::new()
                             }
                         }
                     }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
@@ -98,6 +98,20 @@ pub trait AppRouter: Send + Sync {
         None
     }
 
+    /// §9.5: resolve a token's canonical `policy_commit` from the local
+    /// source-of-truth installed policy (builtins -> canonical constants;
+    /// custom -> the device's own registration history). Returns `Err` when the
+    /// policy is not locally installed — callers MUST fail closed and never
+    /// absorb a peer-supplied commit. Default impl fails closed.
+    fn resolve_policy_commit_strict(
+        &self,
+        _token_id: &[u8],
+    ) -> Result<[u8; 32], dsm::types::error::DsmError> {
+        Err(dsm::types::error::DsmError::invalid_operation(
+            "resolve_policy_commit_strict: unsupported by this router",
+        ))
+    }
+
     /// Pure-prepare view of the canonical AdvanceOutcome — used by the BLE
     /// sender to build a stitched receipt with the real post-advance SMT
     /// roots/proofs before the canonical commit lands (canonical commit

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
@@ -2571,6 +2571,13 @@ impl AppRouter for AppRouterImpl {
         self.core_sdk.device_head()
     }
 
+    fn resolve_policy_commit_strict(
+        &self,
+        token_id: &[u8],
+    ) -> Result<[u8; 32], dsm::types::error::DsmError> {
+        self.core_sdk.resolve_policy_commit_strict(token_id)
+    }
+
     fn execute_on_relationship_for_bilateral(
         &self,
         rel_key: [u8; 32],

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
@@ -991,7 +991,10 @@ impl AppRouterImpl {
         // §9.5: bind the token's canonical policy_commit into the signed transfer.
         // Resolve from the local source-of-truth installed policy; fail closed if
         // the token's policy is not installed (no peer-supplied fallback).
-        let policy_commit = match self.core_sdk.resolve_policy_commit_strict(token_id.as_bytes()) {
+        let policy_commit = match self
+            .core_sdk
+            .resolve_policy_commit_strict(token_id.as_bytes())
+        {
             Ok(pc) => pc,
             Err(e) => return err(format!("wallet.send: policy_commit resolve failed: {e}")),
         };

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
@@ -988,6 +988,13 @@ impl AppRouterImpl {
         // =====================================================================
         let balance_anchor =
             dsm::crypto::blake3::domain_hash(dsm::common::domain_tags::TAG_DSM_BALANCE_ANCHOR, &[]);
+        // §9.5: bind the token's canonical policy_commit into the signed transfer.
+        // Resolve from the local source-of-truth installed policy; fail closed if
+        // the token's policy is not installed (no peer-supplied fallback).
+        let policy_commit = match self.core_sdk.resolve_policy_commit_strict(token_id.as_bytes()) {
+            Ok(pc) => pc,
+            Err(e) => return err(format!("wallet.send: policy_commit resolve failed: {e}")),
+        };
         let signing_op = dsm::types::operations::Operation::Transfer {
             to_device_id: to_device_id.to_vec(),
             amount: dsm::types::token_types::Balance::from_state(
@@ -995,6 +1002,7 @@ impl AppRouterImpl {
                 *balance_anchor.as_bytes(),
             ),
             token_id: token_id.as_bytes().to_vec(),
+            policy_commit,
             mode: dsm::types::operations::TransactionMode::Unilateral,
             nonce: nonce.clone(),
             verification: dsm::types::operations::VerificationType::Standard,
@@ -1174,6 +1182,7 @@ impl AppRouterImpl {
                 *balance_anchor.as_bytes(),
             ),
             token_id: token_id.as_bytes().to_vec(),
+            policy_commit,
             mode: dsm::types::operations::TransactionMode::Unilateral,
             nonce: nonce.clone(),
             verification: dsm::types::operations::VerificationType::Standard,
@@ -1580,6 +1589,7 @@ impl AppRouterImpl {
                     *balance_anchor.as_bytes(),
                 ),
                 token_id: token_id.as_bytes().to_vec(),
+                policy_commit,
                 mode: dsm::types::operations::TransactionMode::Unilateral,
                 nonce: nonce.to_vec(),
                 verification: dsm::types::operations::VerificationType::Standard,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_settlement.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_settlement.rs
@@ -348,6 +348,7 @@ mod tests {
     #[test]
     fn parse_transfer_fields_returns_canonical_dbtc() {
         let op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: vec![0x11; 32],
             amount: Balance::from_state(5, [0u8; 32]),
             token_id: b"DBTC".to_vec(),
@@ -370,6 +371,7 @@ mod tests {
     fn parse_transfer_preserves_public_key_recipient_bytes() {
         let recipient_owner = vec![0x42; 64];
         let op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: vec![0x11; 32],
             amount: Balance::from_state(7, [0u8; 32]),
             token_id: b"ERA".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/wallet_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/wallet_routes.rs
@@ -209,6 +209,7 @@ fn encode_offline_transfer_operation_canonical(
     amount: u64,
     token_id: &str,
     memo: &str,
+    policy_commit: &[u8; 32],
 ) -> Vec<u8> {
     let mut out = Vec::new();
 
@@ -233,6 +234,8 @@ fn encode_offline_transfer_operation_canonical(
 
     let canonical_token_id = canonicalize_token_id(token_id);
     push_str(&mut out, &canonical_token_id);
+    // §9.5 policy_commit — length-prefixed 32 bytes, matching Operation::to_bytes.
+    push_bytes(&mut out, policy_commit);
     push_u8(&mut out, 0); // TransactionMode::Bilateral
     push_bytes(&mut out, &[]);
     push_u8(&mut out, 2); // VerificationType::Bilateral
@@ -727,11 +730,23 @@ impl AppRouterImpl {
                             }
                         }
                     };
+                    let policy_commit = match self
+                        .core_sdk
+                        .resolve_policy_commit_strict(token_id.as_bytes())
+                    {
+                        Ok(pc) => pc,
+                        Err(e) => {
+                            return err(format!(
+                                "wallet.sendOffline: policy_commit resolve failed: {e}"
+                            ))
+                        }
+                    };
                     encode_offline_transfer_operation_canonical(
                         &counterparty_device_id,
                         transfer_amount,
                         &token_id,
                         req.memo_hint.trim(),
+                        &policy_commit,
                     )
                 } else {
                     req.operation_data.clone()
@@ -1192,7 +1207,13 @@ mod tests {
     #[test]
     fn offline_transfer_operation_encodes_canonical_dbtc_token_id() {
         let to_device_id = [0xabu8; 32];
-        let bytes = encode_offline_transfer_operation_canonical(&to_device_id, 42, "DBTC", "memo");
+        let bytes = encode_offline_transfer_operation_canonical(
+            &to_device_id,
+            42,
+            "DBTC",
+            "memo",
+            &[0u8; 32],
+        );
 
         let op = Operation::from_bytes(&bytes).expect("transfer op should decode");
         match op {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/b0x_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/b0x_sdk.rs
@@ -2495,6 +2495,17 @@ impl B0xSDK {
                                     crate::sdk::app_state::AppState::get_public_key()
                                         .unwrap_or_else(|| transfer_req.to_device_id.clone());
 
+                                // §9.5: take the sender's signed policy_commit from the
+                                // canonical preimage so the reconstructed op matches what
+                                // was signed. The receiver independently re-resolves and
+                                // rejects on mismatch at apply (no peer-policy absorption).
+                                let policy_commit: [u8; 32] = match Operation::from_bytes(
+                                    &transfer_req.canonical_operation_bytes,
+                                ) {
+                                    Ok(Operation::Transfer { policy_commit, .. }) => policy_commit,
+                                    _ => [0u8; 32],
+                                };
+
                                 let transfer_op = Operation::Transfer {
                                     to_device_id: transfer_req.to_device_id.clone(),
                                     amount: dsm::types::token_types::Balance::from_state(
@@ -2506,6 +2517,7 @@ impl B0xSDK {
                                     } else {
                                         transfer_req.token_id.clone().into_bytes()
                                     },
+                                    policy_commit,
                                     mode: dsm::types::operations::TransactionMode::Unilateral,
                                     nonce: transfer_req.nonce.clone(),
                                     verification:

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -1607,7 +1607,10 @@ impl CoreSDK {
         }
     }
 
-    fn resolve_policy_commit_strict(&self, token_id: &[u8]) -> Result<[u8; 32], DsmError> {
+    pub(crate) fn resolve_policy_commit_strict(
+        &self,
+        token_id: &[u8],
+    ) -> Result<[u8; 32], DsmError> {
         let token_id = std::str::from_utf8(token_id)
             .map_err(|_| DsmError::invalid_operation("token_id must be valid UTF-8"))?;
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/smart_commitment_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/smart_commitment_sdk.rs
@@ -113,6 +113,7 @@ impl SmartCommitmentSDK {
                 to_device_id,
                 amount,
                 token_id,
+                policy_commit,
                 mode,
                 nonce,
                 verification: _,
@@ -124,6 +125,7 @@ impl SmartCommitmentSDK {
             } => {
                 buf.extend_from_slice(b"XFER");
                 Self::push_bytes(&mut buf, token_id);
+                Self::push_bytes(&mut buf, policy_commit);
                 Self::push_bytes(&mut buf, to_device_id);
                 Self::push_bytes(&mut buf, recipient);
                 Self::push_bytes(&mut buf, to);
@@ -251,8 +253,12 @@ impl SmartCommitmentSDK {
         &self,
         commitment: &SmartCommitmentSdk,
     ) -> Result<Operation, DsmError> {
+        let policy_commit = self
+            .core_sdk
+            .resolve_policy_commit_strict(commitment.token_id.as_bytes())?;
         Ok(Operation::Transfer {
             token_id: commitment.token_id.as_bytes().to_vec(),
+            policy_commit,
             amount: Balance::from_state(commitment.amount, [0u8; 32]),
             recipient: commitment.recipient.as_bytes().to_vec(),
             to: commitment.recipient.as_bytes().to_vec(),
@@ -507,6 +513,7 @@ mod tests {
 
     fn make_transfer_op() -> Operation {
         Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: b"device_A".to_vec(),
             amount: Balance::from_state(1000, [0u8; 32]),
             token_id: b"ROOT".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/smart_commitment_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/smart_commitment_sdk.rs
@@ -738,7 +738,8 @@ mod tests {
         let commitment = SmartCommitmentSdk {
             recipient: "alice".to_string(),
             amount: 250,
-            token_id: "ROOT".to_string(),
+            // builtin token so execute_commitment can resolve its policy_commit
+            token_id: "ERA".to_string(),
             condition: SdkCommitmentCondition::ConditionalOracle {
                 condition: "true".to_string(),
                 oracle_id: "o".to_string(),
@@ -771,7 +772,7 @@ mod tests {
         let commitment = SmartCommitmentSdk {
             recipient: "bob".to_string(),
             amount: 0,
-            token_id: "TOKEN".to_string(),
+            token_id: "ERA".to_string(),
             condition: SdkCommitmentCondition::ConditionalOracle {
                 condition: "".to_string(),
                 oracle_id: "".to_string(),
@@ -786,7 +787,7 @@ mod tests {
                 amount, token_id, ..
             } => {
                 assert_eq!(amount.value(), 0);
-                assert_eq!(token_id, b"TOKEN");
+                assert_eq!(token_id, b"ERA");
             }
             _ => panic!("Expected Transfer"),
         }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/token_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/token_sdk.rs
@@ -982,10 +982,12 @@ impl<I: Send + Sync> TokenSDK<I> {
             } => {
                 let sender = self.core_sdk.get_current_state()?.device_info.device_id;
 
+                let policy_commit = self.resolve_policy_commit_strict(token_id)?;
                 let mut op = Operation::Transfer {
                     to_device_id: recipient.to_vec(),
                     amount: Balance::from_state(*amount, state_hash),
                     token_id: token_id.as_bytes().to_vec(),
+                    policy_commit,
                     mode: TransactionMode::Bilateral,
                     nonce: Vec::new(),
                     verification: VerificationType::Standard,
@@ -1491,10 +1493,12 @@ impl<I: Send + Sync> TokenSDK<I> {
         message: String,
         use_bilateral: bool,
     ) -> Result<Operation, DsmError> {
+        let policy_commit = self.resolve_policy_commit_strict(&token_id)?;
         let mut op = Operation::Transfer {
             to_device_id: recipient.as_bytes().to_vec(),
             amount,
             token_id: token_id.into_bytes(),
+            policy_commit,
             message,
             mode: if use_bilateral {
                 TransactionMode::Bilateral
@@ -1544,6 +1548,8 @@ impl<I: Send + Sync> TokenSDK<I> {
             to_device_id: to.as_bytes().to_vec(),
             amount: Balance::zero(),
             token_id: vec![],
+            // Legacy placeholder builder (empty token, zero amount).
+            policy_commit: [0u8; 32],
             mode: TransactionMode::Bilateral,
             nonce: self.generate_nonce(),
             verification: VerificationType::Standard,
@@ -1570,10 +1576,12 @@ impl<I: Send + Sync> TokenSDK<I> {
     ) -> Result<Operation, DsmError> {
         let id = commitment.id.clone();
 
+        let policy_commit = self.resolve_policy_commit_strict("ERA")?;
         let mut op = Operation::Transfer {
             to_device_id: id.as_bytes().to_vec(),
             amount: Balance::zero(),
             token_id: b"ERA".to_vec(),
+            policy_commit,
             mode: TransactionMode::Bilateral,
             nonce: self.generate_nonce(),
             verification: VerificationType::Standard,
@@ -1944,8 +1952,10 @@ impl<I: Send + Sync> TokenSDK<I> {
             ));
         }
 
+        let policy_commit = self.resolve_policy_commit_strict(&token_id)?;
         let mut bilateral_transfer_op = Operation::Transfer {
             token_id: token_id.as_bytes().to_vec(),
+            policy_commit,
             to_device_id: recipient.to_vec(),
             amount: Balance::from_state(amount, state_hash.clone().try_into().unwrap_or([0u8; 32])),
             recipient: recipient_public_key,
@@ -2377,10 +2387,12 @@ impl<I: Send + Sync> TokenSDK<I> {
         }
 
         let current_state = self.core_sdk.get_current_state()?;
+        let fee_policy_commit = self.resolve_policy_commit_strict("ERA")?;
         let mut fee_transfer_op = Operation::Transfer {
             to_device_id: b"system.fee.device_id".to_vec(),
             amount: Balance::from_state(fee, state_hash.clone().try_into().unwrap_or([0u8; 32])),
             token_id: b"ERA".to_vec(),
+            policy_commit: fee_policy_commit,
             mode: TransactionMode::Bilateral,
             nonce: self.generate_nonce(),
             verification: VerificationType::Standard,
@@ -2557,8 +2569,10 @@ impl<I: Send + Sync> TokenSDK<I> {
             ));
         }
 
+        let policy_commit = self.resolve_policy_commit_strict(&token_id)?;
         let mut op = Operation::Transfer {
             token_id: token_id.as_bytes().to_vec(),
+            policy_commit,
             to_device_id: recipient_device_id.clone(),
             amount: Balance::from_state(amount, state_hash),
             mode: TransactionMode::Unilateral,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bcr.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bcr.rs
@@ -608,6 +608,7 @@ mod tests {
 
     fn sample_operation(tag: &[u8], amount: u64) -> Operation {
         Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: vec![0xBB; 32],
             amount: TokenBalance::from_state(amount, [0u8; 32]),
             token_id: b"ERA".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bcr.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bcr.rs
@@ -606,10 +606,12 @@ mod tests {
         crate::storage::client_db::init_database().expect("init db");
     }
 
+    // Recipient-credit transfer on device [0xA1] bound to policy_commit [0xD4],
+    // consistent with the conservation guard (to_device_id == device => Credit).
     fn sample_operation(tag: &[u8], amount: u64) -> Operation {
         Operation::Transfer {
-            policy_commit: [0u8; 32],
-            to_device_id: vec![0xBB; 32],
+            policy_commit: [0xD4; 32],
+            to_device_id: vec![0xA1; 32],
             amount: TokenBalance::from_state(amount, [0u8; 32]),
             token_id: b"ERA".to_vec(),
             mode: TransactionMode::Bilateral,
@@ -797,7 +799,7 @@ mod tests {
                 &[BalanceDelta {
                     policy_commit: [0xD4; 32],
                     direction: BalanceDirection::Credit,
-                    amount: 2,
+                    amount: 9,
                 }],
                 None,
                 None,
@@ -843,7 +845,7 @@ mod tests {
                 &[BalanceDelta {
                     policy_commit: [0xD4; 32],
                     direction: BalanceDirection::Credit,
-                    amount: 4,
+                    amount: 11,
                 }],
                 None,
                 Some([0xAA; 32]),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/codecs.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/codecs.rs
@@ -40,6 +40,7 @@ pub fn serialize_operation(op: &Operation) -> Vec<u8> {
             to_device_id,
             amount,
             token_id,
+            policy_commit,
             mode,
             nonce,
             verification,
@@ -61,6 +62,9 @@ pub fn serialize_operation(op: &Operation) -> Vec<u8> {
             let token_bytes = token_id.as_slice();
             bytes.extend_from_slice(&(token_bytes.len() as u32).to_le_bytes());
             bytes.extend_from_slice(token_bytes);
+
+            // CPTA policy commitment (§9.5) — fixed 32 bytes.
+            bytes.extend_from_slice(policy_commit);
 
             let mode_byte = match mode {
                 dsm::types::operations::TransactionMode::Unilateral => 0u8,
@@ -164,6 +168,14 @@ pub fn deserialize_operation(bytes: &[u8]) -> Result<Operation> {
             let amount = read_u64(&mut cursor)?;
             let token_id = read_bytes(&mut cursor)?;
 
+            // CPTA policy commitment (§9.5) — fixed 32 bytes.
+            if cursor.len() < 32 {
+                return Err(anyhow!("Incomplete Transfer policy_commit"));
+            }
+            let mut policy_commit = [0u8; 32];
+            policy_commit.copy_from_slice(&cursor[..32]);
+            cursor = &cursor[32..];
+
             if cursor.is_empty() {
                 return Err(anyhow!("Incomplete Transfer data"));
             }
@@ -215,6 +227,7 @@ pub fn deserialize_operation(bytes: &[u8]) -> Result<Operation> {
                 to_device_id,
                 amount: balance,
                 token_id,
+                policy_commit,
                 mode,
                 nonce,
                 verification,
@@ -481,6 +494,7 @@ mod tests {
     fn serialize_deserialize_transfer_round_trip() {
         let balance = dsm::types::token_types::Balance::from_state(1000, [0u8; 32]);
         let op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             to_device_id: vec![0xAAu8; 32],
             amount: balance,
             token_id: b"dBTC".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/b0x_integration.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/b0x_integration.rs
@@ -89,6 +89,7 @@ async fn test_b0x_integration_full_flow() {
     let amount = Balance::from_state(100, dummy_hash);
 
     let op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: recipient_id_bytes.clone(),
         amount,
         token_id: b"native".to_vec(),
@@ -289,6 +290,7 @@ async fn test_b0x_live_recipient_roundtrip() {
 
     let amount = Balance::from_state(7, [0u8; 32]);
     let op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: receiver_device.to_vec(),
         amount,
         token_id: b"ERA".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/bilateral_event_guarantee.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/bilateral_event_guarantee.rs
@@ -229,6 +229,7 @@ async fn verify_frontend_event_guarantees() {
 
     // --- Execute Transfer ---
     let transfer_op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: bob_dev_id.to_vec(),
         amount: Balance::from_state(100, [1u8; 32]),
         token_id: b"ERA".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/mixed_protocol_test.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/mixed_protocol_test.rs
@@ -26,6 +26,7 @@ fn make_transfer_op(
     message: &str,
 ) -> Operation {
     Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: remote_device_id.to_vec(),
         amount: Balance::from_state(amount, [0u8; 32]),
         token_id: b"token_1".to_vec(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/offline_real_protocol_ble_mock.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/offline_real_protocol_ble_mock.rs
@@ -379,6 +379,7 @@ async fn offline_real_protocol_ble_mock_roundtrip() {
     // Transfer operation (real protocol op)
     let amount = Balance::from_state(10, [1u8; 32]);
     let transfer_op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: bob_dev_id.to_vec(),
         amount,
         token_id: b"ERA".to_vec(),
@@ -763,6 +764,7 @@ async fn offline_real_protocol_ble_mock_multi_relationship_multi_tx() {
     }
 
     let op_ab_1 = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: bob_dev_id.to_vec(),
         amount: Balance::from_state(10, [1u8; 32]),
         token_id: b"ERA".to_vec(),
@@ -776,6 +778,7 @@ async fn offline_real_protocol_ble_mock_multi_relationship_multi_tx() {
         signature: Vec::new(),
     };
     let op_ab_2 = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: bob_dev_id.to_vec(),
         amount: Balance::from_state(20, [2u8; 32]),
         token_id: b"ERA".to_vec(),
@@ -789,6 +792,7 @@ async fn offline_real_protocol_ble_mock_multi_relationship_multi_tx() {
         signature: Vec::new(),
     };
     let op_ac_1 = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: carol_dev_id.to_vec(),
         amount: Balance::from_state(30, [3u8; 32]),
         token_id: b"ERA".to_vec(),
@@ -802,6 +806,7 @@ async fn offline_real_protocol_ble_mock_multi_relationship_multi_tx() {
         signature: Vec::new(),
     };
     let op_ac_2 = Operation::Transfer {
+        policy_commit: [0u8; 32],
         to_device_id: carol_dev_id.to_vec(),
         amount: Balance::from_state(40, [4u8; 32]),
         token_id: b"ERA".to_vec(),

--- a/tools/vertical_validation/src/adversarial_bilateral.rs
+++ b/tools/vertical_validation/src/adversarial_bilateral.rs
@@ -69,6 +69,7 @@ fn make_genesis(seed: &[u8; 32], pk: &[u8], initial_balance: u64) -> (State, Sta
 
 fn signed_transfer(sk: &[u8], state: &State, nonce: Vec<u8>, amount: u64) -> Operation {
     let mut op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         token_id: "ERA".into(),
         to_device_id: vec![0xCC; 32],
         amount: Balance::from_state(amount, state.hash),

--- a/tools/vertical_validation/src/bilateral_throughput.rs
+++ b/tools/vertical_validation/src/bilateral_throughput.rs
@@ -184,6 +184,7 @@ fn benchmark_with_signing(
 
         // Sign a transfer
         let mut op = Operation::Transfer {
+            policy_commit: [0u8; 32],
             token_id: "ERA".into(),
             to_device_id: vec![0xDD; 32],
             amount: Balance::from_state(1, state.hash),

--- a/tools/vertical_validation/src/implementation_traces.rs
+++ b/tools/vertical_validation/src/implementation_traces.rs
@@ -1889,6 +1889,7 @@ fn build_signed_transfer(
     recipient: Vec<u8>,
 ) -> Operation {
     let mut op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         token_id,
         to_device_id: recipient.clone(),
         amount: Balance::from_state(amount, current_state.hash),
@@ -1921,6 +1922,7 @@ fn build_signed_transfer_to_owner(
     recipient: Vec<u8>,
 ) -> Operation {
     let mut op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         token_id,
         to_device_id,
         amount: Balance::from_state(amount, current_state.hash),
@@ -1950,6 +1952,7 @@ fn build_signed_bilateral_transfer(
     nonce: u8,
 ) -> Operation {
     let mut op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         token_id: b"ERA".to_vec(),
         to_device_id: remote_device_id.to_vec(),
         amount: Balance::from_state(1, [0u8; 32]),

--- a/tools/vertical_validation/src/property_tests.rs
+++ b/tools/vertical_validation/src/property_tests.rs
@@ -128,6 +128,7 @@ fn build_signed_token_transfer(
     recipient: Vec<u8>,
 ) -> Operation {
     let mut op = Operation::Transfer {
+        policy_commit: [0u8; 32],
         token_id,
         to_device_id,
         amount: Balance::from_state(amount, current_state.hash),

--- a/tools/vertical_validation/src/tla_trace_replay.rs
+++ b/tools/vertical_validation/src/tla_trace_replay.rs
@@ -1428,6 +1428,7 @@ fn build_direct_signed_transfer(
     nonce.extend_from_slice(&payload_hash[..8]);
 
     let mut operation = Operation::Transfer {
+        policy_commit: [0u8; 32],
         token_id: TRACE_TOKEN_ID.to_vec(),
         to_device_id: recipient.clone(),
         amount: Balance::from_state(1, current_state.hash),


### PR DESCRIPTION
## What

Closes #448. Closes #467.

Enforces balance conservation by construction on the live state-advance path and binds the token's CPTA
`policy_commit` into the signed `Operation::Transfer` per whitepaper §9.5. This is the **first mandatory blocker**
of the custom-token policy + per-transfer readiness doctrine (added as a normative spec in this PR); the remaining
enforcement surfaces are tracked as Layer-B follow-ups.

## Why

- The canonical balance-mutation chokepoint `DeviceState::advance` applied caller-supplied `BalanceDelta`s blindly
  — conservation was enforced by *convention* at callers, not by *construction*; the real check
  (`verify_token_balance_consistency`) was dead (test-only, `&State`-typed).
- §9.5 ("All TokenOps MUST include `policy_commit`; verifiers reject if it differs from the token's creation
  `policy_commit`") was normative but `Operation::Transfer` carried only `token_id` (a spec↔code gap).
- The bilateral BLE path silently skipped the credit on an unresolved custom token instead of failing closed.

## How

- **Spec doctrine** (`.github/instructions/token-policy-readiness.instructions.md`): authoritative-source install,
  no absorption from peer/inbox/contact/offline, `policy_commit` bound in every transfer, per-transfer
  counterparty readiness, fail-closed. Each surface marked Layer A (shipped) or Layer B (planned, tracked).
- **`policy_commit` field** added (required `[u8;32]`) to `Operation::Transfer`, threaded through all three
  serializers in lockstep (canonical `to_bytes`/`from_bytes`, storage `codecs`, offline encoder) and every
  construction site. Production send sites resolve from the local source-of-truth installed policy via
  `resolve_policy_commit_strict` (builtins → constants; custom → BCR-history anchor walk; unknown → fail closed).
- **Conservation guard** at `DeviceState::advance`: for a Transfer, exactly one delta, `amount == op.amount`,
  direction `Credit` iff this device is the recipient else `Debit`, and `delta.policy_commit == op.policy_commit`;
  Mint = one Credit==amount; Burn = one Debit==amount; every other op carries no deltas. Rejects value
  creation/substitution regardless of caller. Code correspondence: lean4 `DSMOfflineFinality.lean`
  `commit_conservation` (no Lean change — the code realizes the existing theorem).
- **Bilateral fail-closed**: the three sender/receiver delta builders now resolve the device's *own* installed
  `policy_commit` via the new `AppRouter::resolve_policy_commit_strict` (no silent skip, no peer-policy
  absorption); unresolved → empty deltas → guard rejects. §9.5 receive enforcement is realized end-to-end: signed
  op carries `policy_commit`, receiver independently resolves the delta's commit, guard rejects unless they match.

## Migration

The required field changes the persisted Transfer-op wire layout (`bcr_chain_states`, `bilateral_sessions`), so
**beta installs must wipe their local DB on upgrade** (no auto-reset machinery). Early beta — acceptable.

## Tests / verification

- New `conservation_guard_rules` unit test + round-trip tests for all three serializers.
- `cargo clippy -p dsm -p dsm_sdk --all-features` clean.
- `cargo test -p dsm --lib` 1434 passed; `dsm` integration tests pass.
- `cargo test -p dsm_sdk --lib` (single-threaded) 1506 passed; offline `dsm_sdk` integration tests pass.
- Live-AWS e2e tests not run (need infra).

## Tracked Layer-B follow-ups

#466 (issuer/root-signed anchor verification), #468 (receiver-side install verification), #469 (sender readiness
preflight), #470 (online published readiness object), #471 (offline readiness exchange), #472 (fail-closed test
matrix), #473 (extend `policy_commit` binding to Mint/Burn/CreateToken). Custom-token transfer readiness is marked
INCOMPLETE until these close.

## Coordination with sibling PRs

- #446 (signed-byte binding): when it unifies signing onto a canonical encoder, it must use `to_bytes()` (now incl.
  `policy_commit`), not the divergent `encode_dsm_operation_det`.
- #450 (decoder trailing-byte exhaustion): the required fixed field keeps one-encoding-per-op; composes cleanly.
