### PR TITLE
feat(offline-bearer): H2+H3 hardware proof — phone reads the attested TROPIC01 counter through the production stack

### DIFF
--- a/crates/dsm-anchor-hw-verifier/examples/usb_capture_selftest_vector.rs
+++ b/crates/dsm-anchor-hw-verifier/examples/usb_capture_selftest_vector.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! H2 bench-vector capture: record the exact `OP_SPI_PASSTHROUGH` request frame + the real chip's
+//! response body for ONE L1 `GET_RESPONSE` transaction, so the Android `PicoSelfTestActivity` can
+//! replay the SAME single round-trip against the SAME Pico after it moves to the phone over USB-OTG.
+//!
+//! L1 `GET_RESPONSE` (libtropic `lt_1.rs`) is a single CS-framed SPI transfer of the L2 buffer:
+//! MOSI = `[0xAA, L2_CMD_REQ_LEN(128), 0x00 * 255]` (257 bytes); MISO[0] is the chip STATUS byte and
+//! MISO[1] the response status (0xff = NO_RESP on an idle chip). It needs no session — so the phone
+//! can prove the USB path reached a real TROPIC01 with one opaque frame. Run TWICE here to confirm
+//! the response is deterministic before hard-coding it.
+//!
+//!   cargo run -p dsm-anchor-hw-verifier --example usb_capture_selftest_vector -- /dev/cu.usbmodemdsm_anchor1
+
+// Bring-up tool, not a production path: fail loudly at the console.
+#![allow(clippy::disallowed_methods)]
+
+#[path = "shared/usb.rs"]
+mod usb;
+
+use std::io::{Read, Write};
+use std::time::{Duration, Instant};
+
+use anchor_core::proto::{decode_response, encode_request, pb};
+
+/// TROPIC01 L1 GET_RESPONSE opcode + request length (libtropic `lt_1.rs` / `lib.rs`).
+const L2_CMD_ID_GET_RESPONSE: u8 = 0xaa;
+const L2_CMD_REQ_LEN: u8 = 128;
+/// L2_MAX_FRAME_SIZE + 1 = the size of libtropic's `l2_buf`, i.e. the full MOSI clocked for an L1 read.
+const L2_BUF_LEN: usize = 257;
+
+fn read_exact_timeout(port: &mut Box<dyn serialport::SerialPort>, buf: &mut [u8]) {
+    let mut got = 0;
+    let dl = Instant::now() + Duration::from_secs(8);
+    while got < buf.len() {
+        assert!(Instant::now() <= dl, "read timeout");
+        match port.read(&mut buf[got..]) {
+            Ok(0) => {}
+            Ok(n) => got += n,
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(e) => panic!("serial read: {e}"),
+        }
+    }
+}
+
+/// Send ONE `OP_SPI_PASSTHROUGH` framing the given MOSI; return `(request_frame, response_body)`
+/// exactly as `LocalPicoUsb.transceive` sees them (request frame = LE32 len + ApplianceRequest;
+/// response body = the ApplianceResponse bytes with its own LE32 prefix already stripped).
+fn one_passthrough(port: &mut Box<dyn serialport::SerialPort>, mosi: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    let req = pb::ApplianceRequest {
+        op: pb::Op::SpiPassthrough as i32,
+        spi_payload: mosi.to_vec(),
+        ..Default::default()
+    };
+    let body = encode_request(&req);
+    let mut frame = (body.len() as u32).to_le_bytes().to_vec();
+    frame.extend_from_slice(&body);
+    port.write_all(&frame).expect("serial write");
+
+    let mut lenb = [0u8; 4];
+    read_exact_timeout(port, &mut lenb);
+    let n = u32::from_le_bytes(lenb) as usize;
+    let mut respb = vec![0u8; n];
+    read_exact_timeout(port, &mut respb);
+    (frame, respb)
+}
+
+fn hex(b: &[u8]) -> String {
+    let mut s = String::with_capacity(b.len() * 2);
+    for x in b {
+        s.push_str(&format!("{x:02x}"));
+    }
+    s
+}
+
+fn main() {
+    let dev = std::env::args().nth(1).unwrap_or_else(usb::find_port);
+    eprintln!("[capture] port = {dev}");
+    let mut port = usb::open_and_drain(&dev);
+    eprintln!("[capture] serve loop quiet; sending L1 GET_RESPONSE passthrough\n");
+
+    // MOSI = the exact L1 GET_RESPONSE buffer libtropic clocks: [0xAA, 128, 0x00 * 255].
+    let mut mosi = vec![0u8; L2_BUF_LEN];
+    mosi[0] = L2_CMD_ID_GET_RESPONSE;
+    mosi[1] = L2_CMD_REQ_LEN;
+
+    let (frame1, body1) = one_passthrough(&mut port, &mosi);
+    let (frame2, body2) = one_passthrough(&mut port, &mosi);
+
+    let resp1 = decode_response(&body1).expect("decode ApplianceResponse #1");
+    assert_eq!(frame1, frame2, "request frame must be identical (it is host-built)");
+    let deterministic = body1 == body2;
+
+    println!("req_frame_len   = {}", frame1.len());
+    println!("req_frame_hex   = {}", hex(&frame1));
+    println!("resp_body_len   = {}", body1.len());
+    println!("resp_body_hex   = {}", hex(&body1));
+    println!("resp.ok         = {}", resp1.ok);
+    println!("resp.spi_len    = {}", resp1.spi_response.len());
+    if let Some(status) = resp1.spi_response.first() {
+        println!("chip_status_b0  = 0x{status:02x}  (ready bit0={})", status & 0x01);
+    }
+    println!("deterministic   = {deterministic}  (body #1 == body #2)");
+    if !deterministic {
+        println!("resp_body_hex#2 = {}", hex(&body2));
+        eprintln!("[warn] response NOT byte-identical across calls; compare a stable prefix, not the full body");
+    }
+}

--- a/crates/dsm-android-anchor/Cargo.lock
+++ b/crates/dsm-android-anchor/Cargo.lock
@@ -1039,6 +1039,7 @@ dependencies = [
 name = "dsm-android-anchor"
 version = "0.1.0"
 dependencies = [
+ "dsm",
  "dsm-anchor-core",
  "dsm-anchor-hw-verifier",
  "dsm-anchor-verifier",
@@ -1046,6 +1047,7 @@ dependencies = [
  "futures",
  "jni",
  "log",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/dsm-android-anchor/Cargo.toml
+++ b/crates/dsm-android-anchor/Cargo.toml
@@ -21,7 +21,12 @@ dsm-anchor-verifier = { path = "../dsm-anchor-verifier" }
 # The OP_SPI_PASSTHROUGH ApplianceRequest/Response codec (tropic01-free) — the Phone->Pico USB
 # bridge frames requests / decodes responses in Rust so Kotlin stays an opaque byte transport.
 dsm-anchor-core = { path = "../dsm-anchor-core" }
+# FusedAnchorPin (the reader's pin type) for the on-device self-test.
+dsm = { path = "../../dsm_client/deterministic_state_machine/dsm" }
 log = "0.4"
+# The self-test drives the reader's relay bridge (spawn_blocking) + the router's bounded round-trip
+# (timers); versions unify with dsm_sdk's own tokio.
+tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 
 # On Android, the USB bridge's LocalPicoTransport does a JNI up-call to Kotlin's opaque
 # picoUsbTransceive (mirrors queue_follow_up_chunks' with_env pattern), so it needs dsm_sdk's `jni`
@@ -35,3 +40,13 @@ jni = "0.21"
 [dev-dependencies]
 # Poll the boxed PicoFuture in host tests without a full async runtime.
 futures = { version = "0.3", default-features = false, features = ["executor"] }
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
+
+# This crate is workspace-EXCLUDED, so it is its own profile root: mirror the deterministic_state_machine
+# workspace release profile — LTO must stay off and symbols unstripped to preserve the JNI exports when
+# this cdylib ships as the app's libdsm_sdk.so (H3 packaging).
+[profile.release]
+opt-level = 3
+lto = false
+codegen-units = 1
+strip = false

--- a/crates/dsm-android-anchor/src/lib.rs
+++ b/crates/dsm-android-anchor/src/lib.rs
@@ -27,6 +27,7 @@ use dsm_sdk::bridge::{
     SeSlotWriter,
 };
 
+pub mod self_test;
 pub mod usb_pico;
 pub use usb_pico::{UsbPicoTransport, UsbTransceive};
 

--- a/crates/dsm-android-anchor/src/self_test.rs
+++ b/crates/dsm-android-anchor/src/self_test.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! H3 on-device composition self-test: ONE real attested counter read from a TROPIC01 through the
+//! phone, using the production stack end to end — the REAL [`RelayCounterReader`] (full libtropic
+//! session: cert-store stpub check -> authenticated L3 handshake on the verifier slot ->
+//! `mcounter_get`), driven through the REAL [`TropicRelayRouter`] in the H0 loopback topology, over
+//! the REAL Phone->Pico USB transport proven in H2. The ONLY substitutions vs production are the
+//! loopback `round_trip` (in-process instead of BLE — the H4 seam) and the demo pin below.
+//!
+//! Bench-only wiring: the demo verifier identity (`B_DEMO_SEED`/`A_DEMO_PEER`) is the pairing key
+//! Phase G burned into the bench chip's READ-ONLY verifier slot 1, and `KNOWN_BENCH_STPUB` is that
+//! chip's pinned Noise static key (anti-substitution). A full production pin comes from the
+//! first-transfer enroll/disclosure flow instead. Expected result on the bench chip: `H = 1000`.
+
+use std::sync::Arc;
+
+use dsm_anchor_hw_verifier::{RelayCounterReader, RelayRoundTrip};
+use dsm_anchor_verifier::RelayError;
+use dsm_sdk::bluetooth::tropic_relay::{
+    AnchorCounterReader, LocalPicoTransport, TropicRelayRouter,
+};
+
+/// Phase-G demo verifier identity: the bench chip's slot-1 pairing key is
+/// `derive_pairing_pubkey(B_DEMO_SEED, A_DEMO_PEER)` (see `usb_provision_verifier_slot`).
+const B_DEMO_SEED: [u8; 32] = [0xB0; 32];
+const A_DEMO_PEER: [u8; 32] = [0xA0; 32];
+
+/// The bench chip's pinned Noise static key (captured at provisioning; asserted by
+/// `usb_verify_verifier_slot`). The reader refuses to trust a counter from any other chip.
+const KNOWN_BENCH_STPUB: [u8; 32] = [
+    0xd1, 0x87, 0xbc, 0xf1, 0x08, 0x9e, 0x9d, 0xaa, 0xb6, 0x4e, 0x5c, 0x0b, 0x96, 0xfd, 0x3a, 0x26,
+    0x91, 0xe0, 0xd3, 0x70, 0x91, 0x0a, 0x07, 0xdb, 0x82, 0x1a, 0x32, 0x25, 0x83, 0x0f, 0xbe, 0x7d,
+];
+
+/// The bench chip's read-only verifier slot (Phase G).
+const VERIFIER_SLOT: u8 = 1;
+
+/// Synthetic-but-complete demo pin: exactly the fields `read_counter` gates on (verifier slot,
+/// pinned chip static key, uncompromised); the acceptance-predicate fields are placeholders.
+fn demo_pin() -> dsm::crypto::anchor_enrollment::FusedAnchorPin {
+    dsm::crypto::anchor_enrollment::FusedAnchorPin {
+        bundle: [0u8; 32],
+        anchor_id: [0u8; 32],
+        enrolled_counter: 1000,
+        partition_pk: Vec::new(),
+        uncompromised: true,
+        verifier_slot: Some(VERIFIER_SLOT),
+        chip_static_pubkey: Some(KNOWN_BENCH_STPUB),
+    }
+}
+
+/// Loopback `round_trip`: the H0 topology with the real transport — the SAME router plays receiver
+/// (round_trip) and sender (handle_inbound -> local Pico), no BLE in between. H4 replaces this with
+/// the real phone-to-phone send (`queue_relay_frame`).
+fn loopback_round_trip(router: Arc<TropicRelayRouter>) -> RelayRoundTrip {
+    Arc::new(move |_peer, commitment, mosi| {
+        let router = Arc::clone(&router);
+        Box::pin(async move {
+            let send_router = Arc::clone(&router);
+            router
+                .round_trip(commitment, mosi, move |frame: Vec<u8>| async move {
+                    // "Phone A" side: forward to the local Pico, then feed the reply back in.
+                    if let Some(reply) = send_router.handle_inbound(&frame).await? {
+                        send_router.handle_inbound(&reply).await?;
+                    }
+                    Ok(())
+                })
+                .await
+                .map_err(|e| RelayError::Transport(format!("loopback relay: {e}")))
+        })
+    })
+}
+
+/// Drive one attested counter read through the full production reader stack over `pico`.
+/// Returns the live counter `H` (expect 1000 on the bench chip) or `None` fail-closed.
+pub async fn demo_counter_read_via_local_pico(pico: Arc<dyn LocalPicoTransport>) -> Option<u32> {
+    let router = Arc::new(TropicRelayRouter::new());
+    router.set_local_pico(pico);
+    let reader = RelayCounterReader::new(B_DEMO_SEED, loopback_round_trip(router));
+    // Any 32-byte correlation id works for the single in-process exchange.
+    let commitment = [0x5Eu8; 32];
+    reader
+        .read_counter(A_DEMO_PEER, commitment, demo_pin())
+        .await
+}
+
+/// JNI trigger for the bench: called from the debug `PicoSelfTestActivity` AFTER the H2 opaque
+/// round-trip passes. Builds the real USB transport + a multi-thread runtime (the relay bridge uses
+/// `spawn_blocking`), runs one attested read, and returns `H` (or -1 fail-closed / -2 no runtime).
+#[cfg(target_os = "android")]
+#[no_mangle]
+pub extern "system" fn Java_com_dsm_wallet_bridge_Unified_anchorCounterSelfTest(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+) -> jni::sys::jlong {
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            log::error!("[anchor-selftest] tokio runtime: {e}");
+            return -2;
+        }
+    };
+    let pico: Arc<dyn LocalPicoTransport> = Arc::new(crate::usb_pico::android_usb_pico_transport());
+    match rt.block_on(demo_counter_read_via_local_pico(pico)) {
+        Some(h) => {
+            log::info!("[anchor-selftest] ATTESTED COUNTER READ OK: H = {h}");
+            i64::from(h)
+        }
+        None => {
+            log::error!("[anchor-selftest] counter read failed (fail-closed)");
+            -1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dsm_sdk::bluetooth::tropic_relay::PicoFuture;
+    use dsm_sdk::types::error::DsmError;
+
+    /// A Pico stand-in that answers garbage: the full reader stack must fail CLOSED (None), never
+    /// panic or hang, when the chip end is nonsense. (The positive path needs real silicon — it is
+    /// the bench run this module exists for.)
+    struct GarbagePico;
+    impl LocalPicoTransport for GarbagePico {
+        fn spi_passthrough(&self, spi: Vec<u8>) -> PicoFuture<Result<Vec<u8>, DsmError>> {
+            Box::pin(async move { Ok(vec![0u8; spi.len()]) })
+        }
+    }
+
+    /// A Pico stand-in whose transport errors outright.
+    struct DeadPico;
+    impl LocalPicoTransport for DeadPico {
+        fn spi_passthrough(&self, _spi: Vec<u8>) -> PicoFuture<Result<Vec<u8>, DsmError>> {
+            Box::pin(async { Err(DsmError::invalid_operation("no chip")) })
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn garbage_chip_fails_closed() {
+        assert_eq!(
+            demo_counter_read_via_local_pico(Arc::new(GarbagePico)).await,
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dead_transport_fails_closed() {
+        assert_eq!(
+            demo_counter_read_via_local_pico(Arc::new(DeadPico)).await,
+            None
+        );
+    }
+}

--- a/dsm_client/android/app/src/main/AndroidManifest.xml
+++ b/dsm_client/android/app/src/main/AndroidManifest.xml
@@ -164,6 +164,22 @@
             android:label="Pairing Test"
             android:launchMode="singleTop" />
 
+        <!-- H2 bench self-test: launched when the Pico anchor attaches over USB-OTG (that launch
+             also grants USB permission for the device). Replays one OP_SPI_PASSTHROUGH round-trip
+             and logs whether the phone reached the real TROPIC01. Debug bring-up only. -->
+        <activity
+            android:name="com.dsm.wallet.debug.PicoSelfTestActivity"
+            android:exported="true"
+            android:label="Pico USB self-test"
+            android:launchMode="singleTop">
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/pico_device_filter" />
+        </activity>
+
         <!-- Hardware Incompatibility Screen (shown when JNI library fails to load) -->
         <activity
             android:name="com.dsm.wallet.IncompatibleDeviceScreen"

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
@@ -29,11 +29,18 @@ import android.util.Log
 object LocalPicoUsb {
     private const val TAG = "LocalPicoUsb"
 
-    // Raspberry Pi / RP2350 USB vendor id (the Pico anchor firmware is a CDC-ACM device). Bench may
-    // need to also match the product id or the "dsm_anchor" product string.
-    private const val RPI_VENDOR_ID = 0x2E8A
+    // The DSM Anchor firmware sets its own CDC-ACM USB descriptor: vendor id 0x1209 (pid.codes
+    // community VID), product id 0xD5A1, product string "DSM Anchor" — NOT the bare RP2350 VID
+    // 0x2E8A. Matched first by VID; the CDC-data interface scan below is the fallback.
+    private const val DSM_ANCHOR_VENDOR_ID = 0x1209
     private const val WRITE_TIMEOUT_MS = 2000
     private const val READ_TIMEOUT_MS = 500
+    private const val CONTROL_TIMEOUT_MS = 1000
+    // Drain the firmware boot banner / self-test chatter off the CDC before the first transaction
+    // (mirrors the desktop bench's usb::open_and_drain). Read until quiet, bounded by poll counts.
+    private const val DRAIN_TIMEOUT_MS = 200
+    private const val DRAIN_QUIET_POLLS = 4   // ~800ms of silence ends the drain
+    private const val DRAIN_MAX_POLLS = 40    // hard cap (~8s worst case) so boot chatter can finish
     // Max idle bulk-IN polls before failing closed (each blocks up to READ_TIMEOUT_MS). Bounds the
     // total read wait deterministically without a wall-clock deadline (repo invariant).
     private const val MAX_EMPTY_POLLS = 16
@@ -59,29 +66,38 @@ object LocalPicoUsb {
             Log.w(TAG, "USB open failed (recover online): ${e.message}")
             return ByteArray(0)
         }
-        val out = epOut ?: return ByteArray(0)
-        val inp = epIn ?: return ByteArray(0)
+        val out = epOut ?: return resetAndFail()
+        val inp = epIn ?: return resetAndFail()
 
         Log.d(TAG, "passthrough req len=${frame.size}")
         val wrote = conn.bulkTransfer(out, frame, frame.size, WRITE_TIMEOUT_MS)
         if (wrote < frame.size) {
             Log.w(TAG, "USB write short ($wrote/${frame.size}) — recover online")
-            return ByteArray(0)
+            return resetAndFail()
         }
 
         // Read the LE32 length prefix, then that many body bytes.
-        val header = readExact(conn, inp, 4) ?: return ByteArray(0)
+        val header = readExact(conn, inp, 4) ?: return resetAndFail()
         val bodyLen = (header[0].toInt() and 0xFF) or
             ((header[1].toInt() and 0xFF) shl 8) or
             ((header[2].toInt() and 0xFF) shl 16) or
             ((header[3].toInt() and 0xFF) shl 24)
         if (bodyLen <= 0 || bodyLen > 262_144) {
             Log.w(TAG, "USB response length out of range ($bodyLen) — recover online")
-            return ByteArray(0)
+            return resetAndFail()
         }
-        val body = readExact(conn, inp, bodyLen) ?: return ByteArray(0)
+        val body = readExact(conn, inp, bodyLen) ?: return resetAndFail()
         Log.d(TAG, "passthrough resp len=${body.size}")
         return body
+    }
+
+    /** Tear down the cached connection so the next transceive reopens + reconfigures from scratch
+     * (a half-open handle with DTR unset must never be reused), and fail closed with empty bytes. */
+    private fun resetAndFail(): ByteArray {
+        try { iface?.let { connection?.releaseInterface(it) } } catch (_: Exception) {}
+        try { connection?.close() } catch (_: Exception) {}
+        connection = null; iface = null; epIn = null; epOut = null
+        return ByteArray(0)
     }
 
     /** Read exactly `n` bytes off the bulk-IN endpoint (accumulating across USB packets), or null.
@@ -115,7 +131,7 @@ object LocalPicoUsb {
         val ctx = appContext ?: error("LocalPicoUsb.init(context) not called")
         val usb = ctx.getSystemService(Context.USB_SERVICE) as UsbManager
 
-        val device = usb.deviceList.values.firstOrNull { it.vendorId == RPI_VENDOR_ID }
+        val device = usb.deviceList.values.firstOrNull { it.vendorId == DSM_ANCHOR_VENDOR_ID }
             ?: usb.deviceList.values.firstOrNull { hasCdcDataInterface(it) }
             ?: error("no Pico USB device found")
         Log.i(TAG, "USB device detected: vid=${device.vendorId} pid=${device.productId} ${device.productName}")
@@ -130,12 +146,72 @@ object LocalPicoUsb {
             conn.close()
             error("claimInterface failed")
         }
+        // A desktop cdc-acm driver asserts DTR on open; Android raw USB does not. Without it the
+        // anchor firmware's CDC stays "disconnected", never drains its bulk-OUT FIFO, and the first
+        // write fills the FIFO and times out (-1). Assert line coding + DTR/RTS the same way.
+        configureCdc(conn, device)
         connection = conn
         iface = usbInterface
         epIn = inEp
         epOut = outEp
         Log.i(TAG, "Pico opened (interface ${usbInterface.id}, in=${inEp.address} out=${outEp.address})")
+        // Discard the firmware boot banner / self-test output before the first transaction so the
+        // response read frames on the OP_SPI_PASSTHROUGH reply, not on stale boot chatter.
+        drainInput(conn, inEp)
         return conn
+    }
+
+    /**
+     * Bring the CDC-ACM control line up the way a host cdc-acm driver does: SET_LINE_CODING (115200
+     * 8N1) then SET_CONTROL_LINE_STATE with DTR|RTS asserted, on the CDC communications interface.
+     * Class control transfers (bmRequestType 0x21 = host->device | class | interface). Best-effort:
+     * failures are logged, not fatal (some firmwares ignore line state).
+     */
+    private fun configureCdc(conn: UsbDeviceConnection, device: UsbDevice) {
+        val commIface = (0 until device.interfaceCount)
+            .map { device.getInterface(it) }
+            .firstOrNull { it.interfaceClass == UsbConstants.USB_CLASS_COMM }
+        val commId = commIface?.id ?: 0
+        val claimed = commIface?.let { conn.claimInterface(it, true) } ?: false
+        Log.i(TAG, "comm iface=$commId claim=$claimed (ifaceCount=${device.interfaceCount})")
+        var cls = setControlLine(conn, commId)
+        if (cls < 0 && claimed && commIface != null) {
+            // Some host stacks block class control transfers while the comm interface is claimed by
+            // the app; release it and retry (control transfers target endpoint 0, not the interface).
+            conn.releaseInterface(commIface)
+            Log.i(TAG, "control-line timed out with comm claimed; retrying unclaimed")
+            cls = setControlLine(conn, commId)
+        }
+    }
+
+    /** SET_LINE_CODING (115200 8N1) then SET_CONTROL_LINE_STATE (DTR|RTS) on the comm interface;
+     * returns the SET_CONTROL_LINE_STATE result (<0 = failed/timed out). */
+    private fun setControlLine(conn: UsbDeviceConnection, commId: Int): Int {
+        val lineCoding = byteArrayOf(0x00, 0xC2.toByte(), 0x01, 0x00, 0x00, 0x00, 0x08)
+        val lc = conn.controlTransfer(0x21, 0x20, 0, commId, lineCoding, lineCoding.size, CONTROL_TIMEOUT_MS)
+        val cls = conn.controlTransfer(0x21, 0x22, 0x03, commId, null, 0, CONTROL_TIMEOUT_MS)
+        Log.i(TAG, "CDC line (comm iface $commId): setLineCoding=$lc setControlLineState=$cls")
+        return cls
+    }
+
+    /** Read and discard pending bulk-IN bytes (the firmware boot banner / self-test log) until the
+     * line goes quiet for [DRAIN_QUIET_POLLS] polls, capped at [DRAIN_MAX_POLLS]. */
+    private fun drainInput(conn: UsbDeviceConnection, ep: UsbEndpoint) {
+        val buf = ByteArray(ep.maxPacketSize.coerceAtLeast(64))
+        var quiet = 0
+        var polls = 0
+        var discarded = 0
+        while (quiet < DRAIN_QUIET_POLLS && polls < DRAIN_MAX_POLLS) {
+            val r = conn.bulkTransfer(ep, buf, buf.size, DRAIN_TIMEOUT_MS)
+            if (r > 0) {
+                discarded += r
+                quiet = 0
+            } else {
+                quiet++
+            }
+            polls++
+        }
+        Log.i(TAG, "drained $discarded boot/banner bytes before first transaction ($polls polls)")
     }
 
     private fun hasCdcDataInterface(device: UsbDevice): Boolean {

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/Unified.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/Unified.kt
@@ -95,6 +95,13 @@ object Unified {
     // recovery. `LocalPicoUsb.init(context)` must have been called at startup.
     @Keep @JvmStatic fun picoUsbTransceive(frame: ByteArray): ByteArray =
         LocalPicoUsb.transceive(frame)
+
+    // H3 bench self-test — implemented in the anchor glue (`dsm-android-anchor`, packaged into the
+    // same .so): ONE attested TROPIC01 counter read through the full production reader stack
+    // (libtropic session over the relay router over the H2 USB transport). Returns the live counter
+    // H (>= 0) or a negative fail-closed code. Only present in glue-packaged builds — callers must
+    // catch UnsatisfiedLinkError.
+    @Keep @JvmStatic external fun anchorCounterSelfTest(): Long
     @Keep @JvmStatic fun dispatchStartup(requestBytes: ByteArray): ByteArray =
         UnifiedNativeApi.dispatchStartup(requestBytes)
     @Keep @JvmStatic fun dispatchIngress(requestBytes: ByteArray): ByteArray =

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/debug/PicoSelfTestActivity.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/debug/PicoSelfTestActivity.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+package com.dsm.wallet.debug
+
+import android.app.Activity
+import android.os.Bundle
+import android.util.Log
+import com.dsm.wallet.bridge.LocalPicoUsb
+
+/**
+ * H2 bench self-test (debug bring-up only). Launched by the USB_DEVICE_ATTACHED intent-filter when
+ * the Pico anchor is plugged into the phone over USB-OTG — that launch also grants this app USB
+ * permission for the attached device, so [LocalPicoUsb] can open it.
+ *
+ * It replays ONE captured `OP_SPI_PASSTHROUGH` round-trip (an L1 GET_RESPONSE) and checks the reply
+ * against the vector captured from the SAME chip on the Mac bench. The reply's first spi_response
+ * byte is the chip STATUS (0x01 = ready); an echo/loopback/fake cannot produce it. A full match
+ * proves the phone's USB path reached the real TROPIC01 — the minimal H2 gate before H3 (the full
+ * libtropic counter read over the same transport).
+ *
+ * Kotlin stays opaque: the request frame and expected reply are pre-captured bytes; this class never
+ * builds or decodes a TROPIC/protobuf frame. Result goes to logcat under tag "PicoSelfTest".
+ */
+class PicoSelfTestActivity : Activity() {
+    private companion object {
+        private const val TAG = "PicoSelfTest"
+
+        /**
+         * Captured request frame (266 B): LE32 len(262) ++ ApplianceRequest{op=SpiPassthrough,
+         * spi_payload = L1 GET_RESPONSE MOSI [0xAA, 0x80, 0x00*255]}. Head is the only non-zero
+         * region; the 255 trailing payload bytes are zero (ByteArray default). Opaque to Kotlin.
+         */
+        private val REQ_FRAME: ByteArray = ByteArray(266).also {
+            byteArrayOf(
+                0x06, 0x01, 0x00, 0x00, // LE32 body length = 262
+                0x08, 0x08,             // op = 8 (SpiPassthrough)
+                0x32, 0x81.toByte(), 0x02, // spi_payload: field 6, len 257
+                0xAA.toByte(), 0x80.toByte(), // GET_RESPONSE opcode + L2_CMD_REQ_LEN(128)
+            ).copyInto(it)
+        }
+
+        /**
+         * Expected response body (264 B): ApplianceResponse{ok=true, spi_response = [0x01, 0xFF*256]}.
+         * spi_response[0] = 0x01 is the real chip STATUS byte (ready). Captured from the bench chip.
+         */
+        private val EXPECTED: ByteArray = ByteArray(264).also {
+            byteArrayOf(
+                0x08, 0x08,             // op = 8
+                0x10, 0x01,             // ok = true
+                0x62, 0x81.toByte(), 0x02, // spi_response: field 12, len 257
+                0x01,                   // spi_response[0] = chip STATUS (ready)
+            ).copyInto(it)
+            for (i in 8 until it.size) it[i] = 0xFF.toByte() // spi_response[1..256] = 0xFF (NO_RESP)
+        }
+
+        private fun hex(b: ByteArray, max: Int = 40): String {
+            val n = minOf(b.size, max)
+            val sb = StringBuilder(n * 2)
+            for (i in 0 until n) sb.append("%02x".format(b[i]))
+            if (b.size > max) sb.append("…")
+            return sb.toString()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Log.i(TAG, "=== Pico USB self-test starting ===")
+        LocalPicoUsb.init(this)
+        // USB bulkTransfer blocks — run off the main thread.
+        Thread {
+            val resp = try {
+                LocalPicoUsb.transceive(REQ_FRAME)
+            } catch (e: Exception) {
+                Log.e(TAG, "transceive threw (fail-closed): ${e.message}", e)
+                ByteArray(0)
+            }
+            val full = resp.contentEquals(EXPECTED)
+            // Discriminating prefix: ...62 81 02 01 ff ff — the chip STATUS 0x01 right after the length.
+            val prefixOk = resp.size >= 9 &&
+                resp[6] == 0x62.toByte() && resp[7] == 0x81.toByte() && resp[8] == 0x02.toByte() &&
+                resp.size >= 10 && resp[9] == 0x01.toByte()
+            Log.i(TAG, "resp len=${resp.size} hex=${hex(resp)}")
+            Log.i(TAG, "full match (byte-identical to bench capture): $full")
+            Log.i(TAG, "chip-status prefix present (reached real TROPIC01): $prefixOk")
+            if (full || prefixOk) {
+                Log.i(TAG, "*** H2 PASS: phone reached the real chip over USB-OTG ***")
+                // H3: one attested counter read through the FULL production reader stack
+                // (libtropic session -> relay router -> USB transport). Bench chip expects H=1000.
+                // Only present in glue-packaged builds; absent symbol = old .so, skip gracefully.
+                val h = try {
+                    com.dsm.wallet.bridge.Unified.anchorCounterSelfTest()
+                } catch (e: UnsatisfiedLinkError) {
+                    Log.w(TAG, "anchorCounterSelfTest not in this .so (pre-H3 build): ${e.message}")
+                    Long.MIN_VALUE
+                }
+                when {
+                    h >= 0 -> Log.i(TAG, "*** H3 PASS: attested counter read H=$h through the phone ***")
+                    h == Long.MIN_VALUE -> Log.i(TAG, "H3 self-test skipped (symbol absent)")
+                    else -> Log.e(TAG, "*** H3 FAIL: attested counter read failed (code $h) ***")
+                }
+            } else {
+                Log.e(TAG, "*** H2 FAIL: no real chip response (see resp above) ***")
+            }
+            Log.i(TAG, "=== Pico USB self-test done ===")
+            finish()
+        }.start()
+    }
+}

--- a/dsm_client/android/app/src/main/res/xml/pico_device_filter.xml
+++ b/dsm_client/android/app/src/main/res/xml/pico_device_filter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- H2 bench self-test: match the DSM Anchor firmware's USB descriptor so plugging the Pico into the
+     phone over USB-OTG launches PicoSelfTestActivity and grants USB permission for that device. The
+     anchor firmware sets vendor id 0x1209 (4617, pid.codes community VID), product id 0xD5A1 (54689),
+     product string "DSM Anchor" — NOT the bare RP2350 VID 0x2E8A. Debug bring-up only. -->
+<resources>
+    <usb-device vendor-id="4617" product-id="54689" />
+</resources>

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/bridge_utils.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/bridge_utils.rs
@@ -2,16 +2,13 @@
 
 //! # JNI Bridge Utility Functions
 //!
-//! Shared helpers for JNI entry points: `SDK_READY` gate checks,
-//! protobuf request/response marshalling, and error-to-`OpResult`
-//! conversion.
+//! Shared helpers for JNI entry points: protobuf request/response
+//! marshalling and error-to-`OpResult` conversion.
 
 use crate::generated as pb;
-use crate::sdk::session_manager::SDK_READY;
 use jni::objects::{JByteArray, JString};
 use jni::JNIEnv;
 use prost::Message;
-use std::sync::atomic::Ordering;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // FFI panic safety: catch_unwind wrappers for JNI export functions.


### PR DESCRIPTION
## What this proves (on real hardware, 2026-07-03)

**H2 — Phone→Pico USB transport, BOTH pairs:** each phone (SM-A165M) moves an opaque `OP_SPI_PASSTHROUGH` frame over USB-OTG to its Pico and receives the real TROPIC01 reply, byte-identical to the Mac bench capture (including the chip STATUS byte no echo/loopback can forge).

**H3 — attested counter read through the phone (the Phase-H success condition):** on phone A, one attested counter read through the **full production receiver stack** — `RelayCounterReader` (libtropic session: cert-store **stpub anti-substitution check** → authenticated L3 handshake on the **read-only verifier slot 1** (Phase G) → `mcounter_get`) driven through the real `TropicRelayRouter` (H0 loopback topology; BLE is the H4 seam) over the H2 USB transport. **Result: `H = 1000`, the exact enrolled counter.**

## Changes

- **`LocalPicoUsb` (Android transport):** real firmware USB descriptor (VID 0x1209 pid.codes / PID 0xD5A1, not the bare RP2350 VID); CDC `SET_LINE_CODING` + `SET_CONTROL_LINE_STATE` (DTR|RTS) on open; boot-banner drain before framing; teardown-on-failure (never reuse a half-open handle); all failures → empty → Rust fails closed.
- **Bench harness:** attach-launched debug `PicoSelfTestActivity` (H2 replay + H3 read; Kotlin stays opaque bytes), `usb_capture_selftest_vector` bench tool, USB device filter + manifest intent-filter.
- **Glue crate (`dsm-android-anchor`):** `self_test` module composing the production reader/router/USB stack (demo verifier identity from Phase G + pinned bench stpub); JNI export `anchorCounterSelfTest`; 2 fail-closed host tests. **H3 packaging:** the glue cdylib re-exports the complete dsm_sdk JNI surface (verified a strict superset: 103 = baseline 102 + 1) with `SONAME libdsm_sdk.so`, shipping as the app's single native lib; release profile mirrors the workspace (lto off, unstripped).
- **`dsm_sdk`:** remove two dead imports in `jni/bridge_utils.rs` (latent `deny(warnings)` break only compiled under the android jni+bluetooth cfg).

## Verification

- Glue host tests 7/7 (incl. new garbage-chip / dead-transport fail-closed); fmt + clippy clean
- `cargo tree --workspace -i tropic01` → no match (CI workspace stays tropic01-free; glue is excluded)
- `assembleDebug` green; on-device: H2 PASS both phones, H3 PASS `H=1000` (logcat-verified)
- JNI surface diff old vs new .so: nothing missing, exactly one added symbol

## Fail-closed status (unchanged)

Nothing installs the reader/transport in the production accept path — the self-test is debug-activity-triggered. **No live-acceptance claim.** Remaining: app-flow installs + `SeSlotWriter` + H4/H5 sequencing + 2-phone BLE test, then the explicit flip.