### PR TITLE
chore: restore make lint (rustfmt + clippy) on main

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/common/device_admission.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/device_admission.rs
@@ -296,7 +296,14 @@ mod tests {
         let new_sig = sign_self_attestation(&genesis, &new_id, &new_pk, &new_sk).expect("self-sig");
         // Existing device gate-signs.
         let admission = assemble_and_gate_sign(
-            genesis, genesis, new_id, new_pk, parent_root, version, new_sig, &signer_sk,
+            genesis,
+            genesis,
+            new_id,
+            new_pk,
+            parent_root,
+            version,
+            new_sig,
+            &signer_sk,
         )
         .expect("gate-sign");
         (admission, signer_pk, genesis, current, version)
@@ -339,9 +346,13 @@ mod tests {
         // Attacker keeps a valid gate but swaps in a self-attestation under a different key.
         let (mut a, pk, genesis, current, version) = fixture();
         let (evil_pk, evil_sk) = kp(0x44);
-        a.signature_by_new_device =
-            sign_self_attestation(&genesis, &a.new_device_id, &a.new_device_signing_pubkey, &evil_sk)
-                .unwrap();
+        a.signature_by_new_device = sign_self_attestation(
+            &genesis,
+            &a.new_device_id,
+            &a.new_device_signing_pubkey,
+            &evil_sk,
+        )
+        .unwrap();
         let _ = evil_pk;
         // Self-attestation no longer matches new_device_signing_pubkey → rejected.
         assert!(verify_add_device_admission(&a, &genesis, &current, version, &pk).is_err());
@@ -358,7 +369,14 @@ mod tests {
         let parent_root = DeviceTree::new(current.clone()).root();
         let new_sig = sign_self_attestation(&genesis, &new_id, &new_pk, &new_sk).unwrap();
         let a = assemble_and_gate_sign(
-            genesis, stranger_id, new_id, new_pk, parent_root, 1, new_sig, &stranger_sk,
+            genesis,
+            stranger_id,
+            new_id,
+            new_pk,
+            parent_root,
+            1,
+            new_sig,
+            &stranger_sk,
         )
         .unwrap();
         assert!(verify_add_device_admission(&a, &genesis, &current, 1, &stranger_pk).is_err());

--- a/dsm_client/deterministic_state_machine/dsm/src/common/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/mod.rs
@@ -11,10 +11,10 @@
 
 /// Centralized canonical encoding for cryptographic commitments
 pub mod canonical_encoding;
-/// Additional-device admission (§16.3 — existing device admits a new device into the tree)
-pub mod device_admission;
 /// Deterministic ID generation (no UUID, no wall-clock)
 pub mod deterministic_id;
+/// Additional-device admission (§16.3 — existing device admits a new device into the tree)
+pub mod device_admission;
 pub mod device_tree;
 /// Domain tag constants for BLAKE3 domain-separated hashing
 pub mod domain_tags;

--- a/dsm_client/deterministic_state_machine/dsm/src/dlv/controller_rotation.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/dlv/controller_rotation.rs
@@ -77,10 +77,20 @@ impl core::fmt::Display for RotationError {
             PolicyMismatch => write!(f, "rotation dlv_policy_digest does not match"),
             StaleParent => write!(f, "rotation parent is not the current tip (stale/rollback)"),
             WrongController => write!(f, "old_controller_devid is not the active controller"),
-            ValueStateDrift => write!(f, "rotation does not preserve the latest value-state commit"),
-            ControllerUnchanged => write!(f, "new controller equals old controller (not a rotation)"),
-            ChildTipMismatch => write!(f, "child tip is not the canonical value-preserving child state"),
-            RecoveryAuthorityMismatch => write!(f, "authority public key does not match recovery_commit"),
+            ValueStateDrift => write!(
+                f,
+                "rotation does not preserve the latest value-state commit"
+            ),
+            ControllerUnchanged => {
+                write!(f, "new controller equals old controller (not a rotation)")
+            }
+            ChildTipMismatch => write!(
+                f,
+                "child tip is not the canonical value-preserving child state"
+            ),
+            RecoveryAuthorityMismatch => {
+                write!(f, "authority public key does not match recovery_commit")
+            }
             SignatureInvalid => write!(f, "recovery authority signature verification failed"),
             SignFailed(m) => write!(f, "sphincs sign failed: {m}"),
         }
@@ -288,7 +298,7 @@ mod tests {
     fn value_drift_rejected() {
         let (latest, mut r, pk) = fixture();
         r.latest_value_state_commit = [0xCD; 32]; // attempt to change the balance
-        // Signature now mismatches too, but the value-drift check fires first.
+                                                  // Signature now mismatches too, but the value-drift check fires first.
         assert_eq!(
             validate_controller_rotation(&r, &latest, &pk),
             Err(RotationError::ValueStateDrift)

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/activation.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/activation.rs
@@ -128,7 +128,10 @@ impl RecoveryActivationSeal {
             genesis_id: seal_fixed32(&p.genesis_id, "genesis_id")?,
             old_device_id: seal_fixed32(&p.old_device_id, "old_device_id")?,
             new_device_id: seal_fixed32(&p.new_device_id, "new_device_id")?,
-            recovery_intent_digest: seal_fixed32(&p.recovery_intent_digest, "recovery_intent_digest")?,
+            recovery_intent_digest: seal_fixed32(
+                &p.recovery_intent_digest,
+                "recovery_intent_digest",
+            )?,
             tombstone_proposal_digest: seal_fixed32(
                 &p.tombstone_proposal_digest,
                 "tombstone_proposal_digest",
@@ -230,9 +233,13 @@ mod tests {
         let a_old_str = crate::types::identifiers::encode_crockford(&OLD);
         let tombstone =
             create_tombstone(&[0x01; 32], 0, &[0x02; 32], &a_old_str, &kp.secret_key).expect("t");
-        let succession =
-            create_succession(&tombstone.tombstone_hash, &NEW.to_vec(), &a_old_str, &kp.secret_key)
-                .expect("s");
+        let succession = create_succession(
+            &tombstone.tombstone_hash,
+            NEW.as_ref(),
+            &a_old_str,
+            &kp.secret_key,
+        )
+        .expect("s");
         CrossRelationshipSuccessionEvidence {
             a_old: OLD,
             a_new: NEW,
@@ -361,8 +368,14 @@ mod tests {
     fn evidence_root_is_order_independent() {
         let a = ([1u8; 32], [0xAA; 32]);
         let b = ([2u8; 32], [0xBB; 32]);
-        assert_eq!(compute_evidence_root(&[a, b]), compute_evidence_root(&[b, a]));
+        assert_eq!(
+            compute_evidence_root(&[a, b]),
+            compute_evidence_root(&[b, a])
+        );
         let b2 = ([2u8; 32], [0xCC; 32]);
-        assert_ne!(compute_evidence_root(&[a, b]), compute_evidence_root(&[a, b2]));
+        assert_ne!(
+            compute_evidence_root(&[a, b]),
+            compute_evidence_root(&[a, b2])
+        );
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/assembly.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/assembly.rs
@@ -37,9 +37,7 @@ use crate::recovery::activation::{
 };
 use crate::recovery::chain_segment::{RecoveryEstablishmentReceipt, RelationshipChainSegment};
 use crate::recovery::gate_set::{build_gate_set, CounterpartyValueWitness, FrozenGateSet};
-use crate::recovery::pdsmt_posting::{
-    verify_head_with_leaves, PostedPdsmtHead, PostedPdsmtLeafRecord,
-};
+use crate::recovery::pdsmt_posting::{verify_head_with_leaves, PostedPdsmtHead, PostedPdsmtLeafRecord};
 use crate::recovery::succession_binding::{
     compute_carry_forward_commitment, CrossRelationshipSuccessionEvidence,
 };
@@ -376,7 +374,11 @@ mod tests {
             authority_pubkey: kp.public_key.clone(),
         };
         head.signature = sphincs_sign(&kp.secret_key, &head.digest()).expect("sign");
-        (head, compute_authority_pubkey_commit(&kp.public_key), leaves)
+        (
+            head,
+            compute_authority_pubkey_commit(&kp.public_key),
+            leaves,
+        )
     }
 
     fn old_chain_state(rel_key: [u8; 32], parent: [u8; 32], tag: u8) -> RelationshipChainState {
@@ -407,9 +409,13 @@ mod tests {
         let a_old_str = crate::types::identifiers::encode_crockford(&A_OLD);
         let tombstone =
             create_tombstone(&[0x01; 32], 0, &[0x02; 32], &a_old_str, &ka.secret_key).expect("t");
-        let succession =
-            create_succession(&tombstone.tombstone_hash, &A_NEW.to_vec(), &a_old_str, &ka.secret_key)
-                .expect("s");
+        let succession = create_succession(
+            &tombstone.tombstone_hash,
+            A_NEW.as_ref(),
+            &a_old_str,
+            &ka.secret_key,
+        )
+        .expect("s");
 
         let old_rel_key = compute_smt_key(&A_OLD, &c);
         let new_rel_key = compute_smt_key(&A_NEW, &c);

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/authority_anchor.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/authority_anchor.rs
@@ -44,10 +44,8 @@ use crate::crypto::sphincs::{sphincs_sign, sphincs_verify};
 use crate::types::error::DsmError;
 use crate::types::proto::{Message as _, RecoveryAuthorityAnchorProto};
 
-const AUTHORITY_COMMIT_DOMAIN: &str =
-    crate::common::domain_tags::TAG_DSM_RECOVERY_AUTHORITY_COMMIT;
-const AUTHORITY_ANCHOR_DOMAIN: &str =
-    crate::common::domain_tags::TAG_DSM_RECOVERY_AUTHORITY_ANCHOR;
+const AUTHORITY_COMMIT_DOMAIN: &str = crate::common::domain_tags::TAG_DSM_RECOVERY_AUTHORITY_COMMIT;
+const AUTHORITY_ANCHOR_DOMAIN: &str = crate::common::domain_tags::TAG_DSM_RECOVERY_AUTHORITY_ANCHOR;
 
 /// Commit to a recovery-authority public key (length-prefixed, domain-separated).
 pub fn compute_authority_pubkey_commit(authority_pubkey: &[u8]) -> [u8; 32] {
@@ -126,7 +124,8 @@ impl RecoveryAuthorityAnchor {
                 "authority-anchor: device_id does not match the device under recovery",
             ));
         }
-        if self.authority_pubkey_commit != compute_authority_pubkey_commit(candidate_authority_pubkey)
+        if self.authority_pubkey_commit
+            != compute_authority_pubkey_commit(candidate_authority_pubkey)
         {
             return Err(DsmError::verification(
                 "authority-anchor: candidate authority pubkey does not match the anchored commitment",
@@ -138,7 +137,11 @@ impl RecoveryAuthorityAnchor {
                 "authority-anchor: genesis signing-key signature invalid (genesis binding failed)",
             ));
         }
-        if !sphincs_verify(candidate_authority_pubkey, &digest, &self.authority_signature)? {
+        if !sphincs_verify(
+            candidate_authority_pubkey,
+            &digest,
+            &self.authority_signature,
+        )? {
             return Err(DsmError::verification(
                 "authority-anchor: authority self-signature invalid (possession proof failed)",
             ));
@@ -171,7 +174,10 @@ impl RecoveryAuthorityAnchor {
         Ok(Self {
             genesis_id: fixed32(&p.genesis_id, "genesis_id")?,
             device_id: fixed32(&p.device_id, "device_id")?,
-            authority_pubkey_commit: fixed32(&p.authority_pubkey_commit, "authority_pubkey_commit")?,
+            authority_pubkey_commit: fixed32(
+                &p.authority_pubkey_commit,
+                "authority_pubkey_commit",
+            )?,
             device_signature: p.device_signature,
             authority_signature: p.authority_signature,
         })
@@ -238,7 +244,11 @@ mod tests {
             &authority_kp.secret_key,
         )
         .expect("anchor");
-        (anchor, device_kp.public_key.clone(), authority_kp.public_key.clone())
+        (
+            anchor,
+            device_kp.public_key.clone(),
+            authority_kp.public_key.clone(),
+        )
     }
 
     #[test]
@@ -252,7 +262,9 @@ mod tests {
         let (anchor, gpk, _apk) = fixture();
         let other = kp(0x99);
         // Different authority pubkey → commitment mismatch (and possession-proof fail).
-        assert!(anchor.verify(&GENESIS, &DEVICE, &gpk, &other.public_key).is_err());
+        assert!(anchor
+            .verify(&GENESIS, &DEVICE, &gpk, &other.public_key)
+            .is_err());
     }
 
     #[test]
@@ -267,7 +279,9 @@ mod tests {
         let (anchor, _gpk, apk) = fixture();
         let other = kp(0x55);
         // A different device-key holder cannot have produced the genesis-binding sig.
-        assert!(anchor.verify(&GENESIS, &DEVICE, &other.public_key, &apk).is_err());
+        assert!(anchor
+            .verify(&GENESIS, &DEVICE, &other.public_key, &apk)
+            .is_err());
     }
 
     #[test]
@@ -315,7 +329,10 @@ mod tests {
             &thief_auth.secret_key,
         )
         .expect("forged");
-        assert_ne!(legit.authority_pubkey_commit, forged.authority_pubkey_commit);
+        assert_ne!(
+            legit.authority_pubkey_commit,
+            forged.authority_pubkey_commit
+        );
         // The legit authority pubkey does not validate against the forged anchor.
         assert!(forged.verify(&GENESIS, &DEVICE, &gpk, &legit_apk).is_err());
     }
@@ -327,7 +344,9 @@ mod tests {
         let decoded = RecoveryAuthorityAnchor::from_bytes(&bytes).expect("decode");
         assert_eq!(anchor, decoded);
         // The decoded anchor still verifies end-to-end.
-        decoded.verify(&GENESIS, &DEVICE, &gpk, &apk).expect("verify after round-trip");
+        decoded
+            .verify(&GENESIS, &DEVICE, &gpk, &apk)
+            .expect("verify after round-trip");
         // Re-encode is byte-identical (canonical).
         assert_eq!(bytes, decoded.to_bytes());
     }

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/bundle.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/bundle.rs
@@ -88,7 +88,7 @@ mod tests {
             create_tombstone(&[0x01; 32], 0, &[0x02; 32], device_id, &kp.secret_key).expect("t");
         let succession = create_succession(
             &tombstone.tombstone_hash,
-            &[0xAA; 32].to_vec(),
+            [0xAA; 32].as_ref(),
             device_id,
             &kp.secret_key,
         )

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/capsule.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/capsule.rs
@@ -26,8 +26,7 @@ const RECOVERY_AEAD_CONTEXT: &str = "DSM/recovery-aead\0";
 const RECOVERY_AUTHORITY_CONTEXT: &str = "DSM/recovery-authority\0";
 const RECOVERY_NONCE_DOMAIN: &str = crate::common::domain_tags::TAG_DSM_RECOVERY_NONCE;
 const RECOVERY_CHALLENGE_DOMAIN: &str = crate::common::domain_tags::TAG_DSM_RECOVERY_CHALLENGE;
-const RECOVERY_CONTACT_SET_DOMAIN: &str =
-    crate::common::domain_tags::TAG_DSM_RECOVERY_CONTACT_SET;
+const RECOVERY_CONTACT_SET_DOMAIN: &str = crate::common::domain_tags::TAG_DSM_RECOVERY_CONTACT_SET;
 
 /// Initialize the capsule encryption/decryption subsystem.
 pub fn init_capsule_subsystem() -> Result<(), DsmError> {
@@ -114,9 +113,7 @@ fn hash_sorted_contact_ids(sorted: &[String]) -> [u8; 32] {
     *hasher.finalize().as_bytes()
 }
 
-pub fn compute_contact_set_commit(
-    counterparty_tips: &HashMap<String, (u64, Vec<u8>)>,
-) -> [u8; 32] {
+pub fn compute_contact_set_commit(counterparty_tips: &HashMap<String, (u64, Vec<u8>)>) -> [u8; 32] {
     let mut ids: Vec<String> = counterparty_tips.keys().cloned().collect();
     ids.sort_unstable();
     hash_sorted_contact_ids(&ids)
@@ -127,9 +124,7 @@ pub fn compute_contact_set_commit(
 /// canonical Crockford string used as the capsule's `counterparty_tips` keys, so
 /// the capsule and seal contact-set commitments are byte-identical for the same
 /// contact set (gate-set anchor consistency, R4).
-pub fn contact_set_commit_from_device_ids(
-    ids: &std::collections::BTreeSet<[u8; 32]>,
-) -> [u8; 32] {
+pub fn contact_set_commit_from_device_ids(ids: &std::collections::BTreeSet<[u8; 32]>) -> [u8; 32] {
     let mut strs: Vec<String> = ids
         .iter()
         .map(|id| crate::types::identifiers::encode_crockford(id))

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/chain_segment.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/chain_segment.rs
@@ -27,9 +27,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::core::bilateral_transaction_manager::{
-    compute_smt_key, initial_chain_tip_from_device_ids,
-};
+use crate::core::bilateral_transaction_manager::{compute_smt_key, initial_chain_tip_from_device_ids};
 use crate::crypto::blake3::dsm_domain_hasher;
 use crate::recovery::succession_binding::verify_forward_ancestry;
 use crate::types::device_state::RelationshipChainState;
@@ -241,9 +239,10 @@ impl RecoveryEstablishmentReceipt {
                 Some(e),
             )
         })?;
-        let state = p.state.as_ref().ok_or_else(|| {
-            DsmError::verification("establish-receipt: missing state")
-        })?;
+        let state = p
+            .state
+            .as_ref()
+            .ok_or_else(|| DsmError::verification("establish-receipt: missing state"))?;
         Ok(Self {
             rel_key: fixed32("rel_key", &p.rel_key)?,
             state: rel_chain_state_from_proto(state)?,
@@ -267,7 +266,9 @@ impl RecoveryEstablishmentReceipt {
     /// caller treats `None` as a fail-closed mismatch.
     pub fn bound_commitment(&self) -> Option<[u8; 32]> {
         match &self.state.operation {
-            Operation::CreateRelationship { commitment, .. } => commitment.as_slice().try_into().ok(),
+            Operation::CreateRelationship { commitment, .. } => {
+                commitment.as_slice().try_into().ok()
+            }
             _ => None,
         }
     }
@@ -301,7 +302,9 @@ impl RecoveryEstablishmentReceipt {
             ));
         }
         match &self.state.operation {
-            Operation::CreateRelationship { counterparty_id, .. } => {
+            Operation::CreateRelationship {
+                counterparty_id, ..
+            } => {
                 if counterparty_id.as_slice() != c {
                     return Err(DsmError::verification(
                         "establish-receipt: op counterparty_id != C",
@@ -327,7 +330,12 @@ mod tests {
     const A_NEW: [u8; 32] = [0xA1; 32];
     const C: [u8; 32] = [0xCC; 32];
 
-    fn mk_state(rel_key: [u8; 32], parent: [u8; 32], c: [u8; 32], tag: u8) -> RelationshipChainState {
+    fn mk_state(
+        rel_key: [u8; 32],
+        parent: [u8; 32],
+        c: [u8; 32],
+        tag: u8,
+    ) -> RelationshipChainState {
         let mut bw = BTreeMap::new();
         bw.insert([tag; 32], tag as u64);
         RelationshipChainState {
@@ -342,7 +350,11 @@ mod tests {
                 mode: TransactionMode::Bilateral,
             },
             entropy: vec![tag, tag, tag],
-            encapsulated_entropy: if tag % 2 == 0 { Some(vec![tag; 4]) } else { None },
+            encapsulated_entropy: if tag.is_multiple_of(2) {
+                Some(vec![tag; 4])
+            } else {
+                None
+            },
             balance_witness: bw,
             entity_sig: Some(vec![0x11; 8]),
             counterparty_sig: None,
@@ -404,7 +416,8 @@ mod tests {
             current_tip: floor,
             states: Vec::new(),
         };
-        ok.verify().expect("empty == floor is valid (no divergence)");
+        ok.verify()
+            .expect("empty == floor is valid (no divergence)");
 
         let bad = RelationshipChainSegment {
             rel_key: rk,

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/dbtc_backing.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/dbtc_backing.rs
@@ -121,7 +121,11 @@ mod tests {
                 for derivable in [false, true] {
                     let c = classify_dbtc_backing(&facts(unspent, confirmed, derivable));
                     if !(unspent && confirmed && derivable) {
-                        assert_ne!(c, DbtcVaultCondition::Spendable, "u={unspent} c={confirmed} d={derivable}");
+                        assert_ne!(
+                            c,
+                            DbtcVaultCondition::Spendable,
+                            "u={unspent} c={confirmed} d={derivable}"
+                        );
                     }
                 }
             }

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/dbtc_reconcile.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/dbtc_reconcile.rs
@@ -125,7 +125,10 @@ mod tests {
         assert_eq!(
             aggregate_dbtc_frontier(
                 100,
-                &[o(80, DbtcVaultCondition::Spendable), o(40, DbtcVaultCondition::Spendable)]
+                &[
+                    o(80, DbtcVaultCondition::Spendable),
+                    o(40, DbtcVaultCondition::Spendable)
+                ]
             ),
             (BearerAssetLockState::Spendable, 120)
         );

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/dbtc_vault_index.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/dbtc_vault_index.rs
@@ -70,7 +70,9 @@ impl PostedDbtcVaultIndex {
     /// from the device's anchor + device-tree quorum). Fail-closed at every step.
     pub fn verify(&self, anchored_authority_commit: &[u8; 32]) -> Result<(), DsmError> {
         if self.authority_pubkey.is_empty() {
-            return Err(DsmError::verification("dbtc-vault-index: no authority_pubkey"));
+            return Err(DsmError::verification(
+                "dbtc-vault-index: no authority_pubkey",
+            ));
         }
         if compute_authority_pubkey_commit(&self.authority_pubkey) != self.authority_pubkey_commit {
             return Err(DsmError::verification(
@@ -115,7 +117,10 @@ impl PostedDbtcVaultIndex {
             genesis_id: fixed32(&p.genesis_id, "genesis_id")?,
             device_id: fixed32(&p.device_id, "device_id")?,
             vault_ids: p.vault_ids,
-            authority_pubkey_commit: fixed32(&p.authority_pubkey_commit, "authority_pubkey_commit")?,
+            authority_pubkey_commit: fixed32(
+                &p.authority_pubkey_commit,
+                "authority_pubkey_commit",
+            )?,
             authority_pubkey: p.authority_pubkey,
             signature: p.signature,
         })
@@ -172,7 +177,10 @@ mod tests {
     #[test]
     fn build_canonicalizes_and_verifies() {
         let (idx, pk) = sample();
-        assert_eq!(idx.vault_ids, vec!["VAULTA".to_string(), "VAULTB".to_string()]);
+        assert_eq!(
+            idx.vault_ids,
+            vec!["VAULTA".to_string(), "VAULTB".to_string()]
+        );
         idx.verify(&anchored(&pk)).expect("verify");
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/gate_set.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/gate_set.rs
@@ -221,11 +221,20 @@ mod tests {
         };
         head.signature = sphincs_sign(&kp.secret_key, &head.digest()).expect("sign");
         // Return the genesis-anchored authority commit (what build_gate_set/verify take).
-        (head, compute_authority_pubkey_commit(&kp.public_key), leaves)
+        (
+            head,
+            compute_authority_pubkey_commit(&kp.public_key),
+            leaves,
+        )
     }
 
     /// A counterparty `c` posts its OWN snapshot containing a value-capable leaf about A_old.
-    fn witness_for(c: [u8; 32], c_genesis: [u8; 32], seed: u8, vc: ValueCapability) -> CounterpartyValueWitness {
+    fn witness_for(
+        c: [u8; 32],
+        c_genesis: [u8; 32],
+        seed: u8,
+        vc: ValueCapability,
+    ) -> CounterpartyValueWitness {
         let (head, commit, leaves) = posted_snapshot(c, c_genesis, seed, &[(A_OLD, vc)]);
         CounterpartyValueWitness {
             head,
@@ -241,17 +250,16 @@ mod tests {
         let c2 = [0xC2; 32];
         let c3 = [0xC3; 32];
         // C1, C2 value-capable; C3 a pure contact relationship.
-        let (head, pk, leaves) =
-            posted_snapshot(
-                A_OLD,
-                g_a,
-                0x42,
-                &[
-                    (c1, ValueCapability::Yes),
-                    (c2, ValueCapability::Yes),
-                    (c3, ValueCapability::No),
-                ],
-            );
+        let (head, pk, leaves) = posted_snapshot(
+            A_OLD,
+            g_a,
+            0x42,
+            &[
+                (c1, ValueCapability::Yes),
+                (c2, ValueCapability::Yes),
+                (c3, ValueCapability::No),
+            ],
+        );
         let gs = build_gate_set(&A_OLD, &head, &pk, &leaves, &[]).expect("gate set");
         assert_eq!(gs.members, BTreeSet::from([c1, c2]));
         assert_eq!(
@@ -323,8 +331,12 @@ mod tests {
         let c1 = [0xC1; 32];
         let (head, pk, leaves) = posted_snapshot(A_OLD, g_a, 0x42, &[(c1, ValueCapability::Yes)]);
         // Witness whose leaf is about a DIFFERENT device, not A_old.
-        let (w_head, w_commit, w_leaves) =
-            posted_snapshot([0xC9; 32], [0xD9; 32], 0x55, &[([0xBB; 32], ValueCapability::Yes)]);
+        let (w_head, w_commit, w_leaves) = posted_snapshot(
+            [0xC9; 32],
+            [0xD9; 32],
+            0x55,
+            &[([0xBB; 32], ValueCapability::Yes)],
+        );
         let w = CounterpartyValueWitness {
             head: w_head,
             authority_commit: w_commit,

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/mod.rs
@@ -11,11 +11,11 @@ pub mod assembly;
 pub mod authority_anchor;
 pub mod bearer_lock;
 pub mod bundle;
+pub mod capsule;
+pub mod chain_segment;
 pub mod dbtc_backing;
 pub mod dbtc_reconcile;
 pub mod dbtc_vault_index;
-pub mod capsule;
-pub mod chain_segment;
 pub mod gate_set;
 pub mod pdsmt_posting;
 pub mod rollup;
@@ -23,9 +23,7 @@ pub mod succession_binding;
 pub mod succession_proof;
 pub mod tombstone;
 
-pub use activation::{
-    compute_evidence_root, validate_recovery_activation, RecoveryActivationSeal,
-};
+pub use activation::{compute_evidence_root, validate_recovery_activation, RecoveryActivationSeal};
 pub use assembly::{
     assemble_recovery_activation, AssembledActivation, CounterpartyRecoveryInput,
     RecoveryAssemblyInputs,

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/pdsmt_posting.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/pdsmt_posting.rs
@@ -228,7 +228,10 @@ impl PostedPdsmtHead {
             pd_smt_root: fixed32(&p.pd_smt_root, "pd_smt_root")?,
             leaf_index_root: fixed32(&p.leaf_index_root, "leaf_index_root")?,
             snapshot_id: fixed32(&p.snapshot_id, "snapshot_id")?,
-            authority_pubkey_commit: fixed32(&p.authority_pubkey_commit, "authority_pubkey_commit")?,
+            authority_pubkey_commit: fixed32(
+                &p.authority_pubkey_commit,
+                "authority_pubkey_commit",
+            )?,
             parent_head_hash: fixed32(&p.parent_head_hash, "parent_head_hash")?,
             head_number: p.head_number,
             signature: p.signature,
@@ -335,7 +338,10 @@ impl PostedPdsmtLeafRecord {
         let counterparty_genesis_id = if p.counterparty_genesis_id.is_empty() {
             None
         } else {
-            Some(fixed32(&p.counterparty_genesis_id, "counterparty_genesis_id")?)
+            Some(fixed32(
+                &p.counterparty_genesis_id,
+                "counterparty_genesis_id",
+            )?)
         };
         Ok(Self {
             genesis_id: fixed32(&p.genesis_id, "genesis_id")?,
@@ -462,9 +468,11 @@ pub fn build_pdsmt_snapshot(
             inclusion_proof_to_pd_smt_root: Vec::new(),
             inclusion_proof_to_leaf_index_root: Vec::new(),
         };
-        index.update_leaf(rel_key, &leaf.committed_digest()).map_err(|e| {
-            DsmError::invalid_operation(format!("pdsmt snapshot: leaf index update: {e}"))
-        })?;
+        index
+            .update_leaf(rel_key, &leaf.committed_digest())
+            .map_err(|e| {
+                DsmError::invalid_operation(format!("pdsmt snapshot: leaf index update: {e}"))
+            })?;
         leaves.push(leaf);
     }
     let leaf_index_root = *index.root();
@@ -582,7 +590,9 @@ mod tests {
         let (head, pk) = signed_head();
         let decoded = PostedPdsmtHead::from_bytes(&head.to_bytes()).expect("decode");
         assert_eq!(head, decoded);
-        decoded.verify(&anchored(&pk)).expect("verify after round-trip");
+        decoded
+            .verify(&anchored(&pk))
+            .expect("verify after round-trip");
         assert_eq!(head.to_bytes(), decoded.to_bytes());
     }
 
@@ -688,7 +698,8 @@ mod tests {
     #[test]
     fn leaf_verify_inclusion_passes_and_rejects_tamper() {
         let (l, pd_root, idx_root) = leaf_with_real_proofs();
-        l.verify_inclusion(&pd_root, &idx_root).expect("valid inclusion");
+        l.verify_inclusion(&pd_root, &idx_root)
+            .expect("valid inclusion");
         // Wrong roots fail.
         assert!(l.verify_inclusion(&[0u8; 32], &idx_root).is_err());
         assert!(l.verify_inclusion(&pd_root, &[0u8; 32]).is_err());
@@ -738,7 +749,10 @@ mod tests {
         other_reason.value_capability_reason = "dlv collateral lock".into();
         assert_ne!(yes.committed_digest(), other_reason.committed_digest());
         // Deterministic.
-        assert_eq!(yes.committed_digest(), leaf(ValueCapability::Yes).committed_digest());
+        assert_eq!(
+            yes.committed_digest(),
+            leaf(ValueCapability::Yes).committed_digest()
+        );
         // Inclusion proofs are NOT part of the committed value.
         let mut diff_proof = leaf(ValueCapability::Yes);
         diff_proof.inclusion_proof_to_pd_smt_root = vec![9, 9, 9];

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/succession_binding.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/succession_binding.rs
@@ -144,7 +144,9 @@ pub fn verify_forward_ancestry(
     let mut last = *floor_tip;
     for s in chain {
         if &s.rel_key != rel_key {
-            return Err(DsmError::verification("ancestry: rel_key mismatch in chain"));
+            return Err(DsmError::verification(
+                "ancestry: rel_key mismatch in chain",
+            ));
         }
         if s.embedded_parent != parent {
             return Err(DsmError::verification(
@@ -227,7 +229,9 @@ pub fn verify_recovery_reestablish_request(
     // 2. A_new is the mnemonic-authorized successor of A_old (genesis-anchored authority).
     let a_old_str = crate::types::identifiers::encode_crockford(a_old);
     if tombstone.device_id != a_old_str {
-        return Err(DsmError::verification("reestablish: tombstone is not for A_old"));
+        return Err(DsmError::verification(
+            "reestablish: tombstone is not for A_old",
+        ));
     }
     if succession.new_device_commitment.as_slice() != a_new {
         return Err(DsmError::verification(
@@ -324,16 +328,22 @@ impl CrossRelationshipSuccessionEvidence {
             return Err(DsmError::verification("succession: A_old == A_new"));
         }
         if self.old_rel_key != compute_smt_key(&self.a_old, &self.c) {
-            return Err(DsmError::verification("succession: old_rel_key != H(A_old,C)"));
+            return Err(DsmError::verification(
+                "succession: old_rel_key != H(A_old,C)",
+            ));
         }
         if self.new_rel_key != compute_smt_key(&self.a_new, &self.c) {
-            return Err(DsmError::verification("succession: new_rel_key != H(A_new,C)"));
+            return Err(DsmError::verification(
+                "succession: new_rel_key != H(A_new,C)",
+            ));
         }
 
         // 2. A_new is the mnemonic-authorized successor of A_old (genesis-anchored auth).
         let a_old_str = crate::types::identifiers::encode_crockford(&self.a_old);
         if self.tombstone.device_id != a_old_str {
-            return Err(DsmError::verification("succession: tombstone is not for A_old"));
+            return Err(DsmError::verification(
+                "succession: tombstone is not for A_old",
+            ));
         }
         if self.succession.new_device_commitment.as_slice() != self.a_new {
             return Err(DsmError::verification(
@@ -484,7 +494,12 @@ mod tests {
     const A_NEW: [u8; 32] = [0xA1; 32];
     const C: [u8; 32] = [0xC0; 32];
 
-    fn old_state(rel_key: [u8; 32], parent: [u8; 32], endpoint: [u8; 32], e: u8) -> RelationshipChainState {
+    fn old_state(
+        rel_key: [u8; 32],
+        parent: [u8; 32],
+        endpoint: [u8; 32],
+        e: u8,
+    ) -> RelationshipChainState {
         RelationshipChainState {
             rel_key,
             embedded_parent: parent,
@@ -506,9 +521,13 @@ mod tests {
 
         let tombstone = create_tombstone(&[0x01; 32], 0, &[0x02; 32], &a_old_str, &kp.secret_key)
             .expect("tombstone");
-        let succession =
-            create_succession(&tombstone.tombstone_hash, &A_NEW.to_vec(), &a_old_str, &kp.secret_key)
-                .expect("succession");
+        let succession = create_succession(
+            &tombstone.tombstone_hash,
+            A_NEW.as_ref(),
+            &a_old_str,
+            &kp.secret_key,
+        )
+        .expect("succession");
 
         let old_rel_key = compute_smt_key(&A_OLD, &C);
         let new_rel_key = compute_smt_key(&A_NEW, &C);
@@ -566,7 +585,8 @@ mod tests {
     #[test]
     fn valid_semantics_pass() {
         let (ev, pk) = fixture();
-        ev.verify_succession_semantics(&pk).expect("valid semantics");
+        ev.verify_succession_semantics(&pk)
+            .expect("valid semantics");
     }
 
     #[test]
@@ -646,7 +666,7 @@ mod tests {
         let a_old_str = crate::types::identifiers::encode_crockford(&A_OLD);
         ev.succession = create_succession(
             &ev.tombstone.tombstone_hash,
-            &[0xBB; 32].to_vec(),
+            [0xBB; 32].as_ref(),
             &a_old_str,
             &kp.secret_key,
         )
@@ -755,10 +775,17 @@ mod tests {
         use crate::merkle::sparse_merkle_tree::SparseMerkleTree;
         let mut pd = SparseMerkleTree::new(256);
         pd.update_leaf(&ev.old_rel_key, &ev.t_old_current).unwrap();
-        pd.update_leaf(&ev.new_rel_key, &ev.t_new_established).unwrap();
+        pd.update_leaf(&ev.new_rel_key, &ev.t_new_established)
+            .unwrap();
         ev.counterparty_root = *pd.root();
-        ev.old_inclusion_proof = pd.get_inclusion_proof(&ev.old_rel_key, 256).unwrap().to_bytes();
-        ev.new_inclusion_proof = pd.get_inclusion_proof(&ev.new_rel_key, 256).unwrap().to_bytes();
+        ev.old_inclusion_proof = pd
+            .get_inclusion_proof(&ev.old_rel_key, 256)
+            .unwrap()
+            .to_bytes();
+        ev.new_inclusion_proof = pd
+            .get_inclusion_proof(&ev.new_rel_key, 256)
+            .unwrap()
+            .to_bytes();
     }
 
     #[test]
@@ -768,7 +795,9 @@ mod tests {
         // verifier, which cannot decode/validate these — a latent liveness-fatal mismatch.)
         let (mut ev, pk) = fixture();
         with_real_inclusion(&mut ev);
-        let tip = ev.verify(&pk).expect("full evidence with real PDSMT proofs verifies");
+        let tip = ev
+            .verify(&pk)
+            .expect("full evidence with real PDSMT proofs verifies");
         assert_eq!(tip, ev.t_new_established);
     }
 
@@ -817,7 +846,15 @@ mod tests {
     fn reestablish_accept_guard_passes_for_valid_request() {
         let (op, ev, pk) = reestablish_request();
         verify_recovery_reestablish_request(
-            &op, &A_OLD, &A_NEW, &C, &ev.tombstone, &ev.succession, &pk, &ev.h_cap, &ev.old_chain,
+            &op,
+            &A_OLD,
+            &A_NEW,
+            &C,
+            &ev.tombstone,
+            &ev.succession,
+            &pk,
+            &ev.h_cap,
+            &ev.old_chain,
         )
         .expect("valid recovery re-establish request must be accepted");
     }
@@ -827,7 +864,15 @@ mod tests {
         let (_op, ev, pk) = reestablish_request();
         let bad_op = build_recovery_establishment_op(&C, &[0xBE; 32], &ev.h_cap); // not the real carry-forward
         assert!(verify_recovery_reestablish_request(
-            &bad_op, &A_OLD, &A_NEW, &C, &ev.tombstone, &ev.succession, &pk, &ev.h_cap, &ev.old_chain,
+            &bad_op,
+            &A_OLD,
+            &A_NEW,
+            &C,
+            &ev.tombstone,
+            &ev.succession,
+            &pk,
+            &ev.h_cap,
+            &ev.old_chain,
         )
         .is_err());
     }
@@ -838,7 +883,14 @@ mod tests {
         let other = generate_keypair_from_seed(SphincsVariant::SPX256f, &[0x01; 32]).unwrap();
         // A thief without A's genesis-anchored authority can't pass verify_recovery_pair.
         assert!(verify_recovery_reestablish_request(
-            &op, &A_OLD, &A_NEW, &C, &ev.tombstone, &ev.succession, &other.public_key, &ev.h_cap,
+            &op,
+            &A_OLD,
+            &A_NEW,
+            &C,
+            &ev.tombstone,
+            &ev.succession,
+            &other.public_key,
+            &ev.h_cap,
             &ev.old_chain,
         )
         .is_err());
@@ -848,7 +900,14 @@ mod tests {
     fn reestablish_rejects_non_create_relationship_op() {
         let (_op, ev, pk) = reestablish_request();
         assert!(verify_recovery_reestablish_request(
-            &Operation::Noop, &A_OLD, &A_NEW, &C, &ev.tombstone, &ev.succession, &pk, &ev.h_cap,
+            &Operation::Noop,
+            &A_OLD,
+            &A_NEW,
+            &C,
+            &ev.tombstone,
+            &ev.succession,
+            &pk,
+            &ev.h_cap,
             &ev.old_chain,
         )
         .is_err());
@@ -859,7 +918,14 @@ mod tests {
         let (op, ev, pk) = reestablish_request();
         // Same op but verified as if C were a DIFFERENT device → counterparty_id != C(self).
         assert!(verify_recovery_reestablish_request(
-            &op, &A_OLD, &A_NEW, &[0xDD; 32], &ev.tombstone, &ev.succession, &pk, &ev.h_cap,
+            &op,
+            &A_OLD,
+            &A_NEW,
+            &[0xDD; 32],
+            &ev.tombstone,
+            &ev.succession,
+            &pk,
+            &ev.h_cap,
             &ev.old_chain,
         )
         .is_err());
@@ -871,7 +937,15 @@ mod tests {
         // Tamper C's old chain so h_cap no longer walks to the committed t_old_current.
         ev.old_chain[0].embedded_parent = [0xDE; 32];
         assert!(verify_recovery_reestablish_request(
-            &op, &A_OLD, &A_NEW, &C, &ev.tombstone, &ev.succession, &pk, &ev.h_cap, &ev.old_chain,
+            &op,
+            &A_OLD,
+            &A_NEW,
+            &C,
+            &ev.tombstone,
+            &ev.succession,
+            &pk,
+            &ev.h_cap,
+            &ev.old_chain,
         )
         .is_err());
     }

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/succession_proof.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/succession_proof.rs
@@ -82,7 +82,7 @@ mod tests {
             create_tombstone(&[0x11; 32], 0, &[0x22; 32], device_id, &kp.secret_key).expect("t");
         let succession = create_succession(
             &tombstone.tombstone_hash,
-            &[0xBB; 32].to_vec(),
+            [0xBB; 32].as_ref(),
             device_id,
             &kp.secret_key,
         )

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/tombstone.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/tombstone.rs
@@ -423,7 +423,7 @@ mod tests {
         let tombstone = create_tombstone(&[7; 32], 1, &[9; 32], device_id, &sk)?;
         let original = create_succession(
             &tombstone.tombstone_hash,
-            &[0xAB; 32].to_vec(),
+            [0xAB; 32].as_ref(),
             device_id,
             &sk,
         )?;
@@ -431,7 +431,10 @@ mod tests {
         let decoded = SuccessionReceipt::from_bytes(&original.to_bytes())?;
         assert_eq!(decoded.device_id, original.device_id);
         assert_eq!(decoded.tombstone_hash, original.tombstone_hash);
-        assert_eq!(decoded.new_device_commitment, original.new_device_commitment);
+        assert_eq!(
+            decoded.new_device_commitment,
+            original.new_device_commitment
+        );
         assert_eq!(decoded.tick, original.tick);
         assert_eq!(decoded.signature, original.signature);
         assert_eq!(decoded.succession_hash, original.succession_hash);

--- a/dsm_client/deterministic_state_machine/dsm/src/types/device_state.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/device_state.rs
@@ -515,9 +515,9 @@ impl DeviceState {
         &self,
         rel_key: &[u8; 32],
     ) -> Result<crate::merkle::sparse_merkle_tree::SmtInclusionProof, DsmError> {
-        self.smt.get_inclusion_proof(rel_key, 256).map_err(|e| {
-            DsmError::invalid_operation(format!("rel_inclusion_proof: {e}"))
-        })
+        self.smt
+            .get_inclusion_proof(rel_key, 256)
+            .map_err(|e| DsmError::invalid_operation(format!("rel_inclusion_proof: {e}")))
     }
 
     /// Stash a legacy `State.hash` as a verification anchor. Callers that
@@ -1090,7 +1090,10 @@ mod tests {
             )
             .expect("value advance");
         assert_eq!(
-            o1.new_device_state.rel_chain_tip(&rk).unwrap().value_capability,
+            o1.new_device_state
+                .rel_chain_tip(&rk)
+                .unwrap()
+                .value_capability,
             ValueCapability::Yes
         );
 
@@ -1101,7 +1104,10 @@ mod tests {
             .advance(rk, cp, op(), entropy(2), None, &[], None, None)
             .expect("non-value advance");
         assert_eq!(
-            o2.new_device_state.rel_chain_tip(&rk).unwrap().value_capability,
+            o2.new_device_state
+                .rel_chain_tip(&rk)
+                .unwrap()
+                .value_capability,
             ValueCapability::Yes
         );
 
@@ -1113,7 +1119,10 @@ mod tests {
             .advance(rk2, cp2, op(), entropy(3), None, &[], Some(init2), None)
             .expect("first non-value advance");
         assert_eq!(
-            o3.new_device_state.rel_chain_tip(&rk2).unwrap().value_capability,
+            o3.new_device_state
+                .rel_chain_tip(&rk2)
+                .unwrap()
+                .value_capability,
             ValueCapability::No
         );
     }

--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -621,19 +621,33 @@ impl Operation {
     pub fn egress_asset(&self) -> EgressAsset {
         use Operation::*;
         match self {
-            Transfer { token_id, amount, .. } => EgressAsset::Asset {
+            Transfer {
+                token_id, amount, ..
+            } => EgressAsset::Asset {
                 token_id: token_id.clone(),
                 amount: amount.value(),
             },
-            Burn { token_id, amount, .. } => EgressAsset::Asset {
+            Burn {
+                token_id, amount, ..
+            } => EgressAsset::Asset {
                 token_id: token_id.clone(),
                 amount: amount.value(),
             },
-            Lock { token_id, amount, .. } | Unlock { token_id, amount, .. } => EgressAsset::Asset {
+            Lock {
+                token_id, amount, ..
+            }
+            | Unlock {
+                token_id, amount, ..
+            } => EgressAsset::Asset {
                 token_id: token_id.clone(),
                 amount: amount.value(),
             },
-            LockToken { token_id, amount, .. } | UnlockToken { token_id, amount, .. } => {
+            LockToken {
+                token_id, amount, ..
+            }
+            | UnlockToken {
+                token_id, amount, ..
+            } => {
                 EgressAsset::Asset {
                     token_id: token_id.clone(),
                     // i64 lock/unlock quantity; clamp negatives to 0 (no canonical egress size).
@@ -647,7 +661,10 @@ impl Operation {
                 ..
             } => EgressAsset::Asset {
                 token_id: token_id.clone(),
-                amount: locked_amount.as_ref().map(|b| b.value()).unwrap_or(u64::MAX),
+                amount: locked_amount
+                    .as_ref()
+                    .map(|b| b.value())
+                    .unwrap_or(u64::MAX),
             },
             DlvCreate { token_id: None, .. } => EgressAsset::Unidentified,
             // Vault-keyed DLV ops: the asset is determined by the vault, not a token_id.
@@ -2421,7 +2438,10 @@ mod tests {
         };
         assert_eq!(
             burn.egress_asset(),
-            EgressAsset::Asset { token_id: b"ERA".to_vec(), amount: 7 }
+            EgressAsset::Asset {
+                token_id: b"ERA".to_vec(),
+                amount: 7
+            }
         );
 
         let lt = Operation::LockToken {
@@ -2433,7 +2453,10 @@ mod tests {
         };
         assert_eq!(
             lt.egress_asset(),
-            EgressAsset::Asset { token_id: b"ERA".to_vec(), amount: 0 }
+            EgressAsset::Asset {
+                token_id: b"ERA".to_vec(),
+                amount: 0
+            }
         );
 
         // Vault-keyed DLV claim → asset can't be named here → Unidentified (fail-closed gate).
@@ -2459,7 +2482,14 @@ mod tests {
             proof_of_authorization: vec![],
             message: String::new(),
         };
-        for op in [&burn, &lt, &claim, &mint, &Operation::Noop, &Operation::Genesis] {
+        for op in [
+            &burn,
+            &lt,
+            &claim,
+            &mint,
+            &Operation::Noop,
+            &Operation::Genesis,
+        ] {
             assert_eq!(
                 op.is_value_egress(),
                 !matches!(op.egress_asset(), EgressAsset::NotEgress),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -1780,8 +1780,8 @@ impl BilateralBleHandler {
         counterparty_device_id: [u8; 32],
         validity_iterations: u64,
     ) -> Result<(Vec<u8>, [u8; 32]), DsmError> {
-        let op = crate::sdk::RecoverySDK::begin_recovery_reestablish(&counterparty_device_id)
-            .await?;
+        let op =
+            crate::sdk::RecoverySDK::begin_recovery_reestablish(&counterparty_device_id).await?;
         self.prepare_bilateral_transaction_with_commitment(
             counterparty_device_id,
             op,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_transport_adapter.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_transport_adapter.rs
@@ -78,7 +78,12 @@ impl BilateralTransportAdapter {
         peer_address: &str,
         envelope: &[u8],
     ) -> Result<(), DsmError> {
-        queue_follow_up_chunks(peer_address, BleFrameType::DeviceAdmissionResponse, envelope).await
+        queue_follow_up_chunks(
+            peer_address,
+            BleFrameType::DeviceAdmissionResponse,
+            envelope,
+        )
+        .await
     }
 
     pub async fn cancel_prepared_session_for_counterparty(&self, counterparty_device_id: [u8; 32]) {
@@ -450,8 +455,10 @@ impl BleTransportDelegate for BilateralTransportAdapter {
                     }
                 }
                 BleFrameType::DeviceAdmissionResponse => {
-                    match crate::sdk::DeviceAdmissionSDK::handle_admission_response(&message.payload)
-                        .await
+                    match crate::sdk::DeviceAdmissionSDK::handle_admission_response(
+                        &message.payload,
+                    )
+                    .await
                     {
                         Ok((_genesis, _new_id)) => {
                             info!("[ADMISSION] adopted into the device tree");

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/recovery_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/recovery_impl.rs
@@ -508,7 +508,9 @@ pub fn execute_recovery_pipeline() -> Result<String, String> {
     // 5a. P5: start this recovery cycle with a clean bearer-asset lock registry so stale
     // reconciliations from a prior cycle cannot leave an asset spendable (fail-closed).
     if let Err(e) = crate::storage::client_db::recovery::clear_asset_locks() {
-        return Err(format!("[RECOVERY] Failed to clear stale bearer-asset locks: {e}"));
+        return Err(format!(
+            "[RECOVERY] Failed to clear stale bearer-asset locks: {e}"
+        ));
     }
 
     // 6. Create tombstone receipt
@@ -703,7 +705,9 @@ pub fn resume_all_contacts() -> Result<String, String> {
     if let Some(dev) = crate::sdk::app_state::AppState::get_device_id() {
         let dev_str = crate::util::text_id::encode_base32_crockford(&dev);
         match crate::storage::client_db::recovery::lock_all_restored_bearer_assets(&dev_str) {
-            Ok(n) => log::info!("[RECOVERY] {n} restored bearer-asset projection(s) locked at resume"),
+            Ok(n) => {
+                log::info!("[RECOVERY] {n} restored bearer-asset projection(s) locked at resume")
+            }
             Err(e) => {
                 return Err(format!(
                     "[RECOVERY] Failed to lock restored bearer assets at resume (refusing to \

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/recovery_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/recovery_routes.rs
@@ -141,7 +141,8 @@ impl AppRouterImpl {
                 // same anchor is idempotent.
                 if let Ok(rt) = tokio::runtime::Handle::try_current() {
                     rt.spawn(async {
-                        match crate::sdk::recovery_sdk::RecoverySDK::publish_authority_anchor().await
+                        match crate::sdk::recovery_sdk::RecoverySDK::publish_authority_anchor()
+                            .await
                         {
                             Ok(n) => log::info!(
                                 "[RECOVERY] published recovery-authority anchor to {n} node(s)"
@@ -153,8 +154,12 @@ impl AppRouterImpl {
                         }
                         // P5 dBTC enumeration: publish the signed dBTC vault index so a future
                         // recovered device can discover this identity's vaults (best-effort).
-                        match crate::sdk::recovery_sdk::RecoverySDK::publish_dbtc_vault_index().await {
-                            Ok(n) => log::info!("[RECOVERY] published dBTC vault index ({n} vaults)"),
+                        match crate::sdk::recovery_sdk::RecoverySDK::publish_dbtc_vault_index()
+                            .await
+                        {
+                            Ok(n) => {
+                                log::info!("[RECOVERY] published dBTC vault index ({n} vaults)")
+                            }
                             Err(e) => log::warn!(
                                 "[RECOVERY] dBTC vault index publish deferred (best-effort): {e}"
                             ),
@@ -219,7 +224,8 @@ impl AppRouterImpl {
                 // (spec §3.1, condition T0.2).
                 if mnemonic.split_whitespace().count() < 24 {
                     return err(
-                        "recovery.cacheMnemonic: mnemonic must be a 24-word (256-bit) phrase".into(),
+                        "recovery.cacheMnemonic: mnemonic must be a 24-word (256-bit) phrase"
+                            .into(),
                     );
                 }
 
@@ -944,7 +950,8 @@ impl AppRouterImpl {
                     Ok(c) => c,
                     Err(e) => return err(format!("recovery.activate: context: {e}")),
                 };
-                match crate::sdk::recovery_sdk::RecoverySDK::build_and_activate_recovery(&ctx).await {
+                match crate::sdk::recovery_sdk::RecoverySDK::build_and_activate_recovery(&ctx).await
+                {
                     Ok(()) => {
                         let resp = generated::AppStateResponse {
                             key: "recovery.activate".to_string(),
@@ -975,7 +982,8 @@ impl AppRouterImpl {
             // hard error). dBTC is unlocked only for vaults whose posted frontier proves it;
             // any incomplete/unverifiable evidence keeps it LockedRecovery (fail-closed).
             "recovery.reconcileDbtc" => {
-                let mut candidates: Vec<String> = match Self::decode_recovery_string_param(&i.args) {
+                let mut candidates: Vec<String> = match Self::decode_recovery_string_param(&i.args)
+                {
                     Ok(s) => s
                         .split(',')
                         .map(|v| v.trim().to_string())
@@ -987,7 +995,8 @@ impl AppRouterImpl {
                 // index for A_old. If that's unavailable, candidates stay empty and the
                 // reconcile returns the awaiting-enumeration status (dBTC stays locked).
                 if candidates.is_empty() {
-                    match crate::sdk::recovery_sdk::RecoverySDK::auto_dbtc_vault_candidates().await {
+                    match crate::sdk::recovery_sdk::RecoverySDK::auto_dbtc_vault_candidates().await
+                    {
                         Ok(ids) => candidates = ids,
                         Err(e) => log::debug!("[recovery.reconcileDbtc] no vault index: {e}"),
                     }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/system_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/system_routes.rs
@@ -283,8 +283,8 @@ impl AppRouterImpl {
         match i.method.as_str() {
             // EXISTING device: which device (if any) is awaiting the owner's approval (poll).
             "device.pendingAdmission" => {
-                let v =
-                    crate::sdk::DeviceAdmissionSDK::pending_admission_device_id().unwrap_or_default();
+                let v = crate::sdk::DeviceAdmissionSDK::pending_admission_device_id()
+                    .unwrap_or_default();
                 device_ok("device.pendingAdmission", &v)
             }
             // NEW device: start the handshake (build request + send over BLE to the existing device).

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/init.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/init.rs
@@ -669,15 +669,21 @@ mod tests {
         // Sensitive: changing ANY of the three inputs changes the keypair.
         assert_ne!(
             a.public_key,
-            derive_device_signing_keypair(&[0x99; 32], &d, &k).unwrap().public_key
+            derive_device_signing_keypair(&[0x99; 32], &d, &k)
+                .unwrap()
+                .public_key
         );
         assert_ne!(
             a.public_key,
-            derive_device_signing_keypair(&g, &[0x99; 32], &k).unwrap().public_key
+            derive_device_signing_keypair(&g, &[0x99; 32], &k)
+                .unwrap()
+                .public_key
         );
         assert_ne!(
             a.public_key,
-            derive_device_signing_keypair(&g, &d, &[0x99; 32]).unwrap().public_key
+            derive_device_signing_keypair(&g, &d, &[0x99; 32])
+                .unwrap()
+                .public_key
         );
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/bitcoin_tap_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/bitcoin_tap_sdk.rs
@@ -2510,11 +2510,12 @@ impl BitcoinTapSdk {
             DsmError::InvalidState("reconcile_dbtc_asset: no device identity".into())
         })?;
         let device_str = crate::util::text_id::encode_base32_crockford(&device_id);
-        let hint_sats = crate::storage::client_db::get_balance_projection(&device_str, DBTC_TOKEN_ID)
-            .ok()
-            .flatten()
-            .map(|p| p.available)
-            .unwrap_or(0);
+        let hint_sats =
+            crate::storage::client_db::get_balance_projection(&device_str, DBTC_TOKEN_ID)
+                .ok()
+                .flatten()
+                .map(|p| p.available)
+                .unwrap_or(0);
 
         // Live Bitcoin source for backing verification (UTXO liveness + confirmation). If it
         // can't be constructed, facts are conservative → no vault unlocks (fail-closed).
@@ -2617,7 +2618,7 @@ impl BitcoinTapSdk {
         #[cfg(test)]
         {
             let _ = mempool;
-            return DBTC_BACKING_TEST_FACTS
+            DBTC_BACKING_TEST_FACTS
                 .lock()
                 .ok()
                 .and_then(|m| m.get(&ad.vault_id).copied())
@@ -2625,7 +2626,7 @@ impl BitcoinTapSdk {
                     htlc_utxo_unspent: false,
                     funding_confirmed: false,
                     preimage_derivable: false,
-                });
+                })
         }
         #[cfg(not(test))]
         {
@@ -2643,11 +2644,11 @@ impl BitcoinTapSdk {
             }
             // UTXO liveness: a UTXO present at the HTLC address = the BTC is still locked
             // (unspent); any confirmed UTXO = funding buried. Same gate the planner uses.
-            let (htlc_utxo_unspent, funding_confirmed) = match mp.address_utxos(&ad.htlc_address).await
-            {
-                Ok(utxos) if !utxos.is_empty() => (true, utxos.iter().any(|u| u.confirmed)),
-                _ => (false, false),
-            };
+            let (htlc_utxo_unspent, funding_confirmed) =
+                match mp.address_utxos(&ad.htlc_address).await {
+                    Ok(utxos) if !utxos.is_empty() => (true, utxos.iter().any(|u| u.confirmed)),
+                    _ => (false, false),
+                };
             // Bearer claim-preimage derivability: re-derive from the (deterministic) manifold
             // seed + the ad's deposit_nonce and confirm it matches the vault's HTLC hash_lock.
             let preimage_derivable = Self::dbtc_preimage_matches(ad).await.unwrap_or(false);
@@ -2689,8 +2690,9 @@ impl BitcoinTapSdk {
         if digest.as_bytes() != ad.vault_proto_digest.as_slice() {
             return Ok(false);
         }
-        let vault = generated::LimboVaultProto::decode(proto_bytes.as_slice())
-            .map_err(|e| DsmError::verification(format!("dbtc backing: vault proto decode: {e}")))?;
+        let vault = generated::LimboVaultProto::decode(proto_bytes.as_slice()).map_err(|e| {
+            DsmError::verification(format!("dbtc backing: vault proto decode: {e}"))
+        })?;
         let hash_lock = match vault.fulfillment_condition.and_then(|f| f.kind) {
             Some(generated::fulfillment_mechanism::Kind::BitcoinHtlc(htlc)) => htlc.hash_lock,
             _ => return Ok(false),
@@ -5520,10 +5522,16 @@ mod tests {
             Some(C::InFlight)
         );
         for s in ["limbo", "initiated", "awaiting_confirmation", "claimable"] {
-            assert_eq!(BitcoinTapSdk::classify_dbtc_lifecycle(s, true), Some(C::InFlight));
+            assert_eq!(
+                BitcoinTapSdk::classify_dbtc_lifecycle(s, true),
+                Some(C::InFlight)
+            );
         }
         for s in ["unlocked", "claimed", "spent", "completed", "invalidated"] {
-            assert_eq!(BitcoinTapSdk::classify_dbtc_lifecycle(s, true), Some(C::Finalized));
+            assert_eq!(
+                BitcoinTapSdk::classify_dbtc_lifecycle(s, true),
+                Some(C::Finalized)
+            );
         }
         for s in ["expired", "refunded"] {
             assert_eq!(
@@ -5568,7 +5576,12 @@ mod tests {
         DBTC_BACKING_TEST_FACTS.lock().unwrap().clear();
     }
 
-    async fn put_ad(vault_id: [u8; 32], amount_sats: u64, routeable: bool, lifecycle: &str) -> String {
+    async fn put_ad(
+        vault_id: [u8; 32],
+        amount_sats: u64,
+        routeable: bool,
+        lifecycle: &str,
+    ) -> String {
         let ad = test_advertisement(vault_id, amount_sats, routeable, 1, lifecycle);
         let key = BitcoinTapSdk::vault_advertisement_key(&ad.vault_id);
         BitcoinTapSdk::storage_put_bytes(&key, &ad.encode_to_vec())
@@ -5598,7 +5611,9 @@ mod tests {
         // Bitcoin truth confirms: HTLC UTXO unspent + confirmed + bearer can derive preimage.
         set_backing_facts(&vid, true, true, true);
 
-        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid]).await.expect("reconcile");
+        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid])
+            .await
+            .expect("reconcile");
         assert_eq!(state, dsm::recovery::BearerAssetLockState::Spendable);
         assert_eq!(
             crate::storage::client_db::recovery::get_asset_lock(DBTC_TOKEN_ID.as_bytes())
@@ -5617,7 +5632,9 @@ mod tests {
         // Active ad, but NO Bitcoin backing facts (unreachable/unverified) → must NOT unlock.
         let vid = put_ad(vid_from_label("dbtc-active-noverify"), 500, true, "active").await;
 
-        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid]).await.expect("reconcile");
+        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid])
+            .await
+            .expect("reconcile");
         assert_ne!(
             state,
             dsm::recovery::BearerAssetLockState::Spendable,
@@ -5634,7 +5651,9 @@ mod tests {
         // Ad claims active, but Bitcoin says the HTLC UTXO is SPENT (already withdrawn).
         set_backing_facts(&vid, false, true, true);
 
-        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid]).await.expect("reconcile");
+        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid])
+            .await
+            .expect("reconcile");
         assert_ne!(state, dsm::recovery::BearerAssetLockState::Spendable);
     }
 
@@ -5646,7 +5665,9 @@ mod tests {
         // A limbo (deposit-in-progress) vault → InFlight → no spendable value → blocked.
         let vid = put_ad(vid_from_label("dbtc-limbo"), 500, true, "limbo").await;
 
-        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid]).await.expect("reconcile");
+        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid])
+            .await
+            .expect("reconcile");
         assert_eq!(state, dsm::recovery::BearerAssetLockState::InFlight);
     }
 
@@ -5657,7 +5678,9 @@ mod tests {
         dbtc_reconcile_test_identity();
         // Candidate with NO posted ad → completeness failure → stays LockedRecovery.
         let vid = crate::util::text_id::encode_base32_crockford(&vid_from_label("dbtc-absent"));
-        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid]).await.expect("reconcile");
+        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid])
+            .await
+            .expect("reconcile");
         assert_eq!(state, dsm::recovery::BearerAssetLockState::LockedRecovery);
     }
 
@@ -5667,7 +5690,9 @@ mod tests {
         init_withdrawal_test_db();
         dbtc_reconcile_test_identity();
         let vid = put_ad(vid_from_label("dbtc-weird"), 500, true, "weird_state").await;
-        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid]).await.expect("reconcile");
+        let state = BitcoinTapSdk::reconcile_dbtc_asset(&[vid])
+            .await
+            .expect("reconcile");
         assert_eq!(state, dsm::recovery::BearerAssetLockState::LockedRecovery);
     }
 }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/device_admission_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/device_admission_sdk.rs
@@ -39,9 +39,11 @@ pub struct DeviceAdmissionSDK;
 
 impl DeviceAdmissionSDK {
     fn id32(v: Option<Vec<u8>>, what: &str) -> Result<[u8; 32], DsmError> {
-        let v = v.ok_or_else(|| DsmError::InvalidState(format!("device admission: missing {what}")))?;
-        <[u8; 32]>::try_from(v.as_slice())
-            .map_err(|_| DsmError::verification(format!("device admission: {what} is not 32 bytes")))
+        let v =
+            v.ok_or_else(|| DsmError::InvalidState(format!("device admission: missing {what}")))?;
+        <[u8; 32]>::try_from(v.as_slice()).map_err(|_| {
+            DsmError::verification(format!("device admission: {what} is not 32 bytes"))
+        })
     }
 
     async fn storage() -> Result<StorageNodeSDK, DsmError> {
@@ -72,8 +74,11 @@ impl DeviceAdmissionSDK {
             DsmError::InvalidState("admission request: no device signing pubkey".into())
         })?;
         let core = CoreSDK::new()?;
-        let sig = core
-            .sign_bytes_sphincs(&self_attest_digest(&genesis_hash, &new_device_id, &new_signing_pubkey))?;
+        let sig = core.sign_bytes_sphincs(&self_attest_digest(
+            &genesis_hash,
+            &new_device_id,
+            &new_signing_pubkey,
+        ))?;
         Ok(AddDeviceAdmissionRequestV1 {
             genesis_hash: genesis_hash.to_vec(),
             new_device_id: new_device_id.to_vec(),
@@ -86,14 +91,15 @@ impl DeviceAdmissionSDK {
     /// EXISTING (authority) device: verify the new device's request, gate-sign, and insert. Returns
     /// the gate-signed `AddDeviceAdmission` bytes to send back over BLE. Fail-closed.
     pub async fn approve_admission(request_bytes: &[u8]) -> Result<Vec<u8>, DsmError> {
-        let req = crate::generated::AddDeviceAdmissionRequestV1::decode(request_bytes).map_err(|e| {
-            DsmError::serialization_error(
-                format!("admission request decode: {e}"),
-                "AddDeviceAdmissionRequestV1",
-                None::<String>,
-                Some(e),
-            )
-        })?;
+        let req =
+            crate::generated::AddDeviceAdmissionRequestV1::decode(request_bytes).map_err(|e| {
+                DsmError::serialization_error(
+                    format!("admission request decode: {e}"),
+                    "AddDeviceAdmissionRequestV1",
+                    None::<String>,
+                    Some(e),
+                )
+            })?;
         let genesis = Self::id32(Some(req.genesis_hash.clone()), "genesis_hash")?;
         let new_device_id = Self::id32(Some(req.new_device_id.clone()), "new_device_id")?;
         if req.new_device_signing_pubkey.is_empty() || req.signature_by_new_device.is_empty() {
@@ -142,7 +148,9 @@ impl DeviceAdmissionSDK {
         let signer_pubkey = AppState::get_public_key().ok_or_else(|| {
             DsmError::InvalidState("approve_admission: no device signing pubkey".into())
         })?;
-        storage.apply_admitted_device(&admission, &signer_pubkey).await?;
+        storage
+            .apply_admitted_device(&admission, &signer_pubkey)
+            .await?;
         Ok(admission.to_bytes())
     }
 
@@ -173,8 +181,9 @@ impl DeviceAdmissionSDK {
             ));
         }
         let storage = Self::storage().await?;
-        let (device_ids, _version, root) =
-            storage.read_device_tree_state(&admission.genesis_hash).await?;
+        let (device_ids, _version, root) = storage
+            .read_device_tree_state(&admission.genesis_hash)
+            .await?;
         if !device_ids.contains(&admission.new_device_id) {
             return Err(DsmError::verification(
                 "adopt: new device not present in the published Device Tree",
@@ -223,15 +232,17 @@ impl DeviceAdmissionSDK {
         signer_pubkey: Vec<u8>,
     ) -> Result<Vec<u8>, DsmError> {
         let req_bytes = Self::build_admission_request(genesis, &entropy).await?;
-        let req = crate::generated::AddDeviceAdmissionRequestV1::decode(&*req_bytes).map_err(|e| {
-            DsmError::serialization_error(
-                format!("begin_admission re-decode: {e}"),
-                "AddDeviceAdmissionRequestV1",
-                None::<String>,
-                Some(e),
-            )
-        })?;
-        *PENDING_OUTBOUND.lock().unwrap_or_else(|p| p.into_inner()) = Some((entropy, signer_pubkey));
+        let req =
+            crate::generated::AddDeviceAdmissionRequestV1::decode(&*req_bytes).map_err(|e| {
+                DsmError::serialization_error(
+                    format!("begin_admission re-decode: {e}"),
+                    "AddDeviceAdmissionRequestV1",
+                    None::<String>,
+                    Some(e),
+                )
+            })?;
+        *PENDING_OUTBOUND.lock().unwrap_or_else(|p| p.into_inner()) =
+            Some((entropy, signer_pubkey));
         Self::build_admission_envelope(
             crate::generated::envelope::Payload::DeviceAdmissionRequest(req),
             &genesis,
@@ -280,16 +291,19 @@ impl DeviceAdmissionSDK {
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .take()
-            .ok_or_else(|| DsmError::InvalidState("no pending admission request to approve".into()))?;
+            .ok_or_else(|| {
+                DsmError::InvalidState("no pending admission request to approve".into())
+            })?;
         let admission_bytes = Self::approve_admission(&req_bytes).await?;
-        let adm_proto = crate::generated::AddDeviceAdmissionV1::decode(&*admission_bytes).map_err(|e| {
-            DsmError::serialization_error(
-                format!("approve_pending_admission re-decode: {e}"),
-                "AddDeviceAdmissionV1",
-                None::<String>,
-                Some(e),
-            )
-        })?;
+        let adm_proto =
+            crate::generated::AddDeviceAdmissionV1::decode(&*admission_bytes).map_err(|e| {
+                DsmError::serialization_error(
+                    format!("approve_pending_admission re-decode: {e}"),
+                    "AddDeviceAdmissionV1",
+                    None::<String>,
+                    Some(e),
+                )
+            })?;
         let genesis = Self::id32(Some(adm_proto.genesis_hash.clone()), "genesis_hash")?;
         let env = Self::build_admission_envelope(
             crate::generated::envelope::Payload::DeviceAdmission(adm_proto),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/recovery_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/recovery_sdk.rs
@@ -383,8 +383,10 @@ impl RecoverySDK {
     /// cached authority keypair — i.e. the mnemonic must already be cached (call
     /// `derive_and_cache_key` first, as `recovery.enable` does).
     pub fn build_authority_anchor() -> Result<dsm::recovery::RecoveryAuthorityAnchor, DsmError> {
-        let device_id =
-            Self::require_self_id32(crate::sdk::app_state::AppState::get_device_id(), "device_id")?;
+        let device_id = Self::require_self_id32(
+            crate::sdk::app_state::AppState::get_device_id(),
+            "device_id",
+        )?;
         let genesis_id = Self::require_self_id32(
             crate::sdk::app_state::AppState::get_genesis_hash(),
             "genesis_hash",
@@ -402,14 +404,16 @@ impl RecoverySDK {
 
         // Re-derive the device signing keypair — byte-identical to the one in the
         // device tree (the genesis-binding signer for the anchor).
-        let device_kp = crate::init::derive_device_signing_keypair(&genesis_id, &device_id, &k_dbrw)?;
+        let device_kp =
+            crate::init::derive_device_signing_keypair(&genesis_id, &device_id, &k_dbrw)?;
 
-        let (authority_pk, authority_sk) = Self::get_cached_authority_keypair().ok_or_else(|| {
-            DsmError::InvalidState(
+        let (authority_pk, authority_sk) =
+            Self::get_cached_authority_keypair().ok_or_else(|| {
+                DsmError::InvalidState(
                 "recovery anchor: no cached recovery-authority keypair (cache the mnemonic first)"
                     .into(),
             )
-        })?;
+            })?;
 
         dsm::recovery::create_recovery_authority_anchor(
             &genesis_id,
@@ -522,7 +526,9 @@ impl RecoverySDK {
         )
         .await
         .map_err(|e| {
-            DsmError::verification(format!("authority anchor: device identity quorum failed: {e}"))
+            DsmError::verification(format!(
+                "authority anchor: device identity quorum failed: {e}"
+            ))
         })?;
         if &qid.genesis_hash != genesis_id {
             return Err(DsmError::verification(
@@ -530,7 +536,12 @@ impl RecoverySDK {
             ));
         }
 
-        anchor.verify(genesis_id, device_id, &qid.public_key, candidate_authority_pubkey)?;
+        anchor.verify(
+            genesis_id,
+            device_id,
+            &qid.public_key,
+            candidate_authority_pubkey,
+        )?;
         Ok(anchor)
     }
 
@@ -620,8 +631,10 @@ impl RecoverySDK {
     /// the head. Fail-closed: requires identity, a cached `K_A`, and a live device head;
     /// a head-chain conflict errors (re-fetch the tip and re-chain).
     pub async fn build_and_publish_pdsmt_head() -> Result<usize, DsmError> {
-        let device_id =
-            Self::require_self_id32(crate::sdk::app_state::AppState::get_device_id(), "device_id")?;
+        let device_id = Self::require_self_id32(
+            crate::sdk::app_state::AppState::get_device_id(),
+            "device_id",
+        )?;
         let device_state = crate::storage::client_db::load_bcr_device_head(&device_id)
             .map_err(|e| {
                 DsmError::storage(format!("load device head: {e}"), None::<std::io::Error>)
@@ -632,16 +645,18 @@ impl RecoverySDK {
                 )
             })?;
 
-        let (authority_pk, authority_sk) = Self::get_cached_authority_keypair().ok_or_else(|| {
-            DsmError::InvalidState(
+        let (authority_pk, authority_sk) =
+            Self::get_cached_authority_keypair().ok_or_else(|| {
+                DsmError::InvalidState(
                 "build_and_publish_pdsmt_head: no cached recovery-authority keypair (cache the \
                  mnemonic first)"
                     .into(),
             )
-        })?;
+            })?;
 
         // Chain position: extend the latest valid head, or start the genesis head.
-        let (parent_head_hash, head_number) = match Self::fetch_pdsmt_head_latest(&device_id).await {
+        let (parent_head_hash, head_number) = match Self::fetch_pdsmt_head_latest(&device_id).await
+        {
             Ok(prev) => (prev.head_hash(), prev.head_number.saturating_add(1)),
             Err(_) => (dsm::recovery::GENESIS_PARENT_HEAD_HASH, 0),
         };
@@ -746,8 +761,10 @@ impl RecoverySDK {
             })?;
 
         // Index by embedded_parent so the walk follows hash adjacency, not insertion order.
-        let mut by_parent: HashMap<[u8; 32], Vec<dsm::types::device_state::RelationshipChainState>> =
-            HashMap::new();
+        let mut by_parent: HashMap<
+            [u8; 32],
+            Vec<dsm::types::device_state::RelationshipChainState>,
+        > = HashMap::new();
         for s in all {
             by_parent.entry(s.embedded_parent).or_default().push(s);
         }
@@ -877,17 +894,20 @@ impl RecoverySDK {
     /// Build (from THIS device's local vault store) + sign + publish the dBTC vault index.
     /// Fail-closed: requires identity + a cached `K_A`. Returns the vault-id count posted.
     pub async fn publish_dbtc_vault_index() -> Result<usize, DsmError> {
-        let device_id =
-            Self::require_self_id32(crate::sdk::app_state::AppState::get_device_id(), "device_id")?;
+        let device_id = Self::require_self_id32(
+            crate::sdk::app_state::AppState::get_device_id(),
+            "device_id",
+        )?;
         let genesis_id = Self::require_self_id32(
             crate::sdk::app_state::AppState::get_genesis_hash(),
             "genesis_hash",
         )?;
-        let (authority_pk, authority_sk) = Self::get_cached_authority_keypair().ok_or_else(|| {
-            DsmError::InvalidState(
-                "publish_dbtc_vault_index: no cached recovery-authority keypair".into(),
-            )
-        })?;
+        let (authority_pk, authority_sk) =
+            Self::get_cached_authority_keypair().ok_or_else(|| {
+                DsmError::InvalidState(
+                    "publish_dbtc_vault_index: no cached recovery-authority keypair".into(),
+                )
+            })?;
         let vault_ids = crate::storage::client_db::list_all_vault_ids().map_err(|e| {
             DsmError::storage(format!("list vault ids: {e}"), None::<std::io::Error>)
         })?;
@@ -928,15 +948,16 @@ impl RecoverySDK {
     /// this identity's genesis-anchored `K_A`. Fail-closed: any missing/unverifiable piece
     /// errors (the caller then leaves dBTC LockedRecovery / reports awaiting-enumeration).
     pub async fn auto_dbtc_vault_candidates() -> Result<Vec<String>, DsmError> {
-        let a_old_v = crate::storage::client_db::recovery::get_recovery_pref(
-            "capsule_source_device_id",
-        )
-        .map_err(|e| {
-            DsmError::storage(format!("read capsule source: {e}"), None::<std::io::Error>)
-        })?
-        .ok_or_else(|| {
-            DsmError::InvalidState("auto_dbtc_vault_candidates: no staged capsule source".into())
-        })?;
+        let a_old_v =
+            crate::storage::client_db::recovery::get_recovery_pref("capsule_source_device_id")
+                .map_err(|e| {
+                    DsmError::storage(format!("read capsule source: {e}"), None::<std::io::Error>)
+                })?
+                .ok_or_else(|| {
+                    DsmError::InvalidState(
+                        "auto_dbtc_vault_candidates: no staged capsule source".into(),
+                    )
+                })?;
         let a_old = <[u8; 32]>::try_from(a_old_v.as_slice()).map_err(|_| {
             DsmError::verification("auto_dbtc_vault_candidates: capsule source not 32 bytes")
         })?;
@@ -972,8 +993,10 @@ impl RecoverySDK {
         recovering_device_id: &[u8; 32],
         h_cap: &[u8; 32],
     ) -> Result<[u8; 32], DsmError> {
-        let self_id =
-            Self::require_self_id32(crate::sdk::app_state::AppState::get_device_id(), "device_id")?;
+        let self_id = Self::require_self_id32(
+            crate::sdk::app_state::AppState::get_device_id(),
+            "device_id",
+        )?;
         let old_rel_key = dsm::core::bilateral_transaction_manager::compute_smt_key(
             recovering_device_id,
             &self_id,
@@ -1010,8 +1033,10 @@ impl RecoverySDK {
         establishment_state: dsm::types::device_state::RelationshipChainState,
         counterparty_device_id: &[u8; 32],
     ) -> Result<[u8; 32], DsmError> {
-        let a_new =
-            Self::require_self_id32(crate::sdk::app_state::AppState::get_device_id(), "device_id")?;
+        let a_new = Self::require_self_id32(
+            crate::sdk::app_state::AppState::get_device_id(),
+            "device_id",
+        )?;
         let new_rel_key = dsm::core::bilateral_transaction_manager::compute_smt_key(
             &a_new,
             counterparty_device_id,
@@ -1184,8 +1209,10 @@ impl RecoverySDK {
             crate::sdk::app_state::AppState::get_genesis_hash(),
             "genesis_hash",
         )?;
-        let a_new =
-            Self::require_self_id32(crate::sdk::app_state::AppState::get_device_id(), "device_id")?;
+        let a_new = Self::require_self_id32(
+            crate::sdk::app_state::AppState::get_device_id(),
+            "device_id",
+        )?;
 
         let tombstone_hash = {
             let v = crate::storage::client_db::recovery::get_tombstone_hash()
@@ -1306,7 +1333,10 @@ impl RecoverySDK {
     /// Storage key for A_new's posted recovery succession proof (Base32 Crockford; no hex).
     /// Keyed by `(genesis_under_recovery, a_new)` — the recovering identity's genesis (shared
     /// with A_old) and the successor device.
-    pub fn recovery_succession_proof_storage_key(genesis_id: &[u8; 32], a_new: &[u8; 32]) -> String {
+    pub fn recovery_succession_proof_storage_key(
+        genesis_id: &[u8; 32],
+        a_new: &[u8; 32],
+    ) -> String {
         format!(
             "recovery/succession-proof/v1/{}/{}",
             crate::util::text_id::encode_base32_crockford(genesis_id),
@@ -1366,15 +1396,12 @@ impl RecoverySDK {
         // Post the pre-co-sign succession proof so C can run its accept-guard.
         Self::publish_recovery_succession_proof().await?;
 
-        let old_rel_key =
-            dsm::core::bilateral_transaction_manager::compute_smt_key(&ctx.a_old, c);
-        let new_rel_key =
-            dsm::core::bilateral_transaction_manager::compute_smt_key(&ctx.a_new, c);
+        let old_rel_key = dsm::core::bilateral_transaction_manager::compute_smt_key(&ctx.a_old, c);
+        let new_rel_key = dsm::core::bilateral_transaction_manager::compute_smt_key(&ctx.a_new, c);
 
         // C's current (A_old,C) tip from its posted PDSMT leaf.
         let c_head = Self::fetch_pdsmt_head_latest(c).await?;
-        let c_leaves =
-            Self::fetch_pdsmt_leaves(&c_head.genesis_id, c, c_head.head_number).await?;
+        let c_leaves = Self::fetch_pdsmt_leaves(&c_head.genesis_id, c, c_head.head_number).await?;
         let t_old_current = c_leaves
             .iter()
             .find(|l| l.rel_key == old_rel_key && l.counterparty_device_id == ctx.a_old)
@@ -1398,7 +1425,9 @@ impl RecoverySDK {
             &ctx.a_new,
             c,
         );
-        Ok(dsm::recovery::build_recovery_establishment_op(c, &carry, &h_cap))
+        Ok(dsm::recovery::build_recovery_establishment_op(
+            c, &carry, &h_cap,
+        ))
     }
 
     /// C side: the accept-guard the bilateral handler MUST call before co-signing an incoming
@@ -1430,8 +1459,12 @@ impl RecoverySDK {
         // A_new's genesis + recovery authority, from A_new's posted head (genesis-anchored).
         let a_new_head = Self::fetch_pdsmt_head_latest(a_new).await?;
         let a_new_genesis = a_new_head.genesis_id;
-        Self::fetch_and_verify_authority_anchor(&a_new_genesis, a_new, &a_new_head.authority_pubkey)
-            .await?;
+        Self::fetch_and_verify_authority_anchor(
+            &a_new_genesis,
+            a_new,
+            &a_new_head.authority_pubkey,
+        )
+        .await?;
 
         // The pre-co-sign succession proof, bound to the SAME anchored authority.
         let proof = Self::fetch_recovery_succession_proof(&a_new_genesis, a_new).await?;
@@ -1526,8 +1559,10 @@ impl RecoverySDK {
             Self::fetch_pdsmt_leaves(&ctx.genesis_id, &ctx.a_old, a_old_head.head_number).await?;
 
         // Candidate counterparties: A_old's posted leaves ∪ the capsule's floor set.
-        let mut candidates: BTreeSet<[u8; 32]> =
-            a_old_leaves.iter().map(|l| l.counterparty_device_id).collect();
+        let mut candidates: BTreeSet<[u8; 32]> = a_old_leaves
+            .iter()
+            .map(|l| l.counterparty_device_id)
+            .collect();
         candidates.extend(ctx.capsule_floor.keys().copied());
 
         // Per-C: fetch posted state, GENESIS-ANCHOR C's authority (pubkey carried in the head),
@@ -1556,7 +1591,9 @@ impl RecoverySDK {
             if let Err(e) =
                 Self::fetch_and_verify_authority_anchor(&c_genesis, c, &head.authority_pubkey).await
             {
-                log::debug!("[RECOVERY] counterparty authority not genesis-anchored: {e}; skipping");
+                log::debug!(
+                    "[RECOVERY] counterparty authority not genesis-anchored: {e}; skipping"
+                );
                 continue;
             }
             let authority_commit =
@@ -1568,8 +1605,10 @@ impl RecoverySDK {
                     continue;
                 }
             };
-            let old_rel_key = dsm::core::bilateral_transaction_manager::compute_smt_key(&ctx.a_old, c);
-            let new_rel_key = dsm::core::bilateral_transaction_manager::compute_smt_key(&ctx.a_new, c);
+            let old_rel_key =
+                dsm::core::bilateral_transaction_manager::compute_smt_key(&ctx.a_old, c);
+            let new_rel_key =
+                dsm::core::bilateral_transaction_manager::compute_smt_key(&ctx.a_new, c);
             let old_segment = match Self::fetch_rel_chain_segment(&old_rel_key).await {
                 Ok(s) => s,
                 Err(e) => {
@@ -1624,7 +1663,10 @@ impl RecoverySDK {
         let config = crate::sdk::storage_node_sdk::StorageNodeConfig::from_env_config()
             .await
             .map_err(|e| {
-                DsmError::storage(format!("load storage node config: {e}"), None::<std::io::Error>)
+                DsmError::storage(
+                    format!("load storage node config: {e}"),
+                    None::<std::io::Error>,
+                )
             })?;
         let qid = crate::handlers::app_router_impl::fetch_quorum_device_identity(
             &config.node_urls,
@@ -1632,7 +1674,9 @@ impl RecoverySDK {
         )
         .await
         .map_err(|e| {
-            DsmError::verification(format!("recovery: A_old device identity quorum failed: {e}"))
+            DsmError::verification(format!(
+                "recovery: A_old device identity quorum failed: {e}"
+            ))
         })?;
 
         Self::verify_and_record_activation(
@@ -1780,10 +1824,8 @@ impl RecoverySDK {
         let capsule_count = crate::storage::client_db::recovery::get_capsule_count().unwrap_or(0);
         let last_capsule_index =
             crate::storage::client_db::recovery::get_max_capsule_index().unwrap_or(0);
-        let accepted_state_index =
-            crate::storage::client_db::recovery::accepted_state_index();
-        let capsule_state_index =
-            crate::storage::client_db::recovery::capsule_state_index();
+        let accepted_state_index = crate::storage::client_db::recovery::accepted_state_index();
+        let capsule_state_index = crate::storage::client_db::recovery::capsule_state_index();
         let capsule_dirty = crate::storage::client_db::recovery::is_capsule_dirty();
 
         RecoveryStatus {
@@ -1828,8 +1870,7 @@ impl RecoverySDK {
         Self::persist_capsule(next_index, &smt_root, &capsule_bytes, tip_count)?;
         // Capsule currency (spec §5.2): record the accepted-state index this seal
         // captured so `is_capsule_dirty()` clears.
-        if let Err(e) =
-            crate::storage::client_db::recovery::set_capsule_state_index(captured_index)
+        if let Err(e) = crate::storage::client_db::recovery::set_capsule_state_index(captured_index)
         {
             log::warn!("[RECOVERY_SDK] failed to record capsule_state_index: {e}");
         }
@@ -2054,8 +2095,14 @@ mod tests {
         assert!(k.starts_with("recovery/dbtc-vault-index/v1/"));
         assert!(!k.starts_with('/'));
         // Keyed by BOTH genesis and device.
-        assert_ne!(k, RecoverySDK::dbtc_vault_index_storage_key(&[0x6F; 32], &d));
-        assert_ne!(k, RecoverySDK::dbtc_vault_index_storage_key(&g, &[0xA1; 32]));
+        assert_ne!(
+            k,
+            RecoverySDK::dbtc_vault_index_storage_key(&[0x6F; 32], &d)
+        );
+        assert_ne!(
+            k,
+            RecoverySDK::dbtc_vault_index_storage_key(&g, &[0xA1; 32])
+        );
         // Base32 Crockford only — no hex (repo invariant).
         assert!(!k.contains("0x"));
     }
@@ -2065,12 +2112,21 @@ mod tests {
         let g = [0x6E; 32];
         let a_new = [0xA1; 32];
         let k = RecoverySDK::recovery_succession_proof_storage_key(&g, &a_new);
-        assert_eq!(k, RecoverySDK::recovery_succession_proof_storage_key(&g, &a_new));
+        assert_eq!(
+            k,
+            RecoverySDK::recovery_succession_proof_storage_key(&g, &a_new)
+        );
         assert!(k.starts_with("recovery/succession-proof/v1/"));
         assert!(!k.starts_with('/'));
         // Keyed by BOTH genesis and the successor device.
-        assert_ne!(k, RecoverySDK::recovery_succession_proof_storage_key(&[0x6F; 32], &a_new));
-        assert_ne!(k, RecoverySDK::recovery_succession_proof_storage_key(&g, &[0xA2; 32]));
+        assert_ne!(
+            k,
+            RecoverySDK::recovery_succession_proof_storage_key(&[0x6F; 32], &a_new)
+        );
+        assert_ne!(
+            k,
+            RecoverySDK::recovery_succession_proof_storage_key(&g, &[0xA2; 32])
+        );
         // Base32 Crockford only — no hex (repo invariant).
         assert!(!k.contains("0x"));
     }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/recovery.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/recovery.rs
@@ -433,8 +433,7 @@ pub fn set_recovery_state(state: RecoveryState) -> Result<()> {
 /// (Phase 5); at that point the only paths that re-open spend are the audited
 /// chokepoints. Every value-egress path MUST route through this gate.
 pub fn value_egress_block_reason() -> Option<&'static str> {
-    const UNREADABLE: &str =
-        "recovery state unreadable: value egress blocked (fail-closed)";
+    const UNREADABLE: &str = "recovery state unreadable: value egress blocked (fail-closed)";
 
     // Fail-closed read policy: a genuine DB read error means we CANNOT prove the
     // spend is safe, so we block. A legitimately-unset pref (`Ok(None)`) means
@@ -1480,7 +1479,10 @@ mod tests {
             RecoveryState::Polling,
             RecoveryState::Resuming,
         ] {
-            assert!(s.is_identity_recovery_in_progress(), "{s:?} must block egress");
+            assert!(
+                s.is_identity_recovery_in_progress(),
+                "{s:?} must block egress"
+            );
         }
         for s in [
             RecoveryState::None,
@@ -1601,8 +1603,14 @@ mod tests {
             // owns the transaction (never opening a new one).
             let binding = get_connection().expect("conn");
             let conn = binding.lock().expect("lock");
-            assert_eq!(bump_accepted_state_index_with_conn(&conn).expect("bump1"), 1);
-            assert_eq!(bump_accepted_state_index_with_conn(&conn).expect("bump2"), 2);
+            assert_eq!(
+                bump_accepted_state_index_with_conn(&conn).expect("bump1"),
+                1
+            );
+            assert_eq!(
+                bump_accepted_state_index_with_conn(&conn).expect("bump2"),
+                2
+            );
         } // release the connection lock before reading via a fresh connection
         assert_eq!(accepted_state_index(), 2);
     }
@@ -1750,7 +1758,9 @@ mod tests {
         let lock = get_asset_lock(dbtc).expect("read").expect("present");
         assert!(lock.is_dbtc, "dBTC must be auto-flagged");
         // Generic reconciliation is refused with MissingDbtcFrontierReplay.
-        let err = reconcile_token_asset(dbtc, 100, 100).unwrap_err().to_string();
+        let err = reconcile_token_asset(dbtc, 100, 100)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("MissingDbtcFrontierReplay"), "got: {err}");
         // dBTC stays LockedRecovery → egress still blocked.
         assert_eq!(
@@ -1792,7 +1802,7 @@ mod tests {
         let tok = b"ERA";
         lock_restored_bearer_asset(tok).expect("lock");
         reconcile_token_asset(tok, 100, 100).expect("reconcile"); // → Spendable
-        // Re-locking (e.g. resume re-run) must NOT clobber the reconciled Spendable state.
+                                                                  // Re-locking (e.g. resume re-run) must NOT clobber the reconciled Spendable state.
         lock_restored_bearer_asset(tok).expect("re-lock");
         assert_eq!(
             get_asset_lock(tok).expect("read").expect("present").state,

--- a/dsm_storage_node/src/api/identity/recovery_anchor.rs
+++ b/dsm_storage_node/src/api/identity/recovery_anchor.rs
@@ -209,7 +209,10 @@ async fn put_anchor(
 
     match outcome {
         crate::db::RecoveryAnchorUpsertOutcome::Inserted => {
-            log::info!("PUT /recovery/authority-anchor for genesis={}: inserted", genesis);
+            log::info!(
+                "PUT /recovery/authority-anchor for genesis={}: inserted",
+                genesis
+            );
             Ok(StatusCode::CREATED)
         }
         crate::db::RecoveryAnchorUpsertOutcome::AlreadyExistsIdentical => {
@@ -251,6 +254,7 @@ async fn get_anchor(
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::disallowed_methods)] // unwrap/expect/unwrap_err acceptable in deterministic tests
     use super::*;
 
     fn valid_anchor_bytes(genesis: &[u8; 32]) -> Vec<u8> {
@@ -270,7 +274,10 @@ mod tests {
         let body = valid_anchor_bytes(&g);
         let v = validate_anchor(&body, &g).expect("valid");
         // Canonical re-encode round-trips and the hash is over the canonical bytes.
-        assert_eq!(v.anchor_hash, blake3_tagged(ANCHOR_STORE_TAG, &v.canonical_bytes));
+        assert_eq!(
+            v.anchor_hash,
+            blake3_tagged(ANCHOR_STORE_TAG, &v.canonical_bytes)
+        );
         // Re-validating the canonical bytes yields the same hash (idempotency key stable).
         let v2 = validate_anchor(&v.canonical_bytes, &g).expect("valid2");
         assert_eq!(v.anchor_hash, v2.anchor_hash);
@@ -279,7 +286,10 @@ mod tests {
     #[test]
     fn empty_body_rejected() {
         let g = [0x6E; 32];
-        assert_eq!(validate_anchor(&[], &g).unwrap_err(), AnchorValidationError::Empty);
+        assert_eq!(
+            validate_anchor(&[], &g).unwrap_err(),
+            AnchorValidationError::Empty
+        );
     }
 
     #[test]
@@ -303,7 +313,10 @@ mod tests {
         .encode_to_vec();
         assert!(matches!(
             validate_anchor(&body, &g).unwrap_err(),
-            AnchorValidationError::FieldLen { field: "genesis_id", .. }
+            AnchorValidationError::FieldLen {
+                field: "genesis_id",
+                ..
+            }
         ));
     }
 

--- a/dsm_storage_node/src/db/pg.rs
+++ b/dsm_storage_node/src/db/pg.rs
@@ -759,8 +759,9 @@ pub async fn insert_recovery_authority_anchor_if_absent(
 ) -> Result<RecoveryAnchorUpsertOutcome> {
     use tokio_postgres::IsolationLevel;
 
-    let tick_i64 = i64::try_from(first_written_tick)
-        .map_err(|_| anyhow::anyhow!("first_written_tick {first_written_tick} does not fit in i64"))?;
+    let tick_i64 = i64::try_from(first_written_tick).map_err(|_| {
+        anyhow::anyhow!("first_written_tick {first_written_tick} does not fit in i64")
+    })?;
 
     let mut client = pool.get().await?;
     let tx = client

--- a/dsm_storage_node/src/db/sqlite.rs
+++ b/dsm_storage_node/src/db/sqlite.rs
@@ -876,10 +876,7 @@ pub async fn insert_pdsmt_head_if_chained(
 
 /// Return the payload of the device's latest (highest `head_number`) PDSMT head,
 /// or `None` if the chain is empty.
-pub async fn get_pdsmt_head_latest(
-    pool: &DBPool,
-    device_b32: &str,
-) -> Result<Option<Vec<u8>>> {
+pub async fn get_pdsmt_head_latest(pool: &DBPool, device_b32: &str) -> Result<Option<Vec<u8>>> {
     let device_b32 = device_b32.to_string();
     with_conn(pool, move |conn| {
         let payload: Option<Vec<u8>> = conn
@@ -1932,9 +1929,15 @@ mod tests {
     #[tokio::test]
     async fn recovery_anchor_identical_replay_is_idempotent() {
         let pool = make_inmem_pool().await;
-        insert_recovery_authority_anchor_if_absent(&pool, "GENESISA", &[0xAB; 32], b"anchor-bytes-1", 7)
-            .await
-            .unwrap();
+        insert_recovery_authority_anchor_if_absent(
+            &pool,
+            "GENESISA",
+            &[0xAB; 32],
+            b"anchor-bytes-1",
+            7,
+        )
+        .await
+        .unwrap();
         // Same genesis, same anchor_hash (even with a different tick) → idempotent.
         let outcome = insert_recovery_authority_anchor_if_absent(
             &pool,
@@ -1955,9 +1958,15 @@ mod tests {
     #[tokio::test]
     async fn recovery_anchor_different_same_genesis_conflicts() {
         let pool = make_inmem_pool().await;
-        insert_recovery_authority_anchor_if_absent(&pool, "GENESISA", &[0xAB; 32], b"anchor-bytes-1", 7)
-            .await
-            .unwrap();
+        insert_recovery_authority_anchor_if_absent(
+            &pool,
+            "GENESISA",
+            &[0xAB; 32],
+            b"anchor-bytes-1",
+            7,
+        )
+        .await
+        .unwrap();
         // Same genesis, DIFFERENT anchor_hash → bind-once rejects (no overwrite).
         let outcome = insert_recovery_authority_anchor_if_absent(
             &pool,
@@ -2015,12 +2024,18 @@ mod tests {
         assert_eq!(o1, PdsmtHeadChainOutcome::Appended { head_number: 1 });
 
         assert_eq!(
-            get_pdsmt_head_latest(&pool, "DEVA").await.unwrap().as_deref(),
+            get_pdsmt_head_latest(&pool, "DEVA")
+                .await
+                .unwrap()
+                .as_deref(),
             Some(b"head1".as_ref())
         );
         // History retained: head at/before snapshot reads the older head.
         assert_eq!(
-            get_pdsmt_head_at(&pool, "DEVA", 0).await.unwrap().as_deref(),
+            get_pdsmt_head_at(&pool, "DEVA", 0)
+                .await
+                .unwrap()
+                .as_deref(),
             Some(b"head0".as_ref())
         );
     }
@@ -2029,9 +2044,10 @@ mod tests {
     async fn pdsmt_head_non_genesis_first_rejected() {
         let pool = make_inmem_pool().await;
         // First head must be genesis (number 0, zero parent).
-        let bad_num = insert_pdsmt_head_if_chained(&pool, "DEVA", 1, &[0x10; 32], &[0u8; 32], b"x", 1)
-            .await
-            .unwrap();
+        let bad_num =
+            insert_pdsmt_head_if_chained(&pool, "DEVA", 1, &[0x10; 32], &[0u8; 32], b"x", 1)
+                .await
+                .unwrap();
         assert_eq!(bad_num, PdsmtHeadChainOutcome::Conflict);
         let bad_parent =
             insert_pdsmt_head_if_chained(&pool, "DEVA", 0, &[0x10; 32], &[0x99; 32], b"x", 1)
@@ -2048,9 +2064,10 @@ mod tests {
             .await
             .unwrap();
         // Fork: head_number 1 but parent != h0.
-        let fork = insert_pdsmt_head_if_chained(&pool, "DEVA", 1, &[0x11; 32], &[0xEE; 32], b"f", 2)
-            .await
-            .unwrap();
+        let fork =
+            insert_pdsmt_head_if_chained(&pool, "DEVA", 1, &[0x11; 32], &[0xEE; 32], b"f", 2)
+                .await
+                .unwrap();
         assert_eq!(fork, PdsmtHeadChainOutcome::Conflict);
         // Gap: head_number 2 with no head 1 yet.
         let gap = insert_pdsmt_head_if_chained(&pool, "DEVA", 2, &[0x12; 32], &h0, b"g", 3)
@@ -2072,12 +2089,16 @@ mod tests {
             .unwrap();
         assert_eq!(replay, PdsmtHeadChainOutcome::AlreadyExistsIdentical);
         // DIFFERENT head at the same position → conflict (no overwrite).
-        let fork0 = insert_pdsmt_head_if_chained(&pool, "DEVA", 0, &[0xAB; 32], &[0u8; 32], b"evil", 9)
-            .await
-            .unwrap();
+        let fork0 =
+            insert_pdsmt_head_if_chained(&pool, "DEVA", 0, &[0xAB; 32], &[0u8; 32], b"evil", 9)
+                .await
+                .unwrap();
         assert_eq!(fork0, PdsmtHeadChainOutcome::Conflict);
         assert_eq!(
-            get_pdsmt_head_latest(&pool, "DEVA").await.unwrap().as_deref(),
+            get_pdsmt_head_latest(&pool, "DEVA")
+                .await
+                .unwrap()
+                .as_deref(),
             Some(b"head0".as_ref())
         );
     }

--- a/dsm_storage_node/src/main.rs
+++ b/dsm_storage_node/src/main.rs
@@ -218,8 +218,8 @@ fn build_router(state: Arc<AppState>, config: &ServerConfig, benchmark_mode: boo
     let devtree_router =
         api::identity::devtree::create_router(state.clone()).layer(public_rate_layer.clone());
     // Recovery-authority anchor — single-assignment per genesis (§0.5 bind-once)
-    let recovery_anchor_router =
-        api::identity::recovery_anchor::create_router(state.clone()).layer(public_rate_layer.clone());
+    let recovery_anchor_router = api::identity::recovery_anchor::create_router(state.clone())
+        .layer(public_rate_layer.clone());
     // Append-only Per-Device SMT head chain (§0.5 gap 13, R4 layer 1)
     let pdsmt_head_router =
         api::identity::pdsmt_head::create_router(state.clone()).layer(public_rate_layer.clone());


### PR DESCRIPTION
## Why

`main`'s `Rust` CI job has been **red since 2026-06-05**. Root cause: the #488 recovery/device-admission stack merged with rustfmt drift (32 files) **and** clippy violations. These went unreported because `make lint` runs `cargo fmt --all -- --check` first and short-circuits before `cargo clippy` ever executes. Every open PR inherited this failure.

## What

- `cargo fmt --all` — reformat 32 drifted files (whitespace/line-wrapping only).
- Fix clippy `-D warnings` errors surfaced once fmt passed:
  - unnecessary `to_vec` (recovery/*), unneeded `return` (sdk lib + bitcoin_tap_sdk), manual `is_multiple_of` (chain_segment)
  - `#![allow(clippy::disallowed_methods)]` on the `recovery_anchor` test module (matches existing test convention for `unwrap`/`expect`)

## Verification

Locally green:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --locked --workspace --all-features`