### PR TITLE
feat(offline-bearer): Phase H2 (Android side) — LocalPicoUsb USB-OTG transport + JNI up-call

### DIFF
--- a/crates/dsm-android-anchor/Cargo.lock
+++ b/crates/dsm-android-anchor/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -497,6 +497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +609,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-oid"
@@ -817,7 +833,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -978,7 +994,7 @@ dependencies = [
  "serde",
  "sha2 0.11.0",
  "subtle",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1028,6 +1044,7 @@ dependencies = [
  "dsm-anchor-verifier",
  "dsm_sdk",
  "futures",
+ "jni",
  "log",
 ]
 
@@ -1067,6 +1084,7 @@ dependencies = [
  "glob",
  "hmac 0.13.0",
  "hostname",
+ "jni",
  "lazy_static",
  "libc",
  "log",
@@ -1090,9 +1108,10 @@ dependencies = [
  "serde_json",
  "subtle",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "toml_edit",
@@ -1988,6 +2007,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,7 +2256,7 @@ dependencies = [
  "metrics-util",
  "quanta",
  "rustls",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2827,7 +2890,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2848,7 +2911,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2997,7 +3060,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3098,7 +3161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3214,6 +3277,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3556,11 +3628,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3672,6 +3764,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4020,6 +4124,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,6 +4258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,6 +4285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -4189,6 +4321,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4226,6 +4373,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4238,6 +4391,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4247,6 +4406,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4274,6 +4439,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4283,6 +4454,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4298,6 +4475,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4307,6 +4490,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4381,7 +4570,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/crates/dsm-android-anchor/Cargo.toml
+++ b/crates/dsm-android-anchor/Cargo.toml
@@ -23,6 +23,15 @@ dsm-anchor-verifier = { path = "../dsm-anchor-verifier" }
 dsm-anchor-core = { path = "../dsm-anchor-core" }
 log = "0.4"
 
+# On Android, the USB bridge's LocalPicoTransport does a JNI up-call to Kotlin's opaque
+# picoUsbTransceive (mirrors queue_follow_up_chunks' with_env pattern), so it needs dsm_sdk's `jni`
+# feature + the jni crate. Host builds/tests don't compile this path (it's target_os="android").
+# Match the app's on-device feature set: jni (with_env up-call) + bluetooth (the tropic_relay/BLE
+# code paths). Enabling jni WITHOUT bluetooth surfaces dsm_sdk's own conditional warnings-as-errors.
+[target.'cfg(target_os = "android")'.dependencies]
+dsm_sdk = { path = "../../dsm_client/deterministic_state_machine/dsm_sdk", features = ["jni", "bluetooth"] }
+jni = "0.21"
+
 [dev-dependencies]
 # Poll the boxed PicoFuture in host tests without a full async runtime.
 futures = { version = "0.3", default-features = false, features = ["executor"] }

--- a/crates/dsm-android-anchor/src/usb_pico.rs
+++ b/crates/dsm-android-anchor/src/usb_pico.rs
@@ -81,12 +81,45 @@ impl LocalPicoTransport for UsbPicoTransport {
     }
 }
 
-// Android JNI wiring (bench step): the on-device constructor builds `UsbPicoTransport::new(usb)`
-// where `usb` is the up-call to Kotlin's opaque `picoUsbTransceive`, using the same
-// `dsm_sdk::jni::jni_common::with_env` pattern as `queue_follow_up_chunks`. It is written alongside
-// the Kotlin `LocalPicoUsb` transport in H2's bench session (it needs the Kotlin symbol to target),
-// so it is intentionally absent here — this module ships the framing + fail-closed core, which is
-// host-testable and cross-compiles for Android on its own.
+/// The on-device constructor: `usb` up-calls Kotlin's opaque `Unified.picoUsbTransceive([B)[B`,
+/// which does the actual USB-OTG round-trip to the Pico. Mirrors `queue_follow_up_chunks`'
+/// `with_env` + re-derive-mutable-JNIEnv pattern. Any JNI/USB failure -> `Err` (fail-closed). A
+/// null return from Kotlin (no device / permission / timeout) is treated as a USB failure. This
+/// path is Android-only; host builds/tests use `UsbPicoTransport::new` with a mock.
+#[cfg(target_os = "android")]
+pub fn android_usb_pico_transport() -> UsbPicoTransport {
+    use jni::objects::{JByteArray, JObject, JValue};
+    UsbPicoTransport::new(Arc::new(|frame: Vec<u8>| -> Result<Vec<u8>, DsmError> {
+        dsm_sdk::jni::jni_common::with_env(|env| -> Result<Vec<u8>, String> {
+            // Re-derive a mutable JNIEnv from the raw handle (same as queue_follow_up_chunks).
+            let mut env = unsafe { jni::JNIEnv::from_raw(env.get_raw() as *mut _) }
+                .map_err(|e| format!("clone JNIEnv: {e}"))?;
+            let cls = dsm_sdk::jni::jni_common::find_class_with_app_loader(
+                &mut env,
+                "com/dsm/wallet/bridge/Unified",
+            )?;
+            let arr = env
+                .byte_array_from_slice(&frame)
+                .map_err(|e| format!("byte_array_from_slice: {e}"))?;
+            let arr_obj = JObject::from(arr);
+            let res = env
+                .call_static_method(
+                    &cls,
+                    "picoUsbTransceive",
+                    "([B)[B",
+                    &[JValue::Object(&arr_obj)],
+                )
+                .map_err(|e| format!("call picoUsbTransceive: {e}"))?;
+            let obj = res.l().map_err(|e| format!("result not object: {e}"))?;
+            if obj.is_null() {
+                return Err("picoUsbTransceive returned null (USB failure)".to_string());
+            }
+            env.convert_byte_array(JByteArray::from(obj))
+                .map_err(|e| format!("convert_byte_array: {e}"))
+        })
+        .map_err(|e| DsmError::invalid_operation(format!("usb-pico JNI up-call: {e}")))
+    }))
+}
 
 #[cfg(test)]
 mod tests {

--- a/dsm_client/android/app/src/main/AndroidManifest.xml
+++ b/dsm_client/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,10 @@
         tools:targetApi="s"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE"/>
 
+    <!-- USB host (OTG) for the sender phone -> Pico raw-SPI passthrough (offline-bearer H2).
+         Optional so non-OTG devices still install; the Pico link is only needed to hold an anchor. -->
+    <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
+
     <!-- Location permissions for BLE scanning on pre-Android 12 devices only -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30"/>
     <!-- FINE_LOCATION removed: BLE scanning uses neverForLocation on Android 12+ -->

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
@@ -33,7 +33,10 @@ object LocalPicoUsb {
     // need to also match the product id or the "dsm_anchor" product string.
     private const val RPI_VENDOR_ID = 0x2E8A
     private const val WRITE_TIMEOUT_MS = 2000
-    private const val READ_TIMEOUT_MS = 8000
+    private const val READ_TIMEOUT_MS = 500
+    // Max idle bulk-IN polls before failing closed (each blocks up to READ_TIMEOUT_MS). Bounds the
+    // total read wait deterministically without a wall-clock deadline (repo invariant).
+    private const val MAX_EMPTY_POLLS = 16
 
     @Volatile private var appContext: Context? = null
     private var connection: UsbDeviceConnection? = null
@@ -81,19 +84,25 @@ object LocalPicoUsb {
         return body
     }
 
-    /** Read exactly `n` bytes off the bulk-IN endpoint (accumulating across USB packets), or null. */
+    /** Read exactly `n` bytes off the bulk-IN endpoint (accumulating across USB packets), or null.
+     * Bounded by a poll COUNT (not wall-clock — repo invariant): each `bulkTransfer` already blocks
+     * up to `READ_TIMEOUT_MS`, so at most `MAX_EMPTY_POLLS` idle polls elapse before we fail closed. */
     private fun readExact(conn: UsbDeviceConnection, ep: UsbEndpoint, n: Int): ByteArray? {
         val out = ByteArray(n)
         var got = 0
         val buf = ByteArray(ep.maxPacketSize.coerceAtLeast(64))
-        val deadline = System.nanoTime() + READ_TIMEOUT_MS * 1_000_000L
+        var emptyPolls = 0
         while (got < n) {
-            if (System.nanoTime() > deadline) {
-                Log.w(TAG, "USB read timeout ($got/$n) — recover online")
-                return null
-            }
             val r = conn.bulkTransfer(ep, buf, buf.size, READ_TIMEOUT_MS)
-            if (r < 0) continue // no data this poll; loop until deadline
+            if (r < 0) {
+                emptyPolls++
+                if (emptyPolls > MAX_EMPTY_POLLS) {
+                    Log.w(TAG, "USB read gave up after $MAX_EMPTY_POLLS idle polls ($got/$n) — recover online")
+                    return null
+                }
+                continue
+            }
+            emptyPolls = 0
             val take = minOf(r, n - got)
             System.arraycopy(buf, 0, out, got, take)
             got += take

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package com.dsm.wallet.bridge
+
+import android.content.Context
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import android.util.Log
+
+/**
+ * H2 — the Phone->Pico USB-OTG transport (the sender phone A talking to its own Pico A).
+ *
+ * OPAQUE BYTE TRANSPORT ONLY. This class understands nothing about TROPIC / OP_SPI_PASSTHROUGH /
+ * protobuf — Rust builds the request frame and decodes the response. All this does is: open the
+ * Pico's USB-CDC endpoints and move a length-prefixed frame across. Contract with the Rust
+ * `UsbPicoTransport`:
+ *   - input `frame` = `LE32(bodyLen) ++ body` (the request, already framed by Rust). Written verbatim.
+ *   - the Pico replies `LE32(bodyLen) ++ body`; we read the 4-byte length, then that many bytes, and
+ *     return JUST the body (Rust decodes it). Any failure -> empty ByteArray -> Rust fails closed to
+ *     online recovery. No key material passes through here.
+ *
+ * Bench tuning points (validate on the phone): the Pico VID/PID match, the CDC-data interface +
+ * bulk-endpoint discovery, USB permission (grant via requestPermission or the attach intent-filter),
+ * and the read timeout. Mirrors the desktop bench `examples/shared/usb.rs::transceive`, in Kotlin.
+ */
+object LocalPicoUsb {
+    private const val TAG = "LocalPicoUsb"
+
+    // Raspberry Pi / RP2350 USB vendor id (the Pico anchor firmware is a CDC-ACM device). Bench may
+    // need to also match the product id or the "dsm_anchor" product string.
+    private const val RPI_VENDOR_ID = 0x2E8A
+    private const val WRITE_TIMEOUT_MS = 2000
+    private const val READ_TIMEOUT_MS = 8000
+
+    @Volatile private var appContext: Context? = null
+    private var connection: UsbDeviceConnection? = null
+    private var iface: UsbInterface? = null
+    private var epIn: UsbEndpoint? = null
+    private var epOut: UsbEndpoint? = null
+
+    /** Cache the application context so the static `Unified.picoUsbTransceive` can reach UsbManager. */
+    @JvmStatic
+    fun init(context: Context) {
+        appContext = context.applicationContext
+    }
+
+    /** One opaque USB round-trip. Returns the response body, or empty on any failure (fail-closed). */
+    @Synchronized
+    fun transceive(frame: ByteArray): ByteArray {
+        val conn = try {
+            ensureOpen()
+        } catch (e: Exception) {
+            Log.w(TAG, "USB open failed (recover online): ${e.message}")
+            return ByteArray(0)
+        }
+        val out = epOut ?: return ByteArray(0)
+        val inp = epIn ?: return ByteArray(0)
+
+        Log.d(TAG, "passthrough req len=${frame.size}")
+        val wrote = conn.bulkTransfer(out, frame, frame.size, WRITE_TIMEOUT_MS)
+        if (wrote < frame.size) {
+            Log.w(TAG, "USB write short ($wrote/${frame.size}) — recover online")
+            return ByteArray(0)
+        }
+
+        // Read the LE32 length prefix, then that many body bytes.
+        val header = readExact(conn, inp, 4) ?: return ByteArray(0)
+        val bodyLen = (header[0].toInt() and 0xFF) or
+            ((header[1].toInt() and 0xFF) shl 8) or
+            ((header[2].toInt() and 0xFF) shl 16) or
+            ((header[3].toInt() and 0xFF) shl 24)
+        if (bodyLen <= 0 || bodyLen > 262_144) {
+            Log.w(TAG, "USB response length out of range ($bodyLen) — recover online")
+            return ByteArray(0)
+        }
+        val body = readExact(conn, inp, bodyLen) ?: return ByteArray(0)
+        Log.d(TAG, "passthrough resp len=${body.size}")
+        return body
+    }
+
+    /** Read exactly `n` bytes off the bulk-IN endpoint (accumulating across USB packets), or null. */
+    private fun readExact(conn: UsbDeviceConnection, ep: UsbEndpoint, n: Int): ByteArray? {
+        val out = ByteArray(n)
+        var got = 0
+        val buf = ByteArray(ep.maxPacketSize.coerceAtLeast(64))
+        val deadline = System.nanoTime() + READ_TIMEOUT_MS * 1_000_000L
+        while (got < n) {
+            if (System.nanoTime() > deadline) {
+                Log.w(TAG, "USB read timeout ($got/$n) — recover online")
+                return null
+            }
+            val r = conn.bulkTransfer(ep, buf, buf.size, READ_TIMEOUT_MS)
+            if (r < 0) continue // no data this poll; loop until deadline
+            val take = minOf(r, n - got)
+            System.arraycopy(buf, 0, out, got, take)
+            got += take
+        }
+        return out
+    }
+
+    private fun ensureOpen(): UsbDeviceConnection {
+        connection?.let { return it }
+        val ctx = appContext ?: error("LocalPicoUsb.init(context) not called")
+        val usb = ctx.getSystemService(Context.USB_SERVICE) as UsbManager
+
+        val device = usb.deviceList.values.firstOrNull { it.vendorId == RPI_VENDOR_ID }
+            ?: usb.deviceList.values.firstOrNull { hasCdcDataInterface(it) }
+            ?: error("no Pico USB device found")
+        Log.i(TAG, "USB device detected: vid=${device.vendorId} pid=${device.productId} ${device.productName}")
+
+        if (!usb.hasPermission(device)) {
+            error("no USB permission for the Pico (grant via requestPermission / attach intent)")
+        }
+        val (usbInterface, inEp, outEp) = findBulkEndpoints(device)
+            ?: error("no CDC-data bulk endpoints on the Pico")
+        val conn = usb.openDevice(device) ?: error("openDevice returned null")
+        if (!conn.claimInterface(usbInterface, true)) {
+            conn.close()
+            error("claimInterface failed")
+        }
+        connection = conn
+        iface = usbInterface
+        epIn = inEp
+        epOut = outEp
+        Log.i(TAG, "Pico opened (interface ${usbInterface.id}, in=${inEp.address} out=${outEp.address})")
+        return conn
+    }
+
+    private fun hasCdcDataInterface(device: UsbDevice): Boolean {
+        for (i in 0 until device.interfaceCount) {
+            if (device.getInterface(i).interfaceClass == UsbConstants.USB_CLASS_CDC_DATA) return true
+        }
+        return false
+    }
+
+    /** The CDC-data interface (class 0x0A) with a bulk IN + bulk OUT endpoint. */
+    private fun findBulkEndpoints(device: UsbDevice): Triple<UsbInterface, UsbEndpoint, UsbEndpoint>? {
+        for (i in 0 until device.interfaceCount) {
+            val itf = device.getInterface(i)
+            if (itf.interfaceClass != UsbConstants.USB_CLASS_CDC_DATA) continue
+            var inEp: UsbEndpoint? = null
+            var outEp: UsbEndpoint? = null
+            for (e in 0 until itf.endpointCount) {
+                val ep = itf.getEndpoint(e)
+                if (ep.type != UsbConstants.USB_ENDPOINT_XFER_BULK) continue
+                if (ep.direction == UsbConstants.USB_DIR_IN) inEp = ep else outEp = ep
+            }
+            if (inEp != null && outEp != null) return Triple(itf, inEp, outEp)
+        }
+        return null
+    }
+}

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/Unified.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/Unified.kt
@@ -87,6 +87,14 @@ object Unified {
     @Keep @JvmStatic fun initDsmSdk(configPath: String) {
         UnifiedNativeApi.initDsmSdk(configPath)
     }
+
+    // H2 — Phone->Pico USB-OTG bridge. Rust's `UsbPicoTransport` up-calls this with an OPAQUE,
+    // already-framed OP_SPI_PASSTHROUGH request; this just moves the bytes over USB to the Pico and
+    // returns the response body (Rust decodes it). We understand NOTHING about the payload — no
+    // TROPIC frames, no key material. Empty return on any failure -> Rust fails closed to online
+    // recovery. `LocalPicoUsb.init(context)` must have been called at startup.
+    @Keep @JvmStatic fun picoUsbTransceive(frame: ByteArray): ByteArray =
+        LocalPicoUsb.transceive(frame)
     @Keep @JvmStatic fun dispatchStartup(requestBytes: ByteArray): ByteArray =
         UnifiedNativeApi.dispatchStartup(requestBytes)
     @Keep @JvmStatic fun dispatchIngress(requestBytes: ByteArray): ByteArray =

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_impl.rs
@@ -288,6 +288,7 @@ impl BilateralHandler for BiImpl {
                                     crate::sdk::app_state::AppState::get_public_key()
                                         .unwrap_or_default(),
                                 receiver_challenge: vec![], // r_R: set by the BLE receiver path for bearer transfers
+                                anchor_enroll_request: None, // set by the BLE receiver path (first-transfer bearer enroll)
                             };
 
                             return BiResult {


### PR DESCRIPTION
The Kotlin half of the Phone→Pico USB bridge + the Rust on-device constructor that binds it — completing H2's *code*. Kotlin stays an opaque byte transport; all `OP_SPI_PASSTHROUGH`/protobuf framing stays in Rust.

Also includes a **latent Phase-C android bugfix** (separate commit): the `cfg(android)` `BilateralPrepareResponse` initializer was missing `anchor_enroll_request` — host CI never compiled it, so it merged green while breaking the Android Rust build. Surfaced by this phase's cargo-ndk cross-check.

## What lands
- **`LocalPicoUsb.kt`** — Android USB-host CDC transport: enumerate the Pico (RPi VID `0x2E8A` / CDC-data interface), open bulk endpoints, write the request frame, read the `LE32`-prefixed response body, return it. Understands nothing about the payload; **empty return on any failure** (no device/permission/short-write/timeout/bad-length) → Rust fails closed to online recovery. Hard logging (req #7): device detected, Pico opened, req/resp lengths, recovery reason.
- **`Unified.picoUsbTransceive(frame)`** — the `@JvmStatic` opaque up-call target.
- **`UsbPicoTransport::android()`** (glue crate) — the JNI up-call via `with_env` + `find_class_with_app_loader` + `call_static_method` (mirrors `queue_follow_up_chunks`); null/empty → `DsmError` → fail-closed. Android dep table enables dsm_sdk's `jni` + `bluetooth`.
- **Manifest**: `uses-feature android.hardware.usb.host` (required=false).

## Verification
- glue host tests 5/5; clippy + fmt clean
- the Android JNI constructor + feature plumbing **cross-compile for arm64-v8a** (cargo ndk check)
- Kotlin compiles via the Android CI job; host `dsm_sdk` build clean
- `cargo tree --workspace -i tropic01` still empty

## H2 completion gate (req #8) — the bench proof, not in this PR
Needs the phone + USB-OTG + Pico: `LocalPicoUsb.init(context)` at startup, wire the glue `.so`, grant USB permission, and drive one `OP_SPI_PASSTHROUGH` to get **one real TROPIC response**. H3 stays blocked until that passes. No live claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)