### PR TITLE
test: make suite parallel-safe; drop --test-threads=1 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,9 @@ jobs:
         run: cargo build --locked --workspace --all-features
 
       - name: Test
-        # Run single-threaded: parts of the suite exercise process-global singletons
-        # (AppState, the session wallet-seed cache, the storage base dir, the posted-DLV
-        # store) that are one-per-process by design and are not isolated across parallel
-        # test threads. The Coverage job already runs the same suite with --test-threads=1.
         run: |
-          cargo test --locked --workspace --exclude dsm_storage_node -- --nocapture --test-threads=1
-          cargo test --locked -p dsm_storage_node --no-default-features --features local-dev,strict -- --nocapture --test-threads=1
+          cargo test --locked --workspace --exclude dsm_storage_node -- --nocapture
+          cargo test --locked -p dsm_storage_node --no-default-features --features local-dev,strict -- --nocapture
 
       - name: Codegen enforcement
         run: |
@@ -252,21 +248,11 @@ jobs:
         run: npm ci
 
       - name: Generate Rust coverage artifacts
-        # --test-threads=1: under llvm-cov's instrumentation the test
-        # scheduling differs enough from a plain `cargo test` run that
-        # tests touching shared global state in dsm_sdk (AppState,
-        # binding-key slot, identity-info slot) race. The plain Rust
-        # job passes with default parallelism because its schedule
-        # happens to avoid the bad interleavings; coverage runs flake
-        # on different tests (e.g. test_generate_recovery_mnemonic_and_config,
-        # set_and_get_sdk_initialized) depending on order. Serializing
-        # is the cheap deterministic fix while the wider serial-group
-        # audit lands separately.
         run: |
           mkdir -p coverage
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --locked --workspace --exclude dsm_storage_node --no-report -- --nocapture --test-threads=1
-          cargo llvm-cov --locked -p dsm_storage_node --no-default-features --features local-dev,strict --no-report -- --nocapture --test-threads=1
+          cargo llvm-cov --locked --workspace --exclude dsm_storage_node --no-report -- --nocapture
+          cargo llvm-cov --locked -p dsm_storage_node --no-default-features --features local-dev,strict --no-report -- --nocapture
           cargo llvm-cov report --json --output-path coverage.json
           cargo llvm-cov report --lcov --output-path coverage/rust.lcov
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
@@ -3587,6 +3587,7 @@ mod unified_protobuf_bridge_tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn query_frame_preserves_req_id_on_success_and_error() {
         let _guard = setup_test_env();
         let req_id = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -3614,6 +3615,7 @@ mod unified_protobuf_bridge_tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn invoke_frame_preserves_existing_success_and_error_wire_shape() {
         let _guard = setup_test_env();
 
@@ -3638,6 +3640,7 @@ mod unified_protobuf_bridge_tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn hardware_facts_wrapper_matches_session_manager_bytes() {
         let _guard = setup_test_env();
         let facts = pb::SessionHardwareFactsProto {
@@ -3660,6 +3663,7 @@ mod unified_protobuf_bridge_tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn envelope_wrapper_preserves_framed_response_behavior() {
         let _guard = setup_test_env();
         let request = pb::Envelope {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/app_state.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/app_state.rs
@@ -136,6 +136,34 @@ impl AppState {
         STORAGE_INITIALIZED.store(true, Ordering::SeqCst);
     }
 
+    /// Test-isolation guard around [`Self::ensure_storage_loaded`].
+    ///
+    /// In production (`DSM_SDK_TEST_MODE` unset) this lazily loads persisted
+    /// state exactly like calling `ensure_storage_loaded` directly — behavior
+    /// is unchanged.
+    ///
+    /// Under tests the in-memory `STORAGE` slot is primed explicitly by the
+    /// per-test setup helpers, so a full `ensure_storage_loaded` here is both
+    /// redundant and unsafe. `ensure_storage_loaded` is non-atomic — it checks
+    /// `STORAGE_INITIALIZED`, then later re-stores the `HAS_IDENTITY` /
+    /// `SDK_INITIALIZED` atomics from the loaded/default state — so running it
+    /// concurrently with another test's reset window (which briefly clears
+    /// `STORAGE_INITIALIZED`) stomps those atomics mid-assertion and flakes the
+    /// AppState tests. In test mode we therefore only make sure the `STORAGE`
+    /// slot exists, so accessors can still read and write it, and never touch
+    /// the global atomics or `STORAGE_INITIALIZED`. This generalises the guard
+    /// already used by `get_has_identity` / `get_sdk_initialized`.
+    fn ensure_storage_loaded_unless_test() {
+        if std::env::var("DSM_SDK_TEST_MODE").is_err() {
+            Self::ensure_storage_loaded();
+            return;
+        }
+        let mut guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
+        if guard.is_none() {
+            *guard = Some(AppStateStorage::default());
+        }
+    }
+
     /// Atomically write current in-memory storage to disk as protobuf.
     fn save_storage() {
         if std::env::var("DSM_SDK_TEST_MODE").is_ok() {
@@ -216,7 +244,7 @@ impl AppState {
         genesis_hash: Vec<u8>,
         smt_root: Vec<u8>,
     ) {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         {
             let mut guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
             if let Some(ref mut s) = *guard {
@@ -248,7 +276,7 @@ impl AppState {
         genesis_hash: Vec<u8>,
         smt_root: Vec<u8>,
     ) {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         {
             let mut guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
             if let Some(ref mut s) = *guard {
@@ -281,7 +309,7 @@ impl AppState {
 
     /// Accessors (binary values stay binary; UI must encode externally).
     pub fn get_device_id() -> Option<Vec<u8>> {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         STORAGE
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -289,7 +317,7 @@ impl AppState {
             .and_then(|s| s.device_id.clone())
     }
     pub fn get_public_key() -> Option<Vec<u8>> {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         STORAGE
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -297,7 +325,7 @@ impl AppState {
             .and_then(|s| s.public_key.clone())
     }
     pub fn get_genesis_hash() -> Option<Vec<u8>> {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         STORAGE
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -305,7 +333,7 @@ impl AppState {
             .and_then(|s| s.genesis_hash.clone())
     }
     pub fn get_smt_root() -> Option<Vec<u8>> {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         STORAGE
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -315,7 +343,7 @@ impl AppState {
     /// Get the Device Tree root R_G (§2.3).
     /// Returns the stored 32-byte root, or None if not yet computed.
     pub fn get_device_tree_root() -> Option<[u8; 32]> {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         let guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
         guard.as_ref()?.device_tree_root.as_ref().and_then(|v| {
             if v.len() == 32 {
@@ -337,7 +365,7 @@ impl AppState {
     }
     /// Set the Device Tree root R_G and persist.
     pub fn set_device_tree_root(root: [u8; 32]) {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         {
             let mut guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
             if let Some(ref mut s) = *guard {
@@ -349,29 +377,23 @@ impl AppState {
 
     /// Boolean flags
     pub fn get_has_identity() -> bool {
-        if std::env::var("DSM_SDK_TEST_MODE").is_err() {
-            Self::ensure_storage_loaded();
-        }
+        Self::ensure_storage_loaded_unless_test();
         HAS_IDENTITY.load(Ordering::SeqCst)
     }
     pub fn set_sdk_initialized(value: bool) {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         SDK_INITIALIZED.store(value, Ordering::SeqCst);
         Self::save_storage();
     }
     pub fn get_sdk_initialized() -> bool {
-        if std::env::var("DSM_SDK_TEST_MODE").is_err() {
-            Self::ensure_storage_loaded();
-        }
+        Self::ensure_storage_loaded_unless_test();
         SDK_INITIALIZED.load(Ordering::SeqCst)
     }
 
     /// Preference bridge used by JNI-facing helpers (string K/V only).
     /// Binary fields remain inaccessible here (device_id/genesis_hash).
     pub fn handle_app_state_request(key: &str, operation: &str, value: &str) -> String {
-        if std::env::var("DSM_SDK_TEST_MODE").is_err() {
-            Self::ensure_storage_loaded();
-        }
+        Self::ensure_storage_loaded_unless_test();
 
         match key {
             "has_identity" => {
@@ -437,7 +459,7 @@ impl AppState {
     /// Used by `purge_legacy_prefs` at AppRouterImpl boot to wipe the
     /// retired `dsm.token.*` / `dsm.dlv.*` / `dsm.sofi.*` keyspace.
     pub fn purge_keys_with_prefixes(prefixes: &[&str]) -> usize {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         let removed = {
             let mut guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
             let Some(ref mut store) = *guard else {
@@ -462,7 +484,7 @@ impl AppState {
 
     /// Recovery session helpers
     pub fn set_recovery_state(recovery_id: &str, status: &str) -> Result<(), String> {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         {
             let mut guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
             if let Some(ref mut store) = *guard {
@@ -478,13 +500,13 @@ impl AppState {
     }
 
     pub fn get_recovery_state(recovery_id: &str) -> Option<String> {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         let guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
         guard.as_ref()?.recovery_sessions.get(recovery_id).cloned()
     }
 
     pub fn clear_recovery_state(recovery_id: &str) -> Result<(), String> {
-        Self::ensure_storage_loaded();
+        Self::ensure_storage_loaded_unless_test();
         {
             let mut guard = STORAGE.lock().unwrap_or_else(|p| p.into_inner());
             if let Some(ref mut store) = *guard {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/bootstrap.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/bootstrap.rs
@@ -130,6 +130,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn load_without_identity_errors_or_panics_on_race() {
         setup_test_env();
         // In parallel tests, ensure_storage_loaded() may race on STORAGE_INITIALIZED.

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/inbox_poller.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/inbox_poller.rs
@@ -400,6 +400,7 @@ mod tests {
     // ── Poller state flags ──
 
     #[test]
+    #[serial_test::serial]
     fn stop_poller_sets_flag() {
         POLLER_STOP.store(false, Ordering::SeqCst);
         POLLER_RUNNING.store(false, Ordering::SeqCst);
@@ -410,6 +411,7 @@ mod tests {
     // ── resume_poller when not running calls start_poller ──
 
     #[test]
+    #[serial_test::serial]
     fn resume_when_running_does_not_restart() {
         POLLER_RUNNING.store(true, Ordering::SeqCst);
         POLLER_STOP.store(false, Ordering::SeqCst);
@@ -503,18 +505,21 @@ mod tests {
     // ── Poller flags: independent checks ──
 
     #[test]
+    #[serial_test::serial]
     fn poller_stop_flag_initially_false() {
         POLLER_STOP.store(false, Ordering::SeqCst);
         assert!(!POLLER_STOP.load(Ordering::SeqCst));
     }
 
     #[test]
+    #[serial_test::serial]
     fn poller_running_flag_initially_false() {
         POLLER_RUNNING.store(false, Ordering::SeqCst);
         assert!(!POLLER_RUNNING.load(Ordering::SeqCst));
     }
 
     #[test]
+    #[serial_test::serial]
     fn stop_then_stop_is_idempotent() {
         POLLER_STOP.store(false, Ordering::SeqCst);
         POLLER_RUNNING.store(false, Ordering::SeqCst);

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/posted_dlv_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/posted_dlv_sdk.rs
@@ -383,6 +383,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn alice_posts_bob_lists_carol_sees_nothing() {
         let bob_pk = pk(0xB0, 1568);
         let carol_pk = pk(0xC0, 1568);
@@ -407,6 +408,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn advertisement_digest_binds_proto() {
         let bob_pk = pk(0xB1, 1568);
         let dlv_id = vid(0x02);
@@ -433,6 +435,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn tampered_proto_rejected_by_digest_check() {
         let bob_pk = pk(0xB2, 1568);
         let dlv_id = vid(0x03);
@@ -455,6 +458,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn claimed_state_supersedes_active_in_dedup() {
         let bob_pk = pk(0xB3, 1568);
         let dlv_id = vid(0x04);
@@ -487,6 +491,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn dedup_prefers_higher_state_number() {
         use super::super::bitcoin_tap_sdk::BitcoinTapSdk;
 
@@ -540,6 +545,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn delete_removes_both_ad_and_proto() {
         let bob_pk = pk(0xB5, 1568);
         let dlv_id = vid(0x06);
@@ -573,6 +579,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn empty_recipient_prefix_lists_nothing() {
         let ghost_pk = pk(0xF0, 1568);
         let view = load_active_advertisements_for_recipient(&ghost_pk)

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/route_commit_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/route_commit_sdk.rs
@@ -1345,6 +1345,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn anchor_key_collision_is_rejected_on_fetch() {
         // Manually plant an anchor whose `x` field disagrees with its
         // key.  The fetch helper must reject this — otherwise a
@@ -1495,6 +1496,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn eligibility_rejects_when_anchor_x_does_not_match_key() {
         // Anchor exists at the right key but its `x` field disagrees —
         // a forged/swapped record.  Eligibility MUST reject.
@@ -1889,6 +1891,7 @@ mod tests {
     // chunk-#3 publish flows already use.
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn demo_full_amm_trade_e2e() {
         use dsm::crypto::sphincs::{generate_keypair, sign as sphincs_sign, SphincsVariant};
         use dsm::vault::FulfillmentMechanism;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/routing_path_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/routing_path_sdk.rs
@@ -874,6 +874,7 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn invalid_digest_excluded_from_verified_search() {
         let a = token("AAAd1");
         let b = token("BBBd1");

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/routing_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/routing_sdk.rs
@@ -449,6 +449,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn lists_advertisements_for_pair_in_either_order() {
         let token_a = token(0xA0);
         let token_b = token(0xB0);
@@ -485,6 +486,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn reserves_canonicalise_to_lex_lower_token() {
         // tokens(0x01) < tokens(0xFE) lexicographically (string compare).
         let lower = token(0x01);
@@ -526,6 +528,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn pair_isolation_no_cross_pair_leakage() {
         let token_a = token(0xA1);
         let token_b = token(0xB1);
@@ -558,6 +561,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn digest_binds_proto_and_tamper_is_caught() {
         let token_a = token(0xA2);
         let token_b = token(0xB2);
@@ -588,6 +592,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn terminal_state_supersedes_active_in_dedup() {
         let token_a = token(0xA3);
         let token_b = token(0xB3);
@@ -620,6 +625,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn dedup_prefers_higher_state_number() {
         let token_a = token(0xA4);
         let token_b = token(0xB4);
@@ -669,6 +675,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn delete_removes_both_keys() {
         let token_a = token(0xA5);
         let token_b = token(0xB5);
@@ -693,6 +700,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn unknown_pair_lists_empty() {
         let ghost_a = token(0xF0);
         let ghost_b = token(0xF1);
@@ -715,6 +723,7 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn republish_with_reserves_bumps_state_and_updates_reserves() {
         let token_a = token(0x60);
         let token_b = token(0x61);
@@ -756,6 +765,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn republish_preserves_non_reserve_fields() {
         let token_a = token(0x70);
         let token_b = token(0x71);
@@ -812,6 +822,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn republish_for_absent_advertisement_returns_err() {
         // Vault that was never advertised — republish must surface
         // the storage-not-found error so the caller (chunk #7
@@ -828,6 +839,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn republish_supersedes_baseline_in_dedup() {
         // Republish must produce a higher updated_state_number so the
         // chunk-#1 dedup selector picks the post-trade ad in any

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/session_manager.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/session_manager.rs
@@ -393,6 +393,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn default_phase_is_runtime_loading() {
         let _g = setup_test_env();
         // SDK_READY already reset to false by setup_test_env
@@ -403,6 +404,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn phase_needs_genesis_when_ready_but_no_identity() {
         let _g = setup_test_env();
         SDK_READY.store(true, Ordering::SeqCst);
@@ -414,6 +416,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn phase_locked_when_lock_set() {
         let _g = setup_test_env();
         SDK_READY.store(true, Ordering::SeqCst);
@@ -429,6 +432,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn fatal_error_overrides_phase() {
         let _g = setup_test_env();
         SDK_READY.store(true, Ordering::SeqCst);
@@ -491,6 +495,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn hardware_facts_round_trip() {
         let _g = setup_test_env();
         // SDK_READY already reset to false by setup_test_env
@@ -528,6 +533,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn sync_lock_config_reads_native_prefs() {
         let _g = setup_test_env();
         AppState::handle_app_state_request(LOCK_ENABLED_KEY, "set", "true");
@@ -544,6 +550,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn cold_start_with_enabled_lock_defaults_to_locked() {
         let _g = setup_test_env();
         AppState::handle_app_state_request(LOCK_ENABLED_KEY, "set", "true");
@@ -563,6 +570,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn runtime_unlock_persists_until_next_process_start() {
         let _g = setup_test_env();
         AppState::handle_app_state_request(LOCK_ENABLED_KEY, "set", "true");
@@ -588,6 +596,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn snapshot_bytes_are_envelope_wrapped() {
         let _g = setup_test_env();
         SDK_READY.store(true, Ordering::SeqCst);

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/vault_state_composition.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/vault_state_composition.rs
@@ -1001,6 +1001,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn skips_pointer_when_rc_missing_even_if_x_present() {
         // Cross-version safety: a legacy publisher might write the X
         // anchor without the paired RC bytes.  The composer must skip
@@ -1121,6 +1122,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn rejects_pointer_whose_rc_hop_baseline_disagrees_with_cursor() {
         // A trader publishes a RouteCommit whose hop's
         // vault_state_reserves_digest doesn't match the composer's
@@ -1189,6 +1191,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn rejects_pointer_when_route_commit_x_mismatches_pointer_x() {
         let vault_id = vid_seed(0x18);
         let owner = generate_keypair(SphincsVariant::SPX256f).expect("owner kp");


### PR DESCRIPTION
## What

The Rust **Test** and **Coverage** CI jobs were pinned to `--test-threads=1` because parts of the `dsm_sdk` test suite share **process-global singletons** that aren't isolated across parallel test threads, so tests flaked nondeterministically under parallel execution (different tests on different runs). This makes the suite parallel-safe and drops `--test-threads=1` from both jobs.

Purely test isolation — **no product behavior changes**.

## Root causes & fixes

- **AppState identity atomics.** The getters/setters called the non-atomic `ensure_storage_loaded()` unconditionally, which re-stores `HAS_IDENTITY` / `SDK_INITIALIZED` from defaults whenever `STORAGE_INITIALIZED` is briefly `false` (a concurrent test's reset window), stomping the atomics mid-assertion. Added `ensure_storage_loaded_unless_test()`: in test mode it only ensures the `STORAGE` slot exists without touching the global atomics; **production behavior is unchanged** (`DSM_SDK_TEST_MODE` is never set there). This generalises the guard already used by `get_has_identity` / `get_sdk_initialized`.
- **Shared test stores/flags.** Serialized (`#[serial]`) the tests that touch the DBTC mock store (`posted_dlv`, `routing`, `route_commit`, `routing_path`, `vault`), the inbox-poller flags, `SDK_READY` (`session_manager`), and direct AppState mutators (`bootstrap`, `jni`).
- **CI.** Removed `--test-threads=1` (and the explanatory comments) from both the Test and Coverage steps.

## Validation

Against current DBRW-free `main` (#514):

- **20/20** plain `cargo test --lib` runs at `--test-threads=16`.
- **2/2** runs of the exact `cargo llvm-cov` coverage command (`--workspace --exclude dsm_storage_node`) — the original flaky scenario — **0 failures** across `dsm` core, `dsm_sdk`, and integration binaries.
- rustfmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
