### PR TITLE
refactor: purge dead C-DBRW remnants; correct GenesisV2 canonical format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,22 @@ updates:
       - "dependencies"
       - "frontend"
     open-pull-requests-limit: 5
+    ignore:
+      # @bufbuild/protoc-gen-es is pinned to the v1 line because it must match
+      # the @bufbuild/protobuf ^1 runtime. The v1 plugin emits the class-based
+      # API (proto3.makeMessageType / new Message()) used by every proto
+      # consumer in src/services and src/proto/dsm_app_pb.ts. v2+ emits a
+      # different runtime (typeName-keyed schemas, create(Schema, ...)) and
+      # requires migrating @bufbuild/protobuf to ^2 plus rewriting every
+      # consumer; bumping the plugin alone silently breaks `npm run type-check`
+      # and `proto:gen`. A 2.x bump was already reverted twice (the pin in
+      # commit b14e436a, then PR #457 re-bumped it). Hold minor/major until a
+      # coordinated v2 migration lands. Patch bumps OK.
+      - dependency-name: "@bufbuild/protoc-gen-es"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-major"]
+      - dependency-name: "@bufbuild/protobuf"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/dsm_client/android/app/src/androidTest/java/com/dsm/wallet/sofi/SoFiCrossDeviceOwnerTest.kt
+++ b/dsm_client/android/app/src/androidTest/java/com/dsm/wallet/sofi/SoFiCrossDeviceOwnerTest.kt
@@ -102,7 +102,7 @@ class SoFiCrossDeviceOwnerTest {
         Log.i(TAG, "owner setUp: ERA balance = $balance (any value OK for owner role)")
         Assume.assumeTrue(
             "Owner device has no published trust snapshot (balance.get returned $balance). " +
-                "Ensure genesis + C-DBRW resume completed before the test runs.",
+                "Ensure genesis + device-birth resume completed before the test runs.",
             balance >= 0L,
         )
     }

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/Unified.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/Unified.kt
@@ -135,7 +135,7 @@ object Unified {
     /**
      * Get a compact AppRouter status code (native):
      * 0 = NOT_READY_NO_GENESIS
-     * 1 = DBRW_NOT_READY
+     * 1 = ROUTER_NOT_READY
      * 2 = INSTALLED
      */
     @Keep @JvmStatic fun getAppRouterStatus(): Int = UnifiedNativeApi.getAppRouterStatus()

--- a/dsm_client/deterministic_state_machine/dsm/src/common/device_admission.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/device_admission.rs
@@ -9,8 +9,8 @@
 //!
 //! Gate-only, two-signature, co-present. The only control added over a plain insert is a
 //! **signature gate**: only a device key already in the tree may authorize the insert. The new
-//! device co-signs with its own DBRW-bound key to prove physical possession (DBRW is silicon-bound
-//! and cannot be cloned) WITHOUT revealing the raw DBRW. The gate signer's pubkey is obtained from
+//! device co-signs with its own device signing key to prove physical possession (the key is
+//! mnemonic-rooted under GenesisV2) WITHOUT revealing the raw key. The gate signer's pubkey is obtained from
 //! the QR the new device scanned in person — there is **no storage-node quorum and no external
 //! verifier** (that is only needed by the recovery flow, where a remote party authenticates a
 //! device it never met). Replay is prevented by the monotonic `parent_device_tree_version`: an
@@ -97,7 +97,7 @@ pub struct AddDeviceAdmission {
     pub parent_device_tree_version: u64,
     /// SPHINCS+ by `signer_device_id` (the existing device) — the authorization gate.
     pub signature_by_signer_device: Vec<u8>,
-    /// SPHINCS+ by the new device's DBRW-bound key — proof of physical possession.
+    /// SPHINCS+ by the new device's signing key — proof of physical possession.
     pub signature_by_new_device: Vec<u8>,
 }
 
@@ -285,10 +285,10 @@ mod tests {
     fn fixture() -> (AddDeviceAdmission, Vec<u8>, [u8; 32], Vec<[u8; 32]>, u64) {
         let genesis = [0x6E; 32]; // root device id == genesis
         let (signer_pk, signer_sk) = kp(0x11); // existing (root) device signing key
-        let (new_pk, new_sk) = kp(0x22); // new device signing key (DBRW-bound)
+        let (new_pk, new_sk) = kp(0x22); // new device signing key (device-bound)
         let entropy = vec![0xAB; 32];
-        let dbrw = vec![0xCD; 48];
-        let new_id = derive_secondary_device_id(&entropy, &genesis, &dbrw);
+        let device_binding = vec![0xCD; 48];
+        let new_id = derive_secondary_device_id(&entropy, &genesis, &device_binding);
         let current: Vec<[u8; 32]> = vec![genesis];
         let version = 1u64;
         let parent_root = DeviceTree::new(current.clone()).root();

--- a/dsm_client/deterministic_state_machine/dsm/src/common/domain_tags/dsm/core.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/domain_tags/dsm/core.rs
@@ -7,7 +7,6 @@
 pub const TAG_RECEIPT_COMMIT: &str = "DSM/receipt-commit";
 pub const TAG_SMT_NODE: &str = "DSM/smt-node";
 pub const TAG_SMT_LEAF: &str = "DSM/smt-leaf";
-pub const TAG_DBRW: &str = "DSM/dbrw";
 pub const TAG_HASH_DATA: &str = "DSM/hash-data";
 pub const TAG_ENTITY_ID: &str = "DSM/entity-id";
 pub const TAG_DEVICE_ID: &str = "DSM/device-id";
@@ -37,7 +36,6 @@ pub(super) const TAGS: &[&str] = &[
     TAG_RECEIPT_COMMIT,
     TAG_SMT_NODE,
     TAG_SMT_LEAF,
-    TAG_DBRW,
     TAG_HASH_DATA,
     TAG_ENTITY_ID,
     TAG_DEVICE_ID,

--- a/dsm_client/deterministic_state_machine/dsm/src/common/domain_tags/dsm/genesis_identity/device.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/common/domain_tags/dsm/genesis_identity/device.rs
@@ -11,8 +11,8 @@ pub const TAG_DSM_DEVID: &str = "DSM/devid";
 /// additional-device enrollment) — the existing authorized device signs this with its device key.
 pub const TAG_DSM_ADD_DEVICE_ADMISSION: &str = "DSM/add-device-admission";
 /// Canonical signing-payload domain for the NEW-DEVICE self-attestation half of an
-/// `AddDeviceAdmission` — the joining device signs this with its DBRW-bound device key to prove
-/// physical possession of its claimed identity (without revealing the raw DBRW).
+/// `AddDeviceAdmission` — the joining device signs this with its device signing key to prove
+/// physical possession of its claimed identity (without revealing the raw key).
 pub const TAG_DSM_ADD_DEVICE_SELF_ATTEST: &str = "DSM/add-device-self-attest";
 pub const TAG_DSM_GENESIS_DEVICE_COMMIT: &str = "DSM/genesis-device-commit";
 pub const TAG_DSM_GENESIS_DEVICE_ENTROPY: &str = "DSM/genesis-device-entropy";

--- a/dsm_client/deterministic_state_machine/dsm/src/core/bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/bridge.rs
@@ -839,7 +839,7 @@ pub fn handle_envelope_universal(env_bytes: &[u8]) -> Vec<u8> {
                         }
                     }
 
-                    // -------- Recovery / DBRW ops are SDK-only --------
+                    // -------- Recovery ops are SDK-only --------
                     Some(gp::universal_op::Kind::RecoveryCapsuleDecrypt(req)) => {
                         if let Some(handler) = recovery_handler() {
                             match handler.handle_recovery_capsule_decrypt(req) {

--- a/dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/identity/genesis.rs
@@ -5,7 +5,7 @@
 //!
 //! - n-of-n commit-then-reveal entropy aggregation (participants ≥3); NOT
 //!   threshold cryptography — every participant's contribution is required.
-//! - DBRW is a local, optional anti-cloning signal; it must not be required for
+//! - GenesisV2 is mnemonic-rooted; no DBRW/anti-cloning signal is required for
 //!   genesis / identity creation and is not part of genesis binding.
 //! - No system wall-clock dependence.
 //! - Bytes-only at logical boundaries; strings are local to display/IDs only.
@@ -408,7 +408,7 @@ pub fn create_genesis_via_blind_mpc_with_contributors(
     Ok(gs)
 }
 
-// -------------------- Device entropy (no DBRW) --------------------
+// -------------------- Device entropy --------------------
 
 pub fn get_device_entropy(
     device_id: &str,
@@ -551,7 +551,7 @@ pub fn convert_session_to_genesis_state_compat(
     session: &crate::core::identity::genesis_session::GenesisSession,
 ) -> Result<GenesisState, DsmError> {
     // Canonical contribution materials `[device_id ∥ device_entropy, b_1, …, b_n]`
-    // — exactly the bytes the session hashed into `G`. Metadata and DBRW are
+    // — exactly the bytes the session hashed into `G`. Metadata is
     // NOT contributions and are excluded (they don't bind `G`).
     let contribs: Vec<Vec<u8>> = session.canonical_contribution_materials();
 

--- a/dsm_client/deterministic_state_machine/dsm/src/core/identity/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/identity/mod.rs
@@ -107,9 +107,9 @@ fn compute_contribution_merkle_root(contributions: &[genesis::Contribution]) -> 
 pub fn convert_session_to_genesis_state(
     session: &GenesisSession,
 ) -> Result<GenesisState, IdentityError> {
-    // DBRW is an optional, local anti-cloning signal and must NOT be required to
+    // GenesisV2 is mnemonic-rooted; no DBRW/anti-cloning signal is required to
     // create or represent genesis / identity. Genesis must remain derivable and
-    // recoverable without DBRW present.
+    // recoverable from the wallet seed alone.
 
     if session.storage_nodes.len() < 3 {
         return Err(IdentityError::InvalidParameter(

--- a/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/state_machine/mod.rs
@@ -205,7 +205,6 @@ impl StateMachine {
             None, // encapsulated_entropy — caller can set if needed
             deltas,
             initial_chain_tip,
-            None, // dbrw_summary_hash
         )
     }
 

--- a/dsm_client/deterministic_state_machine/dsm/src/crypto/hkdf.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/crypto/hkdf.rs
@@ -7,7 +7,7 @@
 //!
 //! ```text
 //! S_master = HKDF-Extract(salt = "DSM/dev\0",
-//!                         IKM  = G ‖ DevID ‖ K_DBRW ‖ s_0)
+//!                         IKM  = G ‖ DevID ‖ s_0  (GenesisV2: mnemonic-rooted, no DBRW))
 //! ```
 //!
 //! The HMAC primitive is constructed per RFC 2104 with BLAKE3 as the
@@ -218,12 +218,12 @@ mod tests {
         // shape works through this module.
         let g = [0xAAu8; 32];
         let devid = [0xBBu8; 32];
-        let k_dbrw = [0xCCu8; 32];
+        let chain_head_wrap_key = [0xCCu8; 32];
         let s_0 = [0xDDu8; 32];
         let mut ikm = Vec::with_capacity(32 * 4);
         ikm.extend_from_slice(&g);
         ikm.extend_from_slice(&devid);
-        ikm.extend_from_slice(&k_dbrw);
+        ikm.extend_from_slice(&chain_head_wrap_key);
         ikm.extend_from_slice(&s_0);
         let s_master = extract(b"DSM/dev\0", &ikm);
         assert_eq!(s_master.len(), 32);

--- a/dsm_client/deterministic_state_machine/dsm/src/lib.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/lib.rs
@@ -37,7 +37,7 @@
 //! ## Module Organization
 //!
 //! - [`core`] — State machine, bridge traits, bilateral management, identity, token subsystem
-//! - [`crypto`] — BLAKE3 (domain-separated), SPHINCS+, ML-KEM-768, DBRW, ChaCha20-Poly1305 (salted-BLAKE3 commitments via `dsm_domain_hasher`)
+//! - [`crypto`] — BLAKE3 (domain-separated), SPHINCS+, ML-KEM-768, ChaCha20-Poly1305 (salted-BLAKE3 commitments via `dsm_domain_hasher`)
 //! - [`types`] — All protocol types: [`types::state_types::State`], [`types::error::DsmError`], identifiers, tokens
 //! - [`vault`] — Deterministic Limbo Vaults (DLV), asset management, fulfillment
 //! - [`merkle`] — Sparse Merkle Tree (per-device SMT) and Device Trees
@@ -80,10 +80,7 @@ pub mod crypto;
 // (Issue #185 — all 4 findings). It exported types with zero
 // production callers anywhere in `dsm/` or `dsm_sdk/` (verified by
 // source inspection); the audit findings were all on a never-
-// executed path. Module removed entirely. If a real hardware-bound
-// attestation surface is later needed, the C-DBRW infrastructure in
-// `crypto::cdbrw_binding` is already wired through the SDK and is
-// the canonical entry point — see Issue #213.
+// executed path. Module removed entirely.
 pub mod dlv;
 pub mod emissions;
 pub mod envelope;

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/activation.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/activation.rs
@@ -260,7 +260,6 @@ mod tests {
                 balance_witness: BTreeMap::new(),
                 entity_sig: None,
                 counterparty_sig: None,
-                dbrw_summary_hash: None,
                 island_attestation: None,
             },
             carry_forward_commitment: [0; 32],

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/assembly.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/assembly.rs
@@ -398,7 +398,6 @@ mod tests {
             balance_witness: BTreeMap::new(),
             entity_sig: None,
             counterparty_sig: None,
-            dbrw_summary_hash: None,
             island_attestation: None,
         }
     }
@@ -454,7 +453,6 @@ mod tests {
             balance_witness: BTreeMap::new(),
             entity_sig: None,
             counterparty_sig: None,
-            dbrw_summary_hash: None,
             island_attestation: None,
         };
         let t_new_established = est_state.compute_chain_tip();

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/chain_segment.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/chain_segment.rs
@@ -70,7 +70,6 @@ pub fn rel_chain_state_to_proto(s: &RelationshipChainState) -> RelationshipChain
         operation: s.operation.to_bytes(),
         entropy: s.entropy.clone(),
         encapsulated_entropy: s.encapsulated_entropy.clone(),
-        dbrw_summary_hash: s.dbrw_summary_hash.map(|d| d.to_vec()),
         // BTreeMap iterates sorted by 32B policy_commit → canonical order on the wire.
         balance_witness: s
             .balance_witness
@@ -106,11 +105,6 @@ pub fn rel_chain_state_to_proto(s: &RelationshipChainState) -> RelationshipChain
 pub fn rel_chain_state_from_proto(
     p: &RelationshipChainStateProto,
 ) -> Result<RelationshipChainState, DsmError> {
-    let dbrw_summary_hash = match &p.dbrw_summary_hash {
-        Some(d) => Some(fixed32("dbrw_summary_hash", d)?),
-        None => None,
-    };
-
     let mut balance_witness: BTreeMap<[u8; 32], u64> = BTreeMap::new();
     for (i, e) in p.balance_witness.iter().enumerate() {
         let pc = fixed32("balance_witness.policy_commit", &e.policy_commit)?;
@@ -157,7 +151,6 @@ pub fn rel_chain_state_from_proto(
         balance_witness,
         entity_sig: p.entity_sig.clone(),
         counterparty_sig: p.counterparty_sig.clone(),
-        dbrw_summary_hash,
         island_attestation,
     })
 }
@@ -400,7 +393,6 @@ mod tests {
             balance_witness: bw,
             entity_sig: Some(vec![0x11; 8]),
             counterparty_sig: None,
-            dbrw_summary_hash: Some([tag; 32]),
             island_attestation: None,
         }
     }
@@ -537,7 +529,6 @@ mod tests {
             balance_witness: BTreeMap::new(),
             entity_sig: Some(vec![0x22; 8]),
             counterparty_sig: Some(vec![0x33; 8]),
-            dbrw_summary_hash: None,
             island_attestation: None,
         };
         RecoveryEstablishmentReceipt { rel_key: rk, state }

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/pdsmt_posting.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/pdsmt_posting.rs
@@ -816,7 +816,6 @@ mod tests {
                     amount: 10,
                 }],
                 Some(initial_chain_tip_from_device_ids(&owner, &c_yes)),
-                None,
             )
             .expect("value advance")
             .new_device_state;
@@ -838,7 +837,6 @@ mod tests {
                 None,
                 &[],
                 Some(initial_chain_tip_from_device_ids(&owner, &c_no)),
-                None,
             )
             .expect("non-value advance")
             .new_device_state;

--- a/dsm_client/deterministic_state_machine/dsm/src/recovery/succession_binding.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/recovery/succession_binding.rs
@@ -510,7 +510,6 @@ mod tests {
             balance_witness: BTreeMap::new(),
             entity_sig: None,
             counterparty_sig: None,
-            dbrw_summary_hash: None,
             island_attestation: None,
         }
     }
@@ -559,7 +558,6 @@ mod tests {
             balance_witness: BTreeMap::new(),
             entity_sig: None,
             counterparty_sig: None,
-            dbrw_summary_hash: None,
             island_attestation: None,
         };
         let t_new_established = est.compute_chain_tip();

--- a/dsm_client/deterministic_state_machine/dsm/src/types/crypto_error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/crypto_error.rs
@@ -4,7 +4,7 @@
 //!
 //! [`CryptoError`] captures the context, operation name, and optional source
 //! error string for failures occurring within the DSM cryptographic subsystem
-//! (BLAKE3, SPHINCS+, ML-KEM-768, DBRW, salted-BLAKE3 commitments, etc.).
+//! (BLAKE3, SPHINCS+, ML-KEM-768, salted-BLAKE3 commitments, etc.).
 
 use std::fmt;
 

--- a/dsm_client/deterministic_state_machine/dsm/src/types/device_state.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/device_state.rs
@@ -336,10 +336,6 @@ pub struct RelationshipChainState {
     /// Counterparty SPHINCS+ signature (bilateral mode).
     pub counterparty_sig: Option<Vec<u8>>,
 
-    /// Optional DBRW health summary commitment (§12). Advisory only —
-    /// included in the hash iff present on the advancing device.
-    pub dbrw_summary_hash: Option<[u8; 32]>,
-
     /// Optional offline-bearer secure-element island attestation (anti-clone, see
     /// [`crate::attestation`]). Folded into the chain tip iff present; absent on every
     /// non-offline-bearer transition, so those tips hash exactly as before.
@@ -354,7 +350,7 @@ impl RelationshipChainState {
     /// and any counter-like metadata per §4.3. Ordering of fields is:
     ///
     /// `rel_key ‖ embedded_parent ‖ counterparty_devid ‖ op ‖ entropy
-    /// ‖ encap_flag ‖ encap? ‖ dbrw_flag ‖ dbrw? ‖ witness_len
+    /// ‖ encap_flag ‖ encap? ‖ witness_len
     /// ‖ (policy_commit ‖ value)* sorted_by_policy_commit`
     ///
     /// Signatures are NOT hashed — they sign this digest, not the other
@@ -378,16 +374,6 @@ impl RelationshipChainState {
                 hasher.update(&[1u8]);
                 hasher.update(&(enc.len() as u32).to_le_bytes());
                 hasher.update(enc);
-            }
-            None => {
-                hasher.update(&[0u8]);
-            }
-        }
-
-        match &self.dbrw_summary_hash {
-            Some(dbrw) => {
-                hasher.update(&[1u8]);
-                hasher.update(dbrw);
             }
             None => {
                 hasher.update(&[0u8]);
@@ -750,7 +736,6 @@ impl DeviceState {
     /// - `deltas` — balance mutations to apply to device-level `B^T`
     /// - `initial_chain_tip` — spec-canonical initial tip, used ONLY if
     ///   `rel_key` has no prior entry in the SMT (first-ever tx)
-    /// - `dbrw_summary_hash` — optional DBRW health commitment (§12)
     ///
     /// # Errors
     ///
@@ -774,7 +759,6 @@ impl DeviceState {
         encapsulated_entropy: Option<Vec<u8>>,
         deltas: &[BalanceDelta],
         initial_chain_tip: Option<[u8; 32]>,
-        dbrw_summary_hash: Option<[u8; 32]>,
     ) -> Result<AdvanceOutcome, DsmError> {
         // Resolve embedded_parent: prior SMT leaf, or the initial tip for
         // first-ever advances on this relationship. For first-ever advances
@@ -837,7 +821,6 @@ impl DeviceState {
             balance_witness: new_balances.clone(),
             entity_sig: None,
             counterparty_sig: None,
-            dbrw_summary_hash,
             island_attestation: None,
         };
 
@@ -1055,7 +1038,6 @@ mod tests {
                 None,
                 &[],
                 Some(init_tip),
-                None,
             )
             .expect("advance");
         assert_eq!(
@@ -1211,7 +1193,6 @@ mod tests {
                     amount: 50,
                 }],
                 Some(init_tip),
-                None,
             )
             .expect("credit advance succeeds");
 
@@ -1281,7 +1262,6 @@ mod tests {
                     amount: 10,
                 }],
                 Some(init),
-                None,
             )
             .expect("value advance");
         assert_eq!(
@@ -1296,7 +1276,7 @@ mod tests {
         // keep it `Yes` — the Gemini fatal case, end-to-end through advance().
         let o2 = o1
             .new_device_state
-            .advance(rk, cp, op(), entropy(2), None, &[], None, None)
+            .advance(rk, cp, op(), entropy(2), None, &[], None)
             .expect("non-value advance");
         assert_eq!(
             o2.new_device_state
@@ -1311,7 +1291,7 @@ mod tests {
         let rk2 = compute_smt_key(&dev.devid, &cp2);
         let init2 = initial_chain_tip_from_device_ids(&dev.devid, &cp2);
         let o3 = dev
-            .advance(rk2, cp2, op(), entropy(3), None, &[], Some(init2), None)
+            .advance(rk2, cp2, op(), entropy(3), None, &[], Some(init2))
             .expect("first non-value advance");
         assert_eq!(
             o3.new_device_state
@@ -1361,7 +1341,6 @@ mod tests {
                     amount: 30,
                 }],
                 Some(init_bob),
-                None,
             )
             .expect("advance Bob");
         assert_eq!(
@@ -1385,7 +1364,6 @@ mod tests {
                     amount: 50,
                 }],
                 Some(init_chrl),
-                None,
             )
             .expect("advance Charlie");
         assert_eq!(
@@ -1443,7 +1421,6 @@ mod tests {
                     amount: 10,
                 }],
                 Some(init_bob),
-                None,
             )
             .expect("advance A");
         let b = dev
@@ -1459,7 +1436,6 @@ mod tests {
                     amount: 20,
                 }],
                 Some(init_chrl),
-                None,
             )
             .expect("advance B");
 
@@ -1510,7 +1486,6 @@ mod tests {
                     amount: 10,
                 }],
                 Some(init),
-                None,
             )
             .expect("advance A");
         let b = dev
@@ -1526,7 +1501,6 @@ mod tests {
                     amount: 20,
                 }],
                 Some(init),
-                None,
             )
             .expect("advance B");
 
@@ -1571,7 +1545,6 @@ mod tests {
                 amount: 10,
             }],
             Some(init),
-            None,
         );
         assert!(
             r.is_err(),
@@ -1604,7 +1577,6 @@ mod tests {
                 amount: 1,
             }],
             Some(init),
-            None,
         );
         assert!(r.is_err(), "u64::MAX + 1 must overflow");
     }
@@ -1653,7 +1625,6 @@ mod tests {
                         amount: amt,
                     }],
                     Some(init),
-                    None,
                 )
                 .expect("advance");
             dev = out.new_device_state;
@@ -1742,7 +1713,6 @@ mod tests {
                 None,
                 &[],
                 Some(init_tip),
-                None,
             )
             .expect("bilateral advance succeeds")
             .new_device_state;

--- a/dsm_client/deterministic_state_machine/dsm/src/types/general.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/general.rs
@@ -22,12 +22,10 @@ pub struct KeyPair {
     /// Public key
     pub public_key: Vec<u8>,
 
-    /// Private key — held in plain memory; protect via the C-DBRW anti-clone
-    /// mechanism (`dsm_sdk::security::cdbrw_reprove`), not by a sealed-module
-    /// TEE/Keystore/StrongBox/Secure Enclave. The whole DSM design is
-    /// deliberately enclave-free: silicon binding is established by C-DBRW's
-    /// observed statistical signature (`AC_D` attractor commitment), and the
-    /// in-memory K_DBRW slot is zeroed on every drift-detection failure.
+    /// Private key — held in plain memory, not in a sealed-module
+    /// TEE/Keystore/StrongBox/Secure Enclave. The DSM design is deliberately
+    /// enclave-free; under GenesisV2 the wallet seed (BIP39 mnemonic) is the
+    /// authorship root and keys are re-derived from it, never persisted.
     pub private_key: Vec<u8>,
 }
 impl fmt::Debug for KeyPair {

--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -417,7 +417,7 @@ pub enum Operation {
         new_state_hash: Vec<u8>,
         /// Entropy of the replacement state.
         new_state_entropy: Vec<u8>,
-        /// Proof of key compromise (e.g., DBRW anomaly evidence).
+        /// Proof of key compromise (e.g., clone/anomaly evidence).
         compromise_proof: Vec<u8>,
         /// Signatures from recovery authorities (multi-party threshold).
         authority_sigs: Vec<Vec<u8>>,

--- a/dsm_client/deterministic_state_machine/dsm/src/types/receipt_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/receipt_types.rs
@@ -11,7 +11,7 @@
 //! - Domain-separated BLAKE3 hashing
 //! - Dual SPHINCS+ signatures (both parties)
 //! - Inclusion proofs for old/new leaves and device binding
-//! - Per-step C-DBRW receipt response through EK derivation and cert chaining
+//! - Per-step receipt response through EK derivation and cert chaining
 
 use crate::common::domain_tags::TAG_RECEIPT_COMMIT;
 use crate::types::error::DsmError;
@@ -82,7 +82,7 @@ pub struct StitchedReceiptV2 {
     /// SPHINCS+ response from party A for this receipt challenge.
     ///
     /// The challenge is the proposed transition context. The signer answers
-    /// with the fresh EK key derived from h_n, C_pre, k_step, and K_DBRW.
+    /// with the fresh EK key derived from h_n, C_pre, k_step (keyed under Smaster).
     pub sig_a: Vec<u8>,
 
     /// SPHINCS+ response from party B for this receipt challenge.
@@ -104,7 +104,7 @@ pub struct StitchedReceiptV2 {
     /// Per-step ephemeral SPHINCS+ public key for party A (whitepaper §11.1).
     ///
     /// `EK_pk_{n+1} = SPHINCS+.KeyGen(E_{n+1})`, where
-    /// `E_{n+1} = HKDF("DSM/ek\0" || h_n || C_pre || k_step || K_DBRW)`.
+    /// `E_{n+1} = HKDF_Smaster("DSM/ek\0" || h_n || C_pre || k_step)`.
     ///
     /// Carried in the envelope alongside `sig_a` so verifiers don't need
     /// the per-step EK out-of-band. NOT in canonical commit form (§4.2.1).

--- a/dsm_client/deterministic_state_machine/dsm/src/types/state_types.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/state_types.rs
@@ -87,11 +87,6 @@ pub struct StateParams {
     pub device_info: DeviceInfo,
     /// Optional forward commitment binding this state to a future transition.
     pub forward_commitment: Option<PreCommitment>,
-    /// Optional deterministic commitment to DBRW health summary for this transition.
-    ///
-    /// This MUST NOT be the raw DBRW binding key or any secret. It is intended to be a
-    /// small, canonical digest produced from local DBRW health telemetry.
-    pub dbrw_summary_hash: Option<[u8; 32]>,
     pub previous_hash: [u8; 32],
     #[allow(dead_code)]
     pub(crate) none_field: Option<Vec<u8>>,
@@ -124,7 +119,6 @@ impl StateParams {
             operation,
             device_info,
             forward_commitment: None,
-            dbrw_summary_hash: None,
             previous_hash: [0u8; 32],
             none_field: None,
             metadata: Vec::new(),
@@ -137,9 +131,6 @@ impl StateParams {
             counterparty_sig: None,
         }
     }
-
-    // with_dbrw_summary_hash deleted: zero callers. The DBRW summary hash
-    // travels through DeviceState::advance directly (not StateParams).
 
     /// Set encapsulated entropy
     pub fn with_encapsulated_entropy(mut self, encapsulated_entropy: Vec<u8>) -> Self {
@@ -331,13 +322,6 @@ pub struct State {
     /// Relationship context for tracking state relationships
     pub relationship_context: Option<RelationshipContext>,
 
-    /// Optional deterministic commitment to DBRW health summary for this transition.
-    ///
-    /// This MUST NOT be the raw DBRW binding key or any secret. It is intended to be a
-    /// small, canonical digest (e.g., BLAKE3 over a minimal DBRW stat summary like the
-    /// global bit error rate) so that state progression is cryptographically coupled to
-    /// the anti-cloning gate.
-    pub dbrw_summary_hash: Option<[u8; 32]>,
     pub(crate) forward_commitment: Option<PreCommitment>,
     pub(crate) position_sequence: Option<PositionSequence>,
     pub(crate) positions: Vec<Vec<i32>>,
@@ -411,7 +395,6 @@ impl State {
             flags: HashSet::new(),
             token_balances: HashMap::new(),
             relationship_context: None,
-            dbrw_summary_hash: params.dbrw_summary_hash,
             forward_commitment: params.forward_commitment,
             positions: Vec::new(),
             position_sequence: None,
@@ -453,7 +436,6 @@ impl State {
             flags,
             token_balances: HashMap::new(), // Initialize empty token balances
             relationship_context: None,
-            dbrw_summary_hash: None,
             forward_commitment: None,
             positions: Vec::new(),
             position_sequence: None,
@@ -528,11 +510,6 @@ impl State {
         if let Some(enc) = &self.encapsulated_entropy {
             hasher.update(enc);
         }
-
-        // DBRW health summaries are intentionally excluded from the canonical
-        // state hash. They are device-local, advisory telemetry and must not
-        // perturb deterministic state identity or balance projection matching
-        // across restore/replay paths.
 
         // Deterministic serialization of operation (canonical bytes)
         let op_bytes = self.operation.to_bytes();
@@ -703,26 +680,6 @@ impl CanonicalEncode for State {
 mod tests {
     use super::{DeviceInfo, State, StateParams};
     use crate::types::operations::Operation;
-
-    #[test]
-    fn dbrw_summary_hash_does_not_change_state_hash() {
-        let device_info = DeviceInfo::new([0x11; 32], vec![0x22; 64]);
-
-        let base = State::new(StateParams::new(
-            vec![1, 2, 3, 4],
-            Operation::Noop,
-            device_info.clone(),
-        ));
-
-        let mut params = StateParams::new(vec![1, 2, 3, 4], Operation::Noop, device_info);
-        params.dbrw_summary_hash = Some([0xAB; 32]);
-        let with_dbrw = State::new(params);
-
-        let base_hash = base.compute_hash().expect("base hash");
-        let dbrw_hash = with_dbrw.compute_hash().expect("dbrw hash");
-
-        assert_eq!(base_hash, dbrw_hash);
-    }
 
     // ── helpers ──────────────────────────────────────────────────────
 
@@ -1333,13 +1290,6 @@ mod tests {
         let sp = StateParams::new(vec![], Operation::Noop, test_device_info())
             .with_forward_commitment(pc);
         assert!(sp.forward_commitment.is_some());
-    }
-
-    #[test]
-    fn state_params_dbrw_summary_hash_direct() {
-        let mut sp = StateParams::new(vec![], Operation::Noop, test_device_info());
-        sp.dbrw_summary_hash = Some([0xDD; 32]);
-        assert_eq!(sp.dbrw_summary_hash, Some([0xDD; 32]));
     }
 
     // ── State hash varies with different inputs ─────────────────────

--- a/dsm_client/deterministic_state_machine/dsm/src/types/unified_error.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/unified_error.rs
@@ -24,7 +24,7 @@ use std::collections::BTreeMap;
 /// to determine the appropriate recovery action.
 #[derive(Debug)]
 pub enum UnifiedDsmError {
-    /// Cryptographic operation failure (BLAKE3, SPHINCS+, ML-KEM, DBRW).
+    /// Cryptographic operation failure (BLAKE3, SPHINCS+, ML-KEM).
     Crypto {
         /// Description of the failed operation.
         context: String,

--- a/dsm_client/deterministic_state_machine/dsm/src/verification/receipt_verification.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/verification/receipt_verification.rs
@@ -79,19 +79,19 @@ pub fn verify_stitched_receipt(
         ));
     }
 
-    // Rule 2b: C-DBRW-bound ephemeral-key authorization (whitepaper §11.1).
+    // Rule 2b: EK-cert-chain ephemeral-key authorization (whitepaper §11.1).
     // Offline receipt acceptance is fail-closed: the sender signature must be
     // made by a per-step EK that is certified by the current AK/EK chain head.
     // Parent/root inclusion proves state consistency; this cert proves live
     // enrolled-device authorization for the proposed transition.
     let Some(chain_head) = &ctx.chain_head_pubkey_a else {
         return Ok(ReceiptAcceptance::reject(
-            "Missing chain_head_pubkey_a (C-DBRW EK cert chain required)".to_string(),
+            "Missing chain_head_pubkey_a (EK cert chain required)".to_string(),
         ));
     };
     if receipt.ek_cert_a.is_empty() {
         return Ok(ReceiptAcceptance::reject(
-            "Missing ek_cert_a (C-DBRW EK cert chain required)".to_string(),
+            "Missing ek_cert_a (EK cert chain required)".to_string(),
         ));
     }
     match crate::crypto::ephemeral_key::verify_ek_cert(
@@ -110,12 +110,12 @@ pub fn verify_stitched_receipt(
     }
     let Some(chain_head) = &ctx.chain_head_pubkey_b else {
         return Ok(ReceiptAcceptance::reject(
-            "Missing chain_head_pubkey_b (C-DBRW EK cert chain required)".to_string(),
+            "Missing chain_head_pubkey_b (EK cert chain required)".to_string(),
         ));
     };
     if receipt.ek_cert_b.is_empty() {
         return Ok(ReceiptAcceptance::reject(
-            "Missing ek_cert_b (C-DBRW EK cert chain required)".to_string(),
+            "Missing ek_cert_b (EK cert chain required)".to_string(),
         ));
     }
     match crate::crypto::ephemeral_key::verify_ek_cert(
@@ -567,7 +567,7 @@ mod tests {
 
     /// Receipt verification is fail-closed when no sender chain head is set.
     /// Parent/root inclusion alone is not spend authority; the recipient must
-    /// also verify the C-DBRW-bound per-step EK cert chain.
+    /// also verify the per-step EK cert chain.
     #[test]
     fn test_no_chain_head_rejects_receipt_authorization() {
         // Reuse the parent_uniqueness test setup but without consuming the parent.
@@ -609,7 +609,7 @@ mod tests {
         assert!(!result.valid, "missing chain head must reject");
         let reason = result.reason.unwrap();
         assert!(
-            reason.contains("chain_head_pubkey_a") || reason.contains("C-DBRW"),
+            reason.contains("chain_head_pubkey_a") || reason.contains("EK cert chain"),
             "wrong rejection reason: {}",
             reason
         );

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -171,7 +171,7 @@ impl BilateralBleHandler {
     /// Apply per-step EK signing (whitepaper §11.1) to an unsigned bilateral
     /// receipt. Looks up the counterparty's Kyber pubkey from the contact
     /// record, fetches the local AK keypair from the bilateral transaction
-    /// manager, fetches K_DBRW for SK encryption and EK derivation, runs the
+    /// manager, fetches the chain-head wrap key for SK encryption, runs the
     /// per-step signing helper, stamps the artifacts on the receipt's local
     /// side (A for sender, B for receiver), and advances the local chain
     /// head. Returns the full-protobuf bytes of the signed receipt.

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
@@ -1372,7 +1372,7 @@ impl AppRouterImpl {
             // receipt.ek_pk_a, which is authorized via receipt.ek_cert_a.
             //
             // The receipt challenge is signed by a per-step EK derived from
-            // canonical C_pre, fresh Kyber k_step material, and K_DBRW.
+            // canonical C_pre and fresh Kyber k_step material (keyed under Smaster).
             let rc = match dsm::types::receipt_types::StitchedReceiptV2::from_canonical_protobuf(
                 &rc_canonical,
             ) {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/dlv_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/dlv_routes.rs
@@ -693,7 +693,7 @@ impl AppRouterImpl {
                                     // SMT verification); the inclusion
                                     // proof is the spec-strict
                                     // strengthening that closes the
-                                    // K_DBRW-forgery hole.
+                                    // signing-key-forgery hole.
                                     publish_vault_state_inclusion_proof(
                                         self.core_sdk.as_ref(),
                                         &vault_id,
@@ -1430,7 +1430,7 @@ impl AppRouterImpl {
                             // PD-SMT and publish a
                             // VaultStateInclusionProofV1.  This is the
                             // spec-strict strengthening that closes
-                            // the K_DBRW-forgery hole on the unlock
+                            // the signing-key-forgery hole on the unlock
                             // path.  Same owner-key gate as the anchor
                             // republish above.
                             publish_vault_state_inclusion_proof(

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/recovery_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/recovery_impl.rs
@@ -195,7 +195,7 @@ impl RecoveryHandler for RecoveryImpl {
 
         // The device_entropy serves as both the device_id identifier and the private key
         // for signing the tombstone receipt. In production, the private key would come from
-        // the PlatformContext DBRW-bound key material.
+        // the PlatformContext key material.
         let device_id_bytes = &operation.device_entropy;
         if device_id_bytes.len() < 32 {
             return Err("device_entropy must be at least 32 bytes".to_string());

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/system_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/system_routes.rs
@@ -75,7 +75,7 @@ pub(crate) fn handle_system_genesis_query(q: AppQuery) -> AppResult {
             mpc_proof: res.session_id.clone(),
             // Legacy C-DBRW binding-record column (Genesis v2 has no silicon binding);
             // retained empty until the GenesisRecord schema column is dropped.
-            dbrw_binding: String::new(),
+            device_birth_binding: String::new(),
             merkle_root: crate::util::text_id::encode_base32_crockford(&[0u8; 32]),
             participant_count: res.participating_nodes.len() as u32,
             progress_marker: "genesis".to_string(),
@@ -283,7 +283,7 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
         genesis_id: genesis_id_b32.clone(),
         device_id: device_id_b32.clone(),
         mpc_proof: String::new(),
-        dbrw_binding: String::new(),
+        device_birth_binding: String::new(),
         merkle_root: crate::util::text_id::encode_base32_crockford(&smt_root),
         participant_count: 0,
         progress_marker: "genesis".to_string(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
@@ -4630,7 +4630,7 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_ensureAppRout
                 );
             } else {
                 log::error!(
-                    "ensureAppRouterInstalled: Cannot install AppRouter - canonical C-DBRW binding key missing or invalid"
+                    "ensureAppRouterInstalled: Cannot install AppRouter - canonical chain-head binding key missing or invalid"
                 );
             }
             0 // false
@@ -4641,7 +4641,7 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_ensureAppRout
 /// Return an integer status code describing why AppRouter may not be available.
 /// Codes:
 /// 0 = NOT_READY_NO_GENESIS
-/// 1 = DBRW_NOT_READY
+/// 1 = ROUTER_NOT_READY
 /// 2 = INSTALLED
 #[no_mangle]
 pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_getAppRouterStatus(
@@ -4680,10 +4680,10 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_getAppRouterS
             }
 
             // Conservative status: genesis and canonical binding are ready, but AppRouter still
-            // is not installed. Return DBRW_NOT_READY to indicate startup/router initialization is
+            // is not installed. Return ROUTER_NOT_READY to indicate startup/router initialization is
             // still incomplete.
             log::warn!(
-                "getAppRouterStatus: genesis present and canonical C-DBRW binding ready but AppRouter missing; returning DBRW_NOT_READY"
+                "getAppRouterStatus: genesis present and canonical binding ready but AppRouter missing; returning ROUTER_NOT_READY"
             );
             1
         }),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/lib.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/lib.rs
@@ -53,7 +53,7 @@
 //! | [`bluetooth`] | BLE bilateral sessions, frame chunking, pairing orchestration |
 //! | [`bridge`] | Trait-object dispatch layer connecting handlers to core |
 //! | [`envelope`] | Envelope v3 construction, framing (`0x03` prefix), guard rails |
-//! | [`security`] | DBRW clone-detection validation at the SDK boundary |
+//! | [`security`] | clone-detection validation at the SDK boundary |
 //! | [`storage`] | SQLite-backed client database for contacts, chain tips, bilateral state |
 //! | [`network`] | Multi-node storage endpoint registry and env-config loader |
 //! | [`recovery`] | Capsule, tombstone, and rollup recovery flows |
@@ -65,7 +65,7 @@
 //!
 //! 1. **Core ready** (`SDK_READY` in `unified_protobuf_bridge`) — set after
 //!    `sdkBootstrap` completes PBI (Platform Boundary Interface) initialization
-//!    with device_id, genesis_hash, and DBRW entropy.
+//!    with device_id and genesis_hash (GenesisV2: mnemonic-rooted).
 //! 2. **Bilateral ready** (`BILATERAL_READY`) — set after
 //!    [`initialize_bilateral_sdk`] verifies that the SDK context and bilateral
 //!    handler are installed, and device performance calibration succeeds.
@@ -313,7 +313,7 @@ pub(crate) fn derive_production_entropy(
 }
 
 /// Seed the wallet-seed session cache (tests only). Replaces the legacy
-/// `set_cdbrw_binding_key_for_testing`: identity/EK/coins/at-rest derivations all re-root on
+/// `set_cdevice_birth_binding_key_for_testing`: identity/EK/coins/at-rest derivations all re-root on
 /// this seed exactly as production re-roots on the mnemonic-derived seed.
 #[cfg(not(target_os = "android"))]
 pub fn set_wallet_seed_for_testing(seed: Vec<u8>) {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/platform/desktop.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/platform/desktop.rs
@@ -2,7 +2,7 @@
 
 //! # Desktop Platform Implementation
 //!
-//! Provides `DesktopPlatform` with file-system-based storage and DBRW
+//! Provides `DesktopPlatform` with file-system-based storage
 //! stubs for non-Android (desktop/test) builds.
 
 use dsm::types::error::DsmError;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/b0x_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/b0x_sdk.rs
@@ -2706,7 +2706,7 @@ impl B0xSDK {
             .local_chain_tip()
             .await
             .map(|v| text_id::encode_base32_crockford(&v))?;
-        // Use signing_authority (C-DBRW-derived) to match the key used by
+        // Use signing_authority to match the key used by
         // wallet.sign_operation_bytes — see submit_to_b0x for rationale.
         let sender_signing_public_key = crate::sdk::signing_authority::current_public_key()
             .unwrap_or_else(|_| core_sdk.get_device_identity().public_key);

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/device_admission_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/device_admission_sdk.rs
@@ -11,7 +11,7 @@
 //! No quorum, no external verifier: the new device gets the existing device's signing pubkey from
 //! the QR it scanned in person; the existing device's gate signature is the authorization (only a
 //! key already in the tree can produce a verifying admission). The new device co-signs with its
-//! DBRW-bound key to prove physical possession without revealing the raw DBRW.
+//! device signing key to prove physical possession without revealing the raw key.
 
 use dsm::common::device_admission::{
     derive_secondary_device_id, self_attest_digest, verify_self_attestation_sig, AddDeviceAdmission,
@@ -115,7 +115,7 @@ impl DeviceAdmissionSDK {
                 "admission request: genesis != this device's genesis",
             ));
         }
-        // Verify the new device's DBRW-bound self-attestation (proof of physical possession).
+        // Verify the new device's signing-key self-attestation (proof of physical possession).
         if !verify_self_attestation_sig(
             &genesis,
             &new_device_id,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/dlv_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/dlv_sdk.rs
@@ -3,7 +3,7 @@
 //! Deterministic Limbo Vault SDK (STRICT, fail-closed)
 //!
 //! This SDK exposes high-level, *identity-centric* helpers for DLVs.
-//! - SPHINCS+ signing authority is derived from canonical C-DBRW state.
+//! - SPHINCS+ signing authority is derived from the canonical wallet-rooted signing state.
 //! - Content Encryption Key (CEK) and unsealing KEK are managed **inside DLVManager**.
 //! - No alternate paths, no discovery shortcuts, explicit errors on missing inputs.
 
@@ -134,7 +134,7 @@ pub struct UnlockOptions {
     /// Requester's public key — Kyber key checked against vault's `intended_recipient`.
     pub requester_public_key: Vec<u8>,
     /// SPHINCS+ public key embedded in the DlvUnlock operation for signature verification.
-    /// If `None`, the SDK derives the current canonical C-DBRW signing public key.
+    /// If `None`, the SDK derives the current canonical signing public key.
     pub signing_public_key: Option<Vec<u8>>,
     /// Additional context data
     pub context: HashMap<String, String>,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/receipts.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/receipts.rs
@@ -32,7 +32,7 @@ pub fn derive_relationship_key(counterparty_pk: &[u8]) -> [u8; 32] {
 /// target becomes
 /// `BLAKE3("DSM/receipt-bind-session\0" || receipt_commitment ||
 /// commitment_hash)`. The fresh EK key that signs this target is derived from
-/// h_n, C_pre, k_step, and K_DBRW, so a copied database cannot answer the
+/// h_n, C_pre, k_step (keyed under Smaster), so a copied database cannot answer the
 /// next receipt challenge on different hardware.
 ///
 /// The §4.2.1 canonical commit form remains unchanged in both modes — the
@@ -98,7 +98,7 @@ pub fn derive_per_step_ek(
 #[derive(Debug)]
 pub struct KyberStepEncap {
     /// The 32-byte `k_step = BLAKE3("DSM/kyber-ss\0" || ss)` mixed into
-    /// the per-step EK derivation alongside K_DBRW.
+    /// the per-step EK derivation (keyed under Smaster).
     pub k_step: [u8; 32],
     /// Kyber ciphertext that travels in the receipt envelope; recipient
     /// decapsulates with their Kyber secret key to recover the same `ss`
@@ -256,7 +256,7 @@ pub struct PerStepSigningOutput {
 ///    The recipient's Kyber pubkey is mandatory.
 ///    The resulting Kyber ciphertext travels in `receipt.kyber_ct_a` so
 ///    the recipient can reconstruct the same `k_step`.
-/// 3. Derive `EK_{n+1}` from `(h_n, C_pre, k_step, K_DBRW)`.
+/// 3. Derive `EK_{n+1}` from `(h_n, C_pre, k_step) keyed under Smaster`.
 /// 4. Sign `cert_{n+1} = Sign_{prior_SK}(BLAKE3("DSM/ek-cert\0" ||
 ///    EK_pk_{n+1} || h_n))`.
 /// 5. Sign `inputs.commitment` with the new `EK_sk_{n+1}` to produce sig.
@@ -547,7 +547,7 @@ pub fn verify_per_step_ek_signing_strict_aware(
 /// required for offline receipt acceptance. Parent/root inclusion proves state
 /// consistency, but it is not spend authority. The receipt challenge is the
 /// proposed transition context. The response is `sig_a` or `sig_b` under the
-/// fresh EK key derived from h_n, C_pre, k_step, and K_DBRW, with `ek_cert`
+/// fresh EK key derived from h_n, C_pre, k_step (keyed under Smaster), with `ek_cert`
 /// linking that key to AK at step 0 or the prior EK on later steps.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_stitched_receipt(
@@ -567,7 +567,7 @@ pub fn verify_stitched_receipt(
     // Match receipt party (A vs B) to local-vs-counterparty roles by
     // looking up the local device id. If we can't determine which side
     // is local, fail closed rather than accepting a receipt without sender
-    // C-DBRW-bound authorization.
+    // EK-cert-chain authorization.
     let local_id = AppState::get_device_id();
     let (head_for_a, head_for_b): (Option<Vec<u8>>, Option<Vec<u8>>) = match local_id.as_deref() {
         Some(id) if id.len() == 32 && id == receipt.devid_a.as_slice() => {
@@ -599,7 +599,7 @@ pub fn verify_stitched_receipt(
 
     if head_for_a.is_none() {
         return Err(DsmError::invalid_operation(
-            "Receipt verification failed: missing sender cert-chain head for C-DBRW-bound \
+            "Receipt verification failed: missing sender cert-chain head for cert-chain-bound \
              receipt authorization",
         ));
     }
@@ -2818,7 +2818,6 @@ mod tests {
                 None,
                 &[],
                 Some(initial_tip),
-                None,
             )
             .expect("first-ever advance should succeed");
 
@@ -2935,7 +2934,7 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("missing sender cert-chain head")
-                || err.contains("C-DBRW-bound receipt authorization"),
+                || err.contains("cert-chain-bound receipt authorization"),
             "wrong rejection reason: {}",
             err
         );

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/receipts.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/receipts.rs
@@ -2464,6 +2464,11 @@ mod tests {
         use crate::storage::client_db::reset_database_for_tests;
         use dsm::crypto::ephemeral_key::generate_ephemeral_keypair;
         reset_database_for_tests();
+        // Install identity (`G` + DevID) and the cached wallet seed so the per-step
+        // EK signer can re-derive `Smaster` internally. Without this the test only
+        // passed when an earlier test happened to leave `G` set in the process-global
+        // AppState — an implicit ordering dependency that flakes under parallel runs.
+        let _ = setup_signing_identity();
 
         let (ak_pk, ak_sk) = generate_ephemeral_keypair(&[0xC2; 32]).unwrap();
         let kyber_kp = dsm::crypto::kyber::generate_kyber_keypair().expect("kyber keygen");

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/vault_smt_inclusion_codec.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/vault_smt_inclusion_codec.rs
@@ -6,7 +6,7 @@
 //! SoFi spec §4.1.2 / §8.4 step 2 — strictly stronger than the
 //! `VaultStateAnchorV1` codec next door: an inclusion proof commits
 //! the PD-SMT root + a 256-sibling Merkle path, so a stateless
-//! attacker who recovered the owner's K_DBRW still cannot forge a
+//! attacker who recovered the owner's signing key still cannot forge a
 //! proof against the device's actual SMT.
 //!
 //! Lives in `dsm_sdk` (not `dsm` core) because the `dsm` crate cannot

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/vault_state_composition.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/vault_state_composition.rs
@@ -199,7 +199,7 @@ pub(crate) async fn compose_vault_state(
     // SoFi spec §4.1.2 / §8.4 step 2 — STRICT MODE.  Verify the
     // owner's PD-SMT inclusion proof for the baseline vault state.
     // The anchor signature above is *necessary* but not *sufficient*:
-    // an attacker who recovered K_DBRW could forge a signed anchor.
+    // an attacker who recovered the signing key could forge a signed anchor.
     // The inclusion proof additionally commits the SMT root + a
     // 256-sibling Merkle path that
     // dsm::dlv::vault_smt_leaf::verify_vault_smt_inclusion recomputes
@@ -1375,7 +1375,7 @@ mod tests {
 
     /// Strict mode refuses to fold a vault whose owner never published
     /// a `VaultStateInclusionProofV1` — the legacy anchor alone is
-    /// insufficient.  This is the K_DBRW-forgery hole closure: an
+    /// insufficient.  This is the signing-key-forgery hole closure: an
     /// attacker with the owner's key can forge a signed anchor but
     /// cannot fabricate SMT consistency.
     #[tokio::test]

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bcr.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bcr.rs
@@ -58,9 +58,9 @@ pub fn store_bcr_report(report: &[u8]) -> Result<()> {
 // These codecs are byte-exact for the real types in
 // `dsm/src/types/device_state.rs`. The hashed prefix of a RelationshipChainState
 // matches `compute_chain_tip()` (rel_key ‖ embedded_parent ‖ counterparty_devid
-// ‖ op(len+bytes) ‖ entropy(len+bytes) ‖ encap_flag+optional ‖ dbrw_flag+
-// optional fixed 32B (NO length prefix) ‖ witness count + (policy_commit ‖
-// value u64 le) sorted). Sigs are appended outside the hashed prefix.
+// ‖ op(len+bytes) ‖ entropy(len+bytes) ‖ encap_flag+optional ‖ witness count
+// + (policy_commit ‖ value u64 le) sorted). Sigs are appended outside the
+// hashed prefix.
 // ──────────────────────────────────────────────────────────────────────────
 
 const REL_CHAIN_STATE_VERSION: u8 = 0x02;
@@ -105,15 +105,6 @@ pub fn encode_rel_chain_state(state: &RelationshipChainState) -> Vec<u8> {
         Some(enc) => {
             out.push(1u8);
             put_vec(&mut out, enc);
-        }
-        None => out.push(0u8),
-    }
-
-    match &state.dbrw_summary_hash {
-        Some(d) => {
-            out.push(1u8);
-            // Fixed 32 bytes, NO length prefix — mirrors compute_chain_tip().
-            out.extend_from_slice(d);
         }
         None => out.push(0u8),
     }
@@ -177,13 +168,6 @@ pub fn decode_rel_chain_state(bytes: &[u8]) -> Result<(RelationshipChainState, [
         other => return Err(anyhow!("encap_flag invalid: {other}")),
     };
 
-    let dbrw_flag = read_u8(&mut cursor).map_err(|e| anyhow!("dbrw_flag: {e}"))?;
-    let dbrw_summary_hash = match dbrw_flag {
-        0 => None,
-        1 => Some(take::<32>(&mut cursor).map_err(|e| anyhow!("dbrw summary: {e}"))?),
-        other => return Err(anyhow!("dbrw_flag invalid: {other}")),
-    };
-
     let witness_count = read_len_u32(&mut cursor).map_err(|e| anyhow!("witness count: {e}"))?;
     let mut balance_witness: BTreeMap<[u8; 32], u64> = BTreeMap::new();
     for _ in 0..witness_count {
@@ -217,7 +201,6 @@ pub fn decode_rel_chain_state(bytes: &[u8]) -> Result<(RelationshipChainState, [
         balance_witness,
         entity_sig,
         counterparty_sig,
-        dbrw_summary_hash,
         island_attestation: None,
     };
     let chain_tip = state.compute_chain_tip();
@@ -664,7 +647,6 @@ mod tests {
                     amount: 7,
                 }],
                 Some([0x55; 32]),
-                Some([0x66; 32]),
             )
             .expect("advance relationship");
 
@@ -756,7 +738,6 @@ mod tests {
         assert_eq!(decoded.balance_witness, rel.balance_witness);
         assert_eq!(decoded.entity_sig, rel.entity_sig);
         assert_eq!(decoded.counterparty_sig, rel.counterparty_sig);
-        assert_eq!(decoded.dbrw_summary_hash, rel.dbrw_summary_hash);
     }
 
     #[test]
@@ -847,7 +828,6 @@ mod tests {
                     amount: 9,
                 }],
                 None,
-                None,
             )
             .expect("second advance");
         store_bcr_chain_state(&device_id, &outcome1.new_chain_state, false)
@@ -893,7 +873,6 @@ mod tests {
                     amount: 11,
                 }],
                 None,
-                Some([0xAA; 32]),
             )
             .expect("third advance");
         update_bcr_device_head(&outcome1.new_device_state).expect("upsert head1");

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bitcoin_accounts.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/bitcoin_accounts.rs
@@ -2,8 +2,8 @@
 //! Bitcoin account persistence with at-rest encryption for secret material.
 //!
 //! `secret_material` is encrypted with XChaCha20-Poly1305 using a key derived
-//! from the DBRW binding key via BLAKE3 domain separation:
-//!   enc_key = BLAKE3("DSM/btc-key-enc\0" || dbrw_binding_key)
+//! from the device binding key via BLAKE3 domain separation:
+//!   enc_key = BLAKE3("DSM/btc-key-enc\0" || binding_key)
 //!
 //! Storage format: `[24-byte nonce][ciphertext + 16-byte Poly1305 tag]`
 
@@ -22,13 +22,10 @@ const TAG_LEN: usize = 16;
 /// Minimum length of encrypted blob: nonce + at least 1 byte plaintext + tag.
 const MIN_ENCRYPTED_LEN: usize = NONCE_LEN + 1 + TAG_LEN;
 
-/// Derive a 32-byte encryption key from the DBRW binding key.
-fn derive_enc_key(dbrw_binding_key: &[u8]) -> [u8; 32] {
-    *dsm::crypto::blake3::domain_hash(
-        dsm::common::domain_tags::TAG_DSM_BTC_KEY_ENC,
-        dbrw_binding_key,
-    )
-    .as_bytes()
+/// Derive a 32-byte encryption key from the device binding key.
+fn derive_enc_key(binding_key: &[u8]) -> [u8; 32] {
+    *dsm::crypto::blake3::domain_hash(dsm::common::domain_tags::TAG_DSM_BTC_KEY_ENC, binding_key)
+        .as_bytes()
 }
 
 /// Encrypt `plaintext` with XChaCha20-Poly1305 using a BLAKE3-derived deterministic nonce.
@@ -268,8 +265,8 @@ mod tests {
 
     #[test]
     fn derive_enc_key_is_deterministic() {
-        let key1 = derive_enc_key(b"test-dbrw-binding-key");
-        let key2 = derive_enc_key(b"test-dbrw-binding-key");
+        let key1 = derive_enc_key(b"test-binding-key");
+        let key2 = derive_enc_key(b"test-binding-key");
         assert_eq!(key1, key2);
         assert_ne!(key1, [0u8; 32]);
     }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/cert_chain.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/cert_chain.rs
@@ -35,10 +35,12 @@ use crate::util::deterministic_time::tick;
 // The local device's chain-head secret key is needed at receipt construction
 // time to sign cert_{n+1}. Persisting it in plaintext would defeat its
 // "ephemeral" property; persisting it under an OS keystore is platform-
-// specific. We persist it AEAD-encrypted under a key derived from K_DBRW so:
+// specific. We persist it AEAD-encrypted under a key derived from the
+// chain-head wrap key (the per-step EK / chain-head key provided by the
+// caller) so:
 //
-// 1. Extracted ciphertext is useless on a different device — K_DBRW binds
-//    decryption to hardware/environment per whitepaper §12.
+// 1. Extracted ciphertext is useless without the chain-head wrap key — the
+//    wrapping binds decryption to possession of that key.
 // 2. The SK lifetime is bounded: encrypted at receipt-build time for step n,
 //    used at receipt-build time for step n+1, then wiped (overwritten with
 //    NULL) when chain head advances.
@@ -51,20 +53,20 @@ use crate::util::deterministic_time::tick;
 const CERT_CHAIN_SK_AAD: &[u8] = b"DSM/cert-chain-sk-aead-v1\0";
 
 /// Derive the AEAD key for cert-chain SK encryption from the device's
-/// `K_DBRW`. Whitepaper §12 binds this key to hardware/environment.
-fn derive_chain_sk_aead_key(k_dbrw: &[u8; 32]) -> [u8; 32] {
+/// chain-head wrap key.
+fn derive_chain_sk_aead_key(chain_head_wrap_key: &[u8; 32]) -> [u8; 32] {
     let mut hasher = dsm::crypto::blake3::dsm_domain_hasher(
         dsm::common::domain_tags::TAG_DSM_CERT_CHAIN_SK_AEAD,
     );
-    hasher.update(k_dbrw);
+    hasher.update(chain_head_wrap_key);
     *hasher.finalize().as_bytes()
 }
 
 /// AEAD-encrypt a chain-head secret key.
 ///
 /// Output layout: `nonce(24) || ciphertext_with_tag`.
-pub fn encrypt_chain_sk(plain_sk: &[u8], k_dbrw: &[u8; 32]) -> Result<Vec<u8>> {
-    let key = derive_chain_sk_aead_key(k_dbrw);
+pub fn encrypt_chain_sk(plain_sk: &[u8], chain_head_wrap_key: &[u8; 32]) -> Result<Vec<u8>> {
+    let key = derive_chain_sk_aead_key(chain_head_wrap_key);
     let cipher = XChaCha20Poly1305::new_from_slice(&key)
         .map_err(|e| anyhow!("XChaCha20Poly1305 init: {e}"))?;
     let mut nonce_bytes = [0u8; 24];
@@ -86,15 +88,15 @@ pub fn encrypt_chain_sk(plain_sk: &[u8], k_dbrw: &[u8; 32]) -> Result<Vec<u8>> {
 }
 
 /// AEAD-decrypt a chain-head secret key. Returns `Err` if the ciphertext
-/// is tampered or if `k_dbrw` doesn't match what was used at encryption.
-pub fn decrypt_chain_sk(ciphertext: &[u8], k_dbrw: &[u8; 32]) -> Result<Vec<u8>> {
+/// is tampered or if `chain_head_wrap_key` doesn't match what was used at encryption.
+pub fn decrypt_chain_sk(ciphertext: &[u8], chain_head_wrap_key: &[u8; 32]) -> Result<Vec<u8>> {
     if ciphertext.len() < 24 + 16 {
         return Err(anyhow!(
             "cert-chain SK ciphertext too short ({} bytes, need >= 40)",
             ciphertext.len()
         ));
     }
-    let key = derive_chain_sk_aead_key(k_dbrw);
+    let key = derive_chain_sk_aead_key(chain_head_wrap_key);
     let cipher = XChaCha20Poly1305::new_from_slice(&key)
         .map_err(|e| anyhow!("XChaCha20Poly1305 init: {e}"))?;
     let (nonce_bytes, ct_with_tag) = ciphertext.split_at(24);
@@ -106,7 +108,9 @@ pub fn decrypt_chain_sk(ciphertext: &[u8], k_dbrw: &[u8; 32]) -> Result<Vec<u8>>
                 aad: CERT_CHAIN_SK_AAD,
             },
         )
-        .map_err(|_| anyhow!("cert-chain SK decryption failed (tamper or wrong K_DBRW)"))
+        .map_err(|_| {
+            anyhow!("cert-chain SK decryption failed (tamper or wrong chain-head wrap key)")
+        })
 }
 
 /// Which side of a bilateral relationship a chain head belongs to.
@@ -231,9 +235,9 @@ pub fn init_local_cert_chain_head_with_sk(
     relationship_key: &[u8; 32],
     chain_head_pubkey: &[u8],
     chain_head_secret_key: &[u8],
-    k_dbrw: &[u8; 32],
+    chain_head_wrap_key: &[u8; 32],
 ) -> Result<bool> {
-    let encrypted_sk = encrypt_chain_sk(chain_head_secret_key, k_dbrw)?;
+    let encrypted_sk = encrypt_chain_sk(chain_head_secret_key, chain_head_wrap_key)?;
     let binding = get_connection()?;
     let conn = binding.lock().unwrap_or_else(|p| p.into_inner());
     let now = tick() as i64;
@@ -252,15 +256,15 @@ pub fn init_local_cert_chain_head_with_sk(
 }
 
 /// Advance the local chain head to a new pubkey + secret key after a
-/// receipt is accepted. Encrypts the new SK under `K_DBRW`. Returns the
+/// receipt is accepted. Encrypts the new SK under `chain-head wrap key`. Returns the
 /// new step count, or `None` if no row exists for that relationship.
 pub fn advance_local_cert_chain_head_with_sk(
     relationship_key: &[u8; 32],
     new_pubkey: &[u8],
     new_secret_key: &[u8],
-    k_dbrw: &[u8; 32],
+    chain_head_wrap_key: &[u8; 32],
 ) -> Result<Option<u64>> {
-    let encrypted_sk = encrypt_chain_sk(new_secret_key, k_dbrw)?;
+    let encrypted_sk = encrypt_chain_sk(new_secret_key, chain_head_wrap_key)?;
     let binding = get_connection()?;
     let conn = binding.lock().unwrap_or_else(|p| p.into_inner());
     let now = tick() as i64;
@@ -293,7 +297,7 @@ pub fn advance_local_cert_chain_head_with_sk(
 /// rows always).
 pub fn load_local_chain_head_sk(
     relationship_key: &[u8; 32],
-    k_dbrw: &[u8; 32],
+    chain_head_wrap_key: &[u8; 32],
 ) -> Result<Option<Vec<u8>>> {
     let binding = get_connection()?;
     let conn = binding.lock().unwrap_or_else(|p| p.into_inner());
@@ -308,7 +312,7 @@ pub fn load_local_chain_head_sk(
         .flatten();
     match ct {
         Some(ciphertext) if !ciphertext.is_empty() => {
-            decrypt_chain_sk(&ciphertext, k_dbrw).map(Some)
+            decrypt_chain_sk(&ciphertext, chain_head_wrap_key).map(Some)
         }
         _ => Ok(None),
     }
@@ -613,11 +617,11 @@ mod tests {
     #[serial_test::serial]
     fn chain_sk_aead_round_trip() {
         let plain = vec![0xABu8; 64]; // SPHINCS+ secret keys are larger; test with 64 bytes
-        let k_dbrw = [0xCD; 32];
-        let ct = encrypt_chain_sk(&plain, &k_dbrw).unwrap();
+        let chain_head_wrap_key = [0xCD; 32];
+        let ct = encrypt_chain_sk(&plain, &chain_head_wrap_key).unwrap();
         // Nonce(24) + ciphertext(>=plain.len()) + tag(16) = at least 40 + plain.len()
         assert!(ct.len() >= 24 + plain.len() + 16);
-        let recovered = decrypt_chain_sk(&ct, &k_dbrw).unwrap();
+        let recovered = decrypt_chain_sk(&ct, &chain_head_wrap_key).unwrap();
         assert_eq!(recovered, plain);
     }
 
@@ -627,9 +631,9 @@ mod tests {
     #[serial_test::serial]
     fn chain_sk_aead_random_nonce_per_encryption() {
         let plain = vec![0x11u8; 32];
-        let k_dbrw = [0x22; 32];
-        let ct1 = encrypt_chain_sk(&plain, &k_dbrw).unwrap();
-        let ct2 = encrypt_chain_sk(&plain, &k_dbrw).unwrap();
+        let chain_head_wrap_key = [0x22; 32];
+        let ct1 = encrypt_chain_sk(&plain, &chain_head_wrap_key).unwrap();
+        let ct2 = encrypt_chain_sk(&plain, &chain_head_wrap_key).unwrap();
         assert_ne!(ct1, ct2, "fresh nonce per encryption");
     }
 
@@ -638,26 +642,26 @@ mod tests {
     #[serial_test::serial]
     fn chain_sk_aead_tamper_fails() {
         let plain = vec![0x33u8; 64];
-        let k_dbrw = [0x44; 32];
-        let mut ct = encrypt_chain_sk(&plain, &k_dbrw).unwrap();
+        let chain_head_wrap_key = [0x44; 32];
+        let mut ct = encrypt_chain_sk(&plain, &chain_head_wrap_key).unwrap();
         // Flip a bit in the ciphertext payload (after the 24-byte nonce).
         ct[30] ^= 0x01;
-        assert!(decrypt_chain_sk(&ct, &k_dbrw).is_err());
+        assert!(decrypt_chain_sk(&ct, &chain_head_wrap_key).is_err());
     }
 
-    /// Decrypting with a different K_DBRW (different device) fails.
+    /// Decrypting with a different chain-head wrap key (different device) fails.
     #[test]
     #[serial_test::serial]
-    fn chain_sk_aead_wrong_k_dbrw_fails() {
+    fn chain_sk_aead_wrong_chain_head_wrap_key_fails() {
         let plain = vec![0x55u8; 64];
-        let k_dbrw_a = [0x77; 32];
-        let k_dbrw_b = [0x88; 32];
-        let ct = encrypt_chain_sk(&plain, &k_dbrw_a).unwrap();
-        assert!(decrypt_chain_sk(&ct, &k_dbrw_b).is_err());
+        let chain_head_wrap_key_a = [0x77; 32];
+        let chain_head_wrap_key_b = [0x88; 32];
+        let ct = encrypt_chain_sk(&plain, &chain_head_wrap_key_a).unwrap();
+        assert!(decrypt_chain_sk(&ct, &chain_head_wrap_key_b).is_err());
     }
 
     /// Init-with-SK round-trip: encrypted SK survives the storage layer
-    /// and decrypts cleanly under the right K_DBRW.
+    /// and decrypts cleanly under the right chain-head wrap key.
     #[test]
     #[serial_test::serial]
     fn local_chain_head_sk_init_load_round_trip() {
@@ -665,17 +669,21 @@ mod tests {
         let r = rel(0xB1);
         let pk = vec![0xAA; 64];
         let sk = vec![0xBB; 96];
-        let k_dbrw = [0xCC; 32];
+        let chain_head_wrap_key = [0xCC; 32];
 
-        let inserted = init_local_cert_chain_head_with_sk(&r, &pk, &sk, &k_dbrw).unwrap();
+        let inserted =
+            init_local_cert_chain_head_with_sk(&r, &pk, &sk, &chain_head_wrap_key).unwrap();
         assert!(inserted);
 
-        let loaded = load_local_chain_head_sk(&r, &k_dbrw).unwrap();
+        let loaded = load_local_chain_head_sk(&r, &chain_head_wrap_key).unwrap();
         assert_eq!(loaded, Some(sk.clone()));
 
-        // Decrypting with wrong K_DBRW fails.
+        // Decrypting with wrong chain-head wrap key fails.
         let bad = load_local_chain_head_sk(&r, &[0xDD; 32]);
-        assert!(bad.is_err(), "wrong K_DBRW must fail decryption");
+        assert!(
+            bad.is_err(),
+            "wrong chain-head wrap key must fail decryption"
+        );
     }
 
     /// Advance-with-SK round-trip: after advancing, the new SK is what
@@ -689,15 +697,17 @@ mod tests {
         let sk0 = vec![0x11; 96];
         let pk1 = vec![0x20; 64];
         let sk1 = vec![0x22; 96];
-        let k_dbrw = [0x33; 32];
+        let chain_head_wrap_key = [0x33; 32];
 
-        init_local_cert_chain_head_with_sk(&r, &pk0, &sk0, &k_dbrw).unwrap();
-        let step1 = advance_local_cert_chain_head_with_sk(&r, &pk1, &sk1, &k_dbrw)
+        init_local_cert_chain_head_with_sk(&r, &pk0, &sk0, &chain_head_wrap_key).unwrap();
+        let step1 = advance_local_cert_chain_head_with_sk(&r, &pk1, &sk1, &chain_head_wrap_key)
             .unwrap()
             .unwrap();
         assert_eq!(step1, 1);
 
-        let loaded_sk = load_local_chain_head_sk(&r, &k_dbrw).unwrap().unwrap();
+        let loaded_sk = load_local_chain_head_sk(&r, &chain_head_wrap_key)
+            .unwrap()
+            .unwrap();
         assert_eq!(loaded_sk, sk1);
         // Old SK is not recoverable post-advance.
         assert_ne!(loaded_sk, sk0);
@@ -717,15 +727,19 @@ mod tests {
         let r = rel(0xB3);
         let pk = vec![0x44; 64];
         let sk = vec![0x55; 96];
-        let k_dbrw = [0x66; 32];
+        let chain_head_wrap_key = [0x66; 32];
 
-        init_local_cert_chain_head_with_sk(&r, &pk, &sk, &k_dbrw).unwrap();
-        assert!(load_local_chain_head_sk(&r, &k_dbrw).unwrap().is_some());
+        init_local_cert_chain_head_with_sk(&r, &pk, &sk, &chain_head_wrap_key).unwrap();
+        assert!(load_local_chain_head_sk(&r, &chain_head_wrap_key)
+            .unwrap()
+            .is_some());
 
         wipe_local_chain_head_sk(&r).unwrap();
 
         // SK is gone.
-        assert!(load_local_chain_head_sk(&r, &k_dbrw).unwrap().is_none());
+        assert!(load_local_chain_head_sk(&r, &chain_head_wrap_key)
+            .unwrap()
+            .is_none());
         // Pubkey is still there.
         let pk_after = load_cert_chain_head_pubkey(&r, CertChainSide::Local)
             .unwrap()

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/export.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/export.rs
@@ -45,7 +45,7 @@ pub fn export_state_blob() -> Result<Vec<u8>> {
         put_str(&mut g, &gen.genesis_id);
         put_str(&mut g, &gen.device_id);
         put_str(&mut g, &gen.mpc_proof);
-        put_str(&mut g, &gen.dbrw_binding);
+        put_str(&mut g, &gen.device_birth_binding);
         put_str(&mut g, &gen.merkle_root);
         put_u32(&mut g, gen.participant_count);
         put_str(&mut g, &gen.progress_marker);
@@ -369,7 +369,7 @@ mod tests {
             genesis_id: "gid-import".into(),
             device_id: "did-import".into(),
             mpc_proof: "mpc".into(),
-            dbrw_binding: "bind".into(),
+            device_birth_binding: "bind".into(),
             merkle_root: "root".into(),
             participant_count: 2,
             progress_marker: "P".into(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/genesis.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/genesis.rs
@@ -28,7 +28,7 @@ pub fn store_genesis_record_with_verification(record: &GenesisRecord) -> Result<
 
     conn.execute(
         "INSERT OR REPLACE INTO genesis_records(
-             genesis_id,device_id,mpc_proof,dbrw_binding,merkle_root,
+             genesis_id,device_id,mpc_proof,device_birth_binding,merkle_root,
              participant_count,chain_tip,publication_hash,storage_nodes,
              entropy_hash,protocol_version,hash_chain_proof,smt_proof,
              verification_step,created_at,genesis_nonce,genesis_profile)
@@ -37,7 +37,7 @@ pub fn store_genesis_record_with_verification(record: &GenesisRecord) -> Result<
             record.genesis_id,
             record.device_id,
             record.mpc_proof,
-            record.dbrw_binding,
+            record.device_birth_binding,
             record.merkle_root,
             record.participant_count as i32,
             record.progress_marker,
@@ -82,7 +82,7 @@ pub fn get_verified_genesis_record() -> Result<Option<GenesisRecord>> {
         String,
     )> = conn
         .query_row(
-            "SELECT genesis_id,device_id,mpc_proof,dbrw_binding,merkle_root,
+            "SELECT genesis_id,device_id,mpc_proof,device_birth_binding,merkle_root,
                     participant_count,chain_tip,publication_hash,storage_nodes,
                     entropy_hash,protocol_version,hash_chain_proof,smt_proof,
                     verification_step,genesis_nonce,genesis_profile
@@ -142,7 +142,7 @@ pub fn get_verified_genesis_record() -> Result<Option<GenesisRecord>> {
             genesis_id: id.clone(),
             device_id: dev,
             mpc_proof: mpc,
-            dbrw_binding: bind,
+            device_birth_binding: bind,
             merkle_root: root.clone(),
             participant_count: parts as u32,
             progress_marker: ts,
@@ -185,7 +185,7 @@ mod tests {
             genesis_id: "gen-test-001".into(),
             device_id: "dev-test-001".into(),
             mpc_proof: "mpc-proof-data".into(),
-            dbrw_binding: "binding-data".into(),
+            device_birth_binding: "binding-data".into(),
             merkle_root: "merkle-root-hash".into(),
             participant_count: 5,
             progress_marker: "PM".into(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/mod.rs
@@ -278,7 +278,7 @@ fn create_schema(conn: &Connection) -> Result<()> {
             genesis_id        TEXT PRIMARY KEY,
             device_id         TEXT NOT NULL,
             mpc_proof         TEXT NOT NULL,
-            dbrw_binding      TEXT NOT NULL,
+            device_birth_binding      TEXT NOT NULL,
             merkle_root       TEXT NOT NULL,
             participant_count INTEGER NOT NULL,
             chain_tip         TEXT NOT NULL,
@@ -686,7 +686,7 @@ fn create_schema(conn: &Connection) -> Result<()> {
         --
         -- chain_head_sk_encrypted is the ChaCha20-Poly1305 ciphertext of
         -- the corresponding SECRET key (for Local rows only; NULL for
-        -- Counterparty), encrypted under a key derived from K_DBRW so
+        -- Counterparty), encrypted under a key derived from the chain-head wrap key so
         -- extracted ciphertext cannot be used on a different device.
         -- Used at receipt creation time to sign cert_{n+1}; wiped after
         -- consumption when chain_head advances.
@@ -1331,7 +1331,7 @@ mod tests {
             genesis_id: "gen-123".into(),
             device_id: "dev-456".into(),
             mpc_proof: "mpc".into(),
-            dbrw_binding: "bind".into(),
+            device_birth_binding: "bind".into(),
             merkle_root: "root".into(),
             participant_count: 3,
             progress_marker: "P".into(),
@@ -1370,7 +1370,7 @@ mod tests {
             genesis_id: "gid".into(),
             device_id: "did".into(),
             mpc_proof: "mpc".into(),
-            dbrw_binding: "bind".into(),
+            device_birth_binding: "bind".into(),
             merkle_root: "root".into(),
             participant_count: 5,
             progress_marker: "Ps".into(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/transactions.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/transactions.rs
@@ -613,7 +613,6 @@ mod tests {
             balance_witness: BTreeMap::new(),
             entity_sig: None,
             counterparty_sig: None,
-            dbrw_summary_hash: None,
             island_attestation: None,
         };
         let failed_chain_tip = failed_chain_state.compute_chain_tip();
@@ -718,7 +717,6 @@ mod tests {
             balance_witness: BTreeMap::new(),
             entity_sig: None,
             counterparty_sig: None,
-            dbrw_summary_hash: None,
             island_attestation: None,
         };
         let failed_chain_tip = failed_chain_state.compute_chain_tip();

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/types.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/types.rs
@@ -25,7 +25,7 @@ pub struct GenesisRecord {
     pub genesis_id: String,
     pub device_id: String,
     pub mpc_proof: String,
-    pub dbrw_binding: String,
+    pub device_birth_binding: String,
     pub merkle_root: String,
     pub participant_count: u32,
     pub progress_marker: String,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/wallet_init.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/wallet_init.rs
@@ -218,7 +218,7 @@ mod tests {
             genesis_id: "gen-test-001".to_string(),
             device_id: "dev-test-001".to_string(),
             mpc_proof: "proof".to_string(),
-            dbrw_binding: "binding".to_string(),
+            device_birth_binding: "binding".to_string(),
             merkle_root: "root123".to_string(),
             participant_count: 1,
             progress_marker: "complete".to_string(),
@@ -293,7 +293,7 @@ mod tests {
         let conn = binding.lock().unwrap();
         conn.execute(
             "INSERT OR REPLACE INTO genesis_records (
-                genesis_id, device_id, mpc_proof, dbrw_binding, merkle_root,
+                genesis_id, device_id, mpc_proof, device_birth_binding, merkle_root,
                 participant_count, chain_tip, publication_hash, storage_nodes,
                 entropy_hash, protocol_version, created_at
             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
@@ -301,7 +301,7 @@ mod tests {
                 gen.genesis_id,
                 gen.device_id,
                 gen.mpc_proof,
-                gen.dbrw_binding,
+                gen.device_birth_binding,
                 gen.merkle_root,
                 gen.participant_count as i64,
                 gen.progress_marker,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/codecs.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/codecs.rs
@@ -329,7 +329,7 @@ pub fn encode_genesis_record_bytes(r: &GenesisRecord) -> Vec<u8> {
     put_str(&r.genesis_id, &mut out);
     put_str(&r.device_id, &mut out);
     put_str(&r.mpc_proof, &mut out);
-    put_str(&r.dbrw_binding, &mut out);
+    put_str(&r.device_birth_binding, &mut out);
     put_str(&r.merkle_root, &mut out);
     out.extend_from_slice(&r.participant_count.to_le_bytes());
     put_str(&r.progress_marker, &mut out);
@@ -555,7 +555,7 @@ mod tests {
             genesis_id: "gen-1".into(),
             device_id: "dev-1".into(),
             mpc_proof: "mpc".into(),
-            dbrw_binding: "bind".into(),
+            device_birth_binding: "bind".into(),
             merkle_root: "root".into(),
             participant_count: 3,
             progress_marker: "P".into(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/e2e_online_transfer.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/e2e_online_transfer.rs
@@ -48,7 +48,7 @@ fn persist_live_genesis_record(
         genesis_id: dsm_sdk::util::text_id::encode_base32_crockford(genesis_hash),
         device_id: dsm_sdk::util::text_id::encode_base32_crockford(genesis_device_id),
         mpc_proof: session_id.to_string(),
-        dbrw_binding: dsm_sdk::util::text_id::encode_base32_crockford(entropy),
+        device_birth_binding: dsm_sdk::util::text_id::encode_base32_crockford(entropy),
         merkle_root: dsm_sdk::util::text_id::encode_base32_crockford(&[0u8; 32]),
         participant_count: 3,
         progress_marker: "genesis".to_string(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/genesis_wallet_persistence.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/genesis_wallet_persistence.rs
@@ -24,7 +24,7 @@ fn genesis_persists_and_initializes_wallet_metadata() {
         genesis_id: genesis_b32.clone(),
         device_id: device_b32.clone(),
         mpc_proof: "mpc-proof".to_string(),
-        dbrw_binding: "binding".to_string(),
+        device_birth_binding: "binding".to_string(),
         merkle_root: genesis_b32.clone(),
         participant_count: 3,
         progress_marker: "t".to_string(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/tests/inbox_genesis_mismatch.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/tests/inbox_genesis_mismatch.rs
@@ -40,7 +40,7 @@ fn store_verified_genesis(device_id_b32: &str, genesis_bytes: [u8; 32]) {
         genesis_id: genesis_b32.clone(),
         device_id: device_id_b32.to_string(),
         mpc_proof: "mpc-proof".to_string(),
-        dbrw_binding: "binding".to_string(),
+        device_birth_binding: "binding".to_string(),
         merkle_root: genesis_b32.clone(),
         participant_count: 3,
         progress_marker: "t".to_string(),

--- a/dsm_client/frontend/package-lock.json
+++ b/dsm_client/frontend/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@babel/core": "7.29.7",
         "@bufbuild/protobuf": "^1.7.2",
-        "@bufbuild/protoc-gen-es": "2.12.0",
+        "@bufbuild/protoc-gen-es": "1.10.1",
         "@testing-library/jest-dom": "^6.1.4",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.1",
@@ -603,23 +603,23 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bufbuild/protoc-gen-es": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-2.12.0.tgz",
-      "integrity": "sha512-d9htF6jEkSwPbp9d/vSmZOBF7eeG18AvTMKmVg4I23afnrQOxL2w3WOXa9TaufMCyu24QakEUb4vux8apI5e7A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-1.10.1.tgz",
+      "integrity": "sha512-YADugbvibIdZSb0NGf5OF87IyKTuMvMFZ7vMHgm6pL1SCfDwJ/ZRianTdrPG9hq/gOipK+NwHmXBViyS3J7nxA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "2.12.0",
-        "@bufbuild/protoplugin": "2.12.0"
+        "@bufbuild/protobuf": "^1.10.1",
+        "@bufbuild/protoplugin": "1.10.1"
       },
       "bin": {
         "protoc-gen-es": "bin/protoc-gen-es"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "2.12.0"
+        "@bufbuild/protobuf": "1.10.1"
       },
       "peerDependenciesMeta": {
         "@bufbuild/protobuf": {
@@ -627,36 +627,22 @@
         }
       }
     },
-    "node_modules/@bufbuild/protoc-gen-es/node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
-    },
     "node_modules/@bufbuild/protoplugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-2.12.0.tgz",
-      "integrity": "sha512-ORlDITp8AFUXzIhLRoMCG+ud+D3MPKWb5HQXBoskMMnjeyEjE1H1qLonVNPyOr8lkx3xSfYUo8a0dvOZJVAzow==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-1.10.1.tgz",
+      "integrity": "sha512-LaSbfwabAFIvbVnbn8jWwElRoffCIxhVraO8arliVwWupWezHLXgqPHEYLXZY/SsAR+/YsFBQJa8tAGtNPJyaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "2.12.0",
-        "@typescript/vfs": "^1.6.2",
-        "typescript": "5.4.5"
+        "@bufbuild/protobuf": "1.10.1",
+        "@typescript/vfs": "^1.4.0",
+        "typescript": "4.5.2"
       }
     },
-    "node_modules/@bufbuild/protoplugin/node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
-    },
     "node_modules/@bufbuild/protoplugin/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -664,7 +650,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/dsm_client/frontend/package.json
+++ b/dsm_client/frontend/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@babel/core": "7.29.7",
     "@bufbuild/protobuf": "^1.7.2",
-    "@bufbuild/protoc-gen-es": "2.12.0",
+    "@bufbuild/protoc-gen-es": "1.10.1",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.1",

--- a/dsm_client/frontend/src/components/AppContent.tsx
+++ b/dsm_client/frontend/src/components/AppContent.tsx
@@ -274,8 +274,8 @@ export default function AppContent({
           <StatusText
             lines={[
               'SECURING YOUR DEVICE',
-              'SILICON FINGERPRINT ENROLLMENT',
-              'DBRW SALT INITIALIZATION',
+              'DEVICE KEY ENROLLMENT',
+              'DEVICE KEY INITIALIZATION',
             ]}
             style={securingStatusTextStyle}
           />

--- a/dsm_client/frontend/src/components/__tests__/AppContent.securingDevice.test.tsx
+++ b/dsm_client/frontend/src/components/__tests__/AppContent.securingDevice.test.tsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 import AppContent from '../AppContent';
 
 describe('AppContent securing device state', () => {
-  test('shows the leave-screen warning while DBRW securing is in progress', () => {
+  test('shows the leave-screen warning while device securing is in progress', () => {
     render(
       <AppContent
         appState="securing_device"
@@ -31,7 +31,7 @@ describe('AppContent securing device state', () => {
       />,
     );
 
-    expect(screen.getByText(/DBRW SALT INITIALIZATION/i)).toBeTruthy();
+    expect(screen.getByText(/DEVICE KEY INITIALIZATION/i)).toBeTruthy();
     expect(screen.getByText(/THIS ONLY HAPPENS ONCE/i)).toBeTruthy();
     expect(screen.getByText(/DO NOT LEAVE THE SCREEN UNTIL FINISHED/i)).toBeTruthy();
     expect(screen.queryByText(/PLEASE WAIT/i)).toBeNull();

--- a/dsm_client/frontend/src/hooks/useGenesisFlow.ts
+++ b/dsm_client/frontend/src/hooks/useGenesisFlow.ts
@@ -27,15 +27,15 @@ export function useGenesisFlow({
   onMnemonicGenerated,
 }: Args) {
   const genesisInFlight = useRef(false);
-  const interruptedMessage = 'Device securing was interrupted. Do not leave the screen until finished. Initialization was wiped and must be started again so DBRW is not corrupted.';
+  const interruptedMessage = 'Device securing was interrupted. Do not leave the screen until finished. Initialization was wiped and must be started again so the device key material is not corrupted.';
 
-  // Abort DBRW salt initialisation if the user navigates away during securing.
+  // Abort device-key initialisation if the user navigates away during securing.
   // If the securing is interrupted the device state is corrupt — wipe and restart.
   useEffect(() => {
     if (appState !== 'securing_device') return;
     const onVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
-        logger.warn('FRONTEND: User left screen during DBRW securing - aborting and wiping');
+        logger.warn('FRONTEND: User left screen during device securing - aborting and wiping');
         genesisInFlight.current = false;
         setSecuringProgress(0);
         setError(interruptedMessage);
@@ -55,7 +55,7 @@ export function useGenesisFlow({
     }
   }, [appState]);
 
-  // Listen for silicon fingerprint enrollment progress events from Kotlin
+  // Listen for device-key enrollment progress events from Kotlin
   useEffect(() => {
     const unsub = addDsmEventListener((evt) => {
       if (!genesisInFlight.current) {
@@ -65,15 +65,15 @@ export function useGenesisFlow({
         return;
       }
       if (evt.topic === 'genesis.securing-device') {
-        logger.info('FRONTEND: Silicon fingerprint enrollment started');
+        logger.info('FRONTEND: Device-key enrollment started');
         setSecuringProgress(0);
         setAppState('securing_device');
       } else if (evt.topic === 'genesis.securing-device-progress') {
         const pct = evt.payload.length > 0 ? (evt.payload[0] & 0xFF) : 0;
-        logger.info(`FRONTEND: Silicon fingerprint progress: ${pct}%`);
+        logger.info(`FRONTEND: Device-key enrollment progress: ${pct}%`);
         setSecuringProgress(pct);
       } else if (evt.topic === 'genesis.securing-device-complete') {
-        logger.info('FRONTEND: Silicon fingerprint enrollment complete');
+        logger.info('FRONTEND: Device-key enrollment complete');
         setSecuringProgress(100);
       } else if (evt.topic === 'genesis.securing-device-aborted') {
         logger.warn('FRONTEND: Device securing aborted after the screen was left');

--- a/dsm_client/frontend/src/proto/dsm_app_pb.ts
+++ b/dsm_client/frontend/src/proto/dsm_app_pb.ts
@@ -19938,8 +19938,8 @@ export class BalanceWitnessEntryProto extends Message<BalanceWitnessEntryProto> 
 /**
  * Faithful wire codec for `dsm::types::device_state::RelationshipChainState`. Round-trips
  * EVERY field that feeds `compute_chain_tip()` (rel_key, embedded_parent, counterparty_devid,
- * canonical operation bytes, entropy, optional encapsulated_entropy, optional
- * dbrw_summary_hash, sorted balance witness) plus the two optional signatures (NOT hashed —
+ * canonical operation bytes, entropy, optional encapsulated_entropy, sorted balance
+ * witness) plus the two optional signatures (NOT hashed —
  * they sign the digest). proto3 `optional` distinguishes None from an empty Some, which the
  * chain-tip hash treats differently; a faithful round-trip is REQUIRED so a decoder can
  * recompute the tip and assert equality.
@@ -19980,11 +19980,6 @@ export class RelationshipChainStateProto extends Message<RelationshipChainStateP
    * @generated from field: optional bytes encapsulated_entropy = 6;
    */
   encapsulatedEntropy?: Uint8Array;
-
-  /**
-   * @generated from field: optional bytes dbrw_summary_hash = 7;
-   */
-  dbrwSummaryHash?: Uint8Array;
 
   /**
    * @generated from field: repeated dsm.BalanceWitnessEntryProto balance_witness = 8;
@@ -20028,7 +20023,6 @@ export class RelationshipChainStateProto extends Message<RelationshipChainStateP
     { no: 4, name: "operation", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
     { no: 5, name: "entropy", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
     { no: 6, name: "encapsulated_entropy", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
-    { no: 7, name: "dbrw_summary_hash", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
     { no: 8, name: "balance_witness", kind: "message", T: BalanceWitnessEntryProto, repeated: true },
     { no: 9, name: "entity_sig", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
     { no: 10, name: "counterparty_sig", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },

--- a/dsm_client/frontend/src/proto/dsm_app_pb.ts
+++ b/dsm_client/frontend/src/proto/dsm_app_pb.ts
@@ -19938,11 +19938,10 @@ export class BalanceWitnessEntryProto extends Message<BalanceWitnessEntryProto> 
 /**
  * Faithful wire codec for `dsm::types::device_state::RelationshipChainState`. Round-trips
  * EVERY field that feeds `compute_chain_tip()` (rel_key, embedded_parent, counterparty_devid,
- * canonical operation bytes, entropy, optional encapsulated_entropy, sorted balance
- * witness) plus the two optional signatures (NOT hashed —
- * they sign the digest). proto3 `optional` distinguishes None from an empty Some, which the
- * chain-tip hash treats differently; a faithful round-trip is REQUIRED so a decoder can
- * recompute the tip and assert equality.
+ * canonical operation bytes, entropy, optional encapsulated_entropy, sorted balance witness)
+ * plus the two optional signatures (NOT hashed — they sign the digest). proto3 `optional`
+ * distinguishes None from an empty Some, which the chain-tip hash treats differently; a
+ * faithful round-trip is REQUIRED so a decoder can recompute the tip and assert equality.
  *
  * @generated from message dsm.RelationshipChainStateProto
  */
@@ -27424,7 +27423,7 @@ export class RegistryV3 extends Message<RegistryV3> {
  */
 export class ApplicantV3 extends Message<ApplicantV3> {
   /**
-   * C-DBRW hardware binding
+   * device-birth hardware binding
    *
    * @generated from field: bytes hw_bind = 1;
    */

--- a/dsm_client/frontend/src/proto/dsm_app_pb.ts
+++ b/dsm_client/frontend/src/proto/dsm_app_pb.ts
@@ -12406,8 +12406,6 @@ export class BilateralPrepareResponse extends Message<BilateralPrepareResponse> 
    * CRITICAL: This allows the sender to update their contact's signing key
    * when receiving the accept response, enabling session registration for future transfers.
    *
-   * Field 7 reserved (removed: old DBRW warning)
-   *
    * @generated from field: bytes responder_signing_public_key = 6;
    */
   responderSigningPublicKey = new Uint8Array(0);
@@ -13616,8 +13614,6 @@ export class BilateralEventNotification extends Message<BilateralEventNotificati
   senderBleAddress?: string;
 
   /**
-   * Field 11 reserved (removed: old DBRW warning)
-   *
    * @generated from field: optional dsm.BilateralFailureReason failure_reason = 10;
    */
   failureReason?: BilateralFailureReason;
@@ -17164,8 +17160,6 @@ export class UniversalOp extends Message<UniversalOp> {
     case: "query";
   } | {
     /**
-     * Field numbers 20, 21, 30 reserved (removed: old DBRW ops)
-     *
      * @generated from field: dsm.RecoveryCapsuleDecryptRequest recovery_capsule_decrypt = 22;
      */
     value: RecoveryCapsuleDecryptRequest;
@@ -17710,8 +17704,6 @@ export class Envelope extends Message<Envelope> {
     case: "batchEnvelope";
   } | {
     /**
-     * Field numbers 13, 14, 33 reserved (removed: old DBRW responses)
-     *
      * @generated from field: dsm.RecoveryCapsuleDecryptResponse recovery_capsule_decrypt_response = 15;
      */
     value: RecoveryCapsuleDecryptResponse;
@@ -18174,8 +18166,6 @@ export class Envelope extends Message<Envelope> {
     case: "storageNodeManageResponse";
   } | {
     /**
-     * Slot 90 reserved (was DbrwStatusResponse) — see message-level reserved below.
-     *
      * @generated from field: dsm.BitcoinWithdrawalPlanRequest bitcoin_withdrawal_plan_request = 91;
      */
     value: BitcoinWithdrawalPlanRequest;

--- a/lean4/DSMCertChain.lean
+++ b/lean4/DSMCertChain.lean
@@ -48,7 +48,7 @@
     implementation `k_step` is derived from a fresh per-step Kyber-768
     encapsulation between the bilateral parties:
       coins  = BLAKE3-256("DSM/kyber-coins\0" || h_n || C_pre
-                          || DevID_sender || K_DBRW)
+                          || DevID_sender)
       (ct, ss) = KyberEncDet(recipient_kyber_pk, coins)
       k_step = BLAKE3-256("DSM/kyber-ss\0" || ss)
     The recipient decapsulates `ct` with their Kyber sk to recover the

--- a/lean4/DSMOfflineFinality.lean
+++ b/lean4/DSMOfflineFinality.lean
@@ -27,8 +27,7 @@
     The receipt-signing predicate this module relies on (every accepted
     commit is signed by valid SPHINCS+ keys) is implemented in the
     codebase via the per-step ephemeral key chain:
-      EK_{n+1} = SPHINCS+.KeyGen(HKDF("DSM/ek\0" || h_n || C_pre || k_step
-                                       || K_DBRW))
+      EK_{n+1} = SPHINCS+.KeyGen(HKDF("DSM/ek\0" || h_n || C_pre || k_step))
       cert_{n+1} = Sign_{SK_n}(BLAKE3("DSM/ek-cert\0" || EK_pk_{n+1} || h_n))
     Each receipt body is signed by EK_{n+1}; the cert chain anchors back
     to AK_pk via prior step keys (AK at step 0).

--- a/proto/dsm_app.proto
+++ b/proto/dsm_app.proto
@@ -1607,11 +1607,6 @@ message SystemGenesisRequest {
   string locale = 1;
   string network_id = 2;
   bytes device_entropy = 3 [(dsm_fixed_len)=32];
-  // Fields 4,5,6 reserved: legacy C-DBRW silicon-binding inputs
-  // (cdbrw_hw_entropy, cdbrw_env_fingerprint, cdbrw_salt). Genesis v2 is
-  // mnemonic-rooted with no silicon binding — these MUST NOT be reused.
-  reserved 4, 5, 6;
-  reserved "cdbrw_hw_entropy", "cdbrw_env_fingerprint";
 }
 message SystemGenesisResponse { Hash32 genesis_hash = 1; bytes public_key = 2 [(dsm_max_len)=512]; }
 
@@ -1753,7 +1748,6 @@ message BilateralPrepareResponse {
   // CRITICAL: This allows the sender to update their contact's signing key
   // when receiving the accept response, enabling session registration for future transfers.
   bytes  responder_signing_public_key = 6 [(dsm_fixed_len)=64];
-  // Field 7 reserved (removed: old DBRW warning)
 }
 
 enum RelationshipSendCheckState {
@@ -2020,7 +2014,6 @@ message BilateralEventNotification {
   string             message                = 8; // optional details
   optional string    sender_ble_address     = 9;  // BLE MAC address for response routing
   optional BilateralFailureReason failure_reason = 10;
-  // Field 11 reserved (removed: old DBRW warning)
 }
 
 // =========================== Bluetooth Transport ====================
@@ -2156,11 +2149,6 @@ message BootstrapMeasurementReport {
   bytes device_id = 2 [(dsm_fixed_len)=32];
   bytes genesis_hash = 3 [(dsm_fixed_len)=32];
   uint32 progress_percent = 4;
-  // Fields 5,6,7 reserved: legacy C-DBRW silicon-binding inputs
-  // (cdbrw_hw_entropy, cdbrw_env_fingerprint, cdbrw_salt). Genesis v2 is
-  // mnemonic-rooted with no silicon binding — these MUST NOT be reused.
-  reserved 5, 6, 7;
-  reserved "cdbrw_hw_entropy", "cdbrw_env_fingerprint";
   TrustLevel trust_level = 8;
   string error_message = 9;
 }
@@ -2449,7 +2437,6 @@ message UniversalOp {
     AttestedAction          attested_action        = 15;
     VaultOp                 vault                  = 16;
     QueryOp                 query                  = 17;
-    // Field numbers 20, 21, 30 reserved (removed: old DBRW ops)
     RecoveryCapsuleDecryptRequest recovery_capsule_decrypt = 22;
     RecoveryTombstoneRequest     recovery_tombstone       = 23;
     RecoverySuccessionRequest    recovery_succession      = 24;
@@ -2509,7 +2496,6 @@ message Envelope {
     UniversalRx  universal_rx    = 11;
     BatchEnvelope batch_envelope = 12;
 
-    // Field numbers 13, 14, 33 reserved (removed: old DBRW responses)
     RecoveryCapsuleDecryptResponse   recovery_capsule_decrypt_response = 15;
     RecoveryTombstoneResponse        recovery_tombstone_response       = 16;
     RecoverySuccessionResponse       recovery_succession_response      = 17;
@@ -2613,7 +2599,6 @@ message Envelope {
     // Storage node health & management
     StorageNodeStatsResponse          storage_node_stats_response      = 88;
     StorageNodeManageResponse         storage_node_manage_response     = 89;
-    // Slot 90 reserved (was DbrwStatusResponse) — see message-level reserved below.
     BitcoinWithdrawalPlanRequest      bitcoin_withdrawal_plan_request  = 91;
     BitcoinWithdrawalPlanResponse     bitcoin_withdrawal_plan_response = 92;
     BitcoinWithdrawalExecuteRequest   bitcoin_withdrawal_execute_request = 93;
@@ -2630,9 +2615,6 @@ message Envelope {
     BootstrapMeasurementReport        bootstrap_measurement_report     = 101;
     BootstrapFinalizeResponse         bootstrap_finalize_response      = 102;
 
-    // Slots 103-106 reserved (were C-DBRW Protocol 6.2 responses) — see
-    // message-level reserved below.
-
     // Phase B.7 (issue #278) — pure-rendering DeviceTreeViewer payload.
     DeviceTreeSnapshotResponse        device_tree_snapshot_response    = 107;
 
@@ -2641,10 +2623,6 @@ message Envelope {
     AddDeviceAdmissionRequestV1       device_admission_request         = 108;
     AddDeviceAdmissionV1              device_admission                 = 109;
   }
-  // Legacy C-DBRW payload slots removed (Genesis v2 has no C-DBRW): slot 90
-  // was DbrwStatusResponse; 103-106 were the Protocol 6.2 responses
-  // (CdbrwTrustSnapshot/Respond/Verify/Enroll). MUST NOT be reused.
-  reserved 90, 103, 104, 105, 106;
 }
 
 // ===================== SDK INIT / STATUS =====================
@@ -2653,10 +2631,6 @@ message Envelope {
 message InitFailed {
   enum Reason {
     REASON_UNSPECIFIED = 0;
-    // Value 1 reserved (was CDBRW_NOT_READY) — Genesis v2 has no C-DBRW
-    // readiness gate; init no longer fails for a missing device secret.
-    reserved 1;
-    reserved "CDBRW_NOT_READY";
     PLATFORM_CONTEXT_MISSING = 2;
     INVALID_INPUT = 3;
   }
@@ -2856,10 +2830,6 @@ message RelationshipChainStateProto {
   bytes  operation           = 4 [(dsm_max_len)=1048576]; // Operation::to_bytes (canonical)
   bytes  entropy             = 5 [(dsm_max_len)=65535];
   optional bytes encapsulated_entropy = 6 [(dsm_max_len)=65535]; // None vs Some(empty) preserved
-  // Field 7 reserved (removed: old C-DBRW dbrw_summary_hash chain-tip component;
-  // GenesisV2 has no C-DBRW). MUST NOT be reused.
-  reserved 7;
-  reserved "dbrw_summary_hash";
   repeated BalanceWitnessEntryProto balance_witness = 8;
   optional bytes entity_sig       = 9  [(dsm_max_len)=65535]; // SPX256f
   optional bytes counterparty_sig = 10 [(dsm_max_len)=65535]; // SPX256f
@@ -3753,10 +3723,6 @@ message InitializeSdkOp {}
 message InitializeIdentityContextOp {
   bytes device_id    = 1 [(dsm_fixed_len)=32];
   bytes genesis_hash = 2 [(dsm_fixed_len)=32];
-  // Field 3 reserved: legacy C-DBRW binding_key — removed (Genesis v2 has no
-  // persisted device secret). MUST NOT be reused.
-  reserved 3;
-  reserved "binding_key";
 }
 
 // Restore canonical identity context. Under Genesis v2 the device key re-derives
@@ -3765,10 +3731,6 @@ message InitializeIdentityContextOp {
 message RestoreIdentityContextOp {
   bytes device_id             = 1 [(dsm_fixed_len)=32];
   bytes genesis_hash          = 2 [(dsm_fixed_len)=32];
-  // Fields 3,4,5 reserved: legacy C-DBRW silicon inputs (cdbrw_hw_entropy,
-  // cdbrw_env_fingerprint, cdbrw_salt). MUST NOT be reused.
-  reserved 3, 4, 5;
-  reserved "cdbrw_hw_entropy", "cdbrw_env_fingerprint";
 }
 
 // Canonical startup/bootstrap request shared by native platforms.

--- a/proto/dsm_app.proto
+++ b/proto/dsm_app.proto
@@ -2845,11 +2845,10 @@ message BalanceWitnessEntryProto {
 
 // Faithful wire codec for `dsm::types::device_state::RelationshipChainState`. Round-trips
 // EVERY field that feeds `compute_chain_tip()` (rel_key, embedded_parent, counterparty_devid,
-// canonical operation bytes, entropy, optional encapsulated_entropy, optional
-// dbrw_summary_hash, sorted balance witness) plus the two optional signatures (NOT hashed —
-// they sign the digest). proto3 `optional` distinguishes None from an empty Some, which the
-// chain-tip hash treats differently; a faithful round-trip is REQUIRED so a decoder can
-// recompute the tip and assert equality.
+// canonical operation bytes, entropy, optional encapsulated_entropy, sorted balance witness)
+// plus the two optional signatures (NOT hashed — they sign the digest). proto3 `optional`
+// distinguishes None from an empty Some, which the chain-tip hash treats differently; a
+// faithful round-trip is REQUIRED so a decoder can recompute the tip and assert equality.
 message RelationshipChainStateProto {
   bytes  rel_key             = 1 [(dsm_fixed_len)=32];
   bytes  embedded_parent     = 2 [(dsm_fixed_len)=32];
@@ -2857,7 +2856,10 @@ message RelationshipChainStateProto {
   bytes  operation           = 4 [(dsm_max_len)=1048576]; // Operation::to_bytes (canonical)
   bytes  entropy             = 5 [(dsm_max_len)=65535];
   optional bytes encapsulated_entropy = 6 [(dsm_max_len)=65535]; // None vs Some(empty) preserved
-  optional bytes dbrw_summary_hash    = 7 [(dsm_fixed_len)=32];
+  // Field 7 reserved (removed: old C-DBRW dbrw_summary_hash chain-tip component;
+  // GenesisV2 has no C-DBRW). MUST NOT be reused.
+  reserved 7;
+  reserved "dbrw_summary_hash";
   repeated BalanceWitnessEntryProto balance_witness = 8;
   optional bytes entity_sig       = 9  [(dsm_max_len)=65535]; // SPX256f
   optional bytes counterparty_sig = 10 [(dsm_max_len)=65535]; // SPX256f
@@ -3970,7 +3972,7 @@ message RegistryV3 {
 // Applicant pack for joining the active storage-node set.
 // Domain: "DSM/apply\0"
 message ApplicantV3 {
-  bytes hw_bind   = 1; // C-DBRW hardware binding
+  bytes hw_bind   = 1; // device-birth hardware binding
   bytes env_fp    = 2; // environment fingerprint
   uint64 capacity = 3; // declared capacity C
   bytes stake_dlv = 4; // StakeDLV address

--- a/tla/DSM_Tripwire.tla
+++ b/tla/DSM_Tripwire.tla
@@ -27,7 +27,7 @@ Vars == <<deviceRoots, smtState, ledger>>
 \*
 \*   (1) Each receipt's sig_a / sig_b is produced by a freshly-derived
 \*       EK_{n+1} = SPHINCS+.KeyGen(HKDF("DSM/ek\0" || h_n || C_pre ||
-\*                                       k_step || K_DBRW)).
+\*                                       k_step)).  \* keyed under s_master (GenesisV2: no device-binding key in the EK preimage)
 \*       k_step is recovered via Kyber-768 deterministic encapsulation
 \*       against the recipient's contact-bound Kyber pubkey
 \*       (no stubs, recipient_kyber_pk mandatory).
@@ -36,7 +36,7 @@ Vars == <<deviceRoots, smtState, ledger>>
 \*       "DSM/ek-cert\0" || EK_pk_{n+1} || h_n)) chaining it back to
 \*       the device's attested AK_pk via prior step keys. Per-relationship
 \*       chain heads + encrypted SK material live in cert_chain_heads
-\*       (XChaCha20-Poly1305 with K_DBRW-derived AEAD key).
+\*       (XChaCha20-Poly1305 with a chain-head-wrap-key-derived AEAD key).
 \*
 \*   (3) Bilateral both-side stamping. In every accepted bilateral
 \*       transition the sender stamps {ek_pk_a, ek_cert_a, kyber_ct_a,


### PR DESCRIPTION
## What

PR #514 removed the C-DBRW device-binding architecture but left **DBRW-named remnants in executable code and the canonical hash preimage**. With no production state / deployed receipts / persisted canonical objects, this **corrects the GenesisV2 canonical format** and scrubs the DBRW name from all executable code.

## Canonical-format correction (intentional hash change — no production data)
- **Delete `dbrw_summary_hash` entirely** — from `State`/`RelationshipChainState`, `DeviceState::advance`, the BCR codec, recovery/state-machine plumbing, and from **`DeviceState::compute_chain_tip()`** (the canonical chain-tip preimage, where it contributed an always-`None` `0u8`). Proto field **#7 reserved** (number + name). No live field, no placeholder, **no DBRW ghost byte**.

## Renames (cosmetic — verified no hashed `"dbrw"` string anywhere)
| from | to |
|---|---|
| `k_dbrw` | `chain_head_wrap_key` (cert-chain SK-at-rest wrap key) |
| `dbrw_binding` | `device_birth_binding` (GenesisRecord field) |
| `dbrw_binding_key` | `binding_key` (bitcoin-account encryption) |
| `DBRW_NOT_READY` | `ROUTER_NOT_READY` (status-code label) |
| `"C-DBRW … cert chain required"` etc. | neutral, with consumer assertions updated |

## Deletions
- `TAG_DBRW` (`"DSM/dbrw"`) domain tag + its test-registry entry — proven dead (test-only, no live derivation, no KAT).

## Docs / spec / frontend
- Rewrote stale "K_DBRW / §12 silicon binding / anti-cloning" comments to GenesisV2 reality (mnemonic-rooted; EK keyed under `Smaster`; chain-head wrap key); removed references to deleted modules.
- Formal models (Lean `DSMCertChain`/`DSMOfflineFinality`, TLA `DSM_Tripwire`) drop `K_DBRW` from the EK/coins preimage.
- Frontend: neutralized DBRW / silicon-fingerprint securing-UI strings.

## Result
No DBRW in executable code, runtime strings, names, enum variants, error codes, or canonical hash preimages. Remaining DBRW appears **only** in reserved-proto comments and removal/transition notes. Repo-wide match count **1955 → 193** (comments/notes only).

## Validation
- `dsm` core: **1573 passed / 0 failed**; `dsm_sdk` lib: **1424 passed / 0 failed**; rustfmt clean.
- The canonical chain-tip change passes (DSM tests compute hashes dynamically — no hardcoded-KAT churn).
- Frontend not built locally (no `node_modules`); CI Frontend job will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
