### PR TITLE
feat(offline-bearer): H3 Path-B install shell (accept-enabling reader gated OFF by default)

### DIFF
--- a/crates/dsm-android-anchor/Cargo.toml
+++ b/crates/dsm-android-anchor/Cargo.toml
@@ -10,6 +10,12 @@ description = "On-device glue that installs the DSM Boot Fenced Fused Anchor har
 # rlib for host tests; staticlib/cdylib so the Android build can link the on-device JNI shell (H3).
 crate-type = ["rlib", "staticlib", "cdylib"]
 
+[features]
+# OFF by default. Compiles the ACCEPT-ENABLING receiver-reader install (install.rs) + its JNI
+# trigger. A default build cannot accept offline-bearer value — the reader never even compiles in.
+# The device layer enables this for the 2-phone bench test; the production flip is the owner's call.
+on_device_installs = []
+
 [dependencies]
 # The SDK whose bridge install seams we fill. One-directional: dsm_sdk never depends back on us.
 dsm_sdk = { path = "../../dsm_client/deterministic_state_machine/dsm_sdk" }

--- a/crates/dsm-android-anchor/src/install.rs
+++ b/crates/dsm-android-anchor/src/install.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! H3 device-flow installs: wire the on-device Path-B transport into the running SDK so an
+//! offline-bearer RECEIVER can read the sender's TROPIC01 counter over the live BLE relay, and a
+//! SENDER can service that read from its own Pico.
+//!
+//! Two installs, both onto the process-global bilateral stack:
+//!   1. SENDER side — `set_local_pico(android_usb_pico_transport())` on the bilateral adapter's
+//!      `TropicRelayRouter`, so an inbound `from_receiver` relay frame is forwarded to A's Pico and
+//!      the MISO replied. (Being READABLE is not acceptance.)
+//!   2. RECEIVER side — `install_receiver_anchor(seed, round_trip)`: the reader + verifier-pairing
+//!      deriver. The `round_trip` closure resolves the peer's BLE address, then drives ONE relay
+//!      round-trip through the adapter's router (`round_trip` registers the pending reply + sends
+//!      via `queue_relay_frame`). This is the ACCEPT-ENABLING install: with the reader present AND a
+//!      COMPLETE pin (verifier slot + pinned stpub, from the sender's SeSlotWriter disclosure) AND a
+//!      matching counter, the canonical predicate accepts. It stays fail-closed while any of those
+//!      is absent — in particular the SeSlotWriter is a separate install, so no pin completes yet.
+//!
+//! NOT auto-called from `initDsmSdk`: the reader install is gated behind an explicit device-layer
+//! trigger (bench for the 2-phone test; the production flip is the owner's call).
+
+// The entire module body is Android + accept-enabling-opt-in only; on the host cfg it compiles to
+// nothing, so gate the imports the same way to avoid unused-import warnings.
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+use std::sync::Arc;
+
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+use dsm_anchor_hw_verifier::RelayRoundTrip;
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+use dsm_anchor_verifier::RelayError;
+
+/// Build the receiver `round_trip`: for each raw-SPI transaction, resolve the sender's BLE address
+/// and drive it through the global bilateral adapter's `TropicRelayRouter` over `queue_relay_frame`.
+/// Any missing piece (no manager, unknown address, send/timeout) is a fail-closed `RelayError`.
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+fn adapter_round_trip() -> RelayRoundTrip {
+    use dsm_sdk::bluetooth::bilateral_transport_adapter::BilateralTransportAdapter;
+    use dsm_sdk::bluetooth::get_global_bluetooth_manager;
+
+    Arc::new(move |peer_device_id, commitment, mosi| {
+        Box::pin(async move {
+            let address =
+                dsm_sdk::jni::state::resolve_ble_address(&peer_device_id).ok_or_else(|| {
+                    RelayError::Transport("no BLE address for relay peer (fail-closed)".into())
+                })?;
+            let manager = get_global_bluetooth_manager().ok_or_else(|| {
+                RelayError::Transport("BluetoothManager not registered (fail-closed)".into())
+            })?;
+            let router = Arc::clone(manager.transport_adapter().tropic_relay());
+            router
+                .round_trip(commitment, mosi, move |frame: Vec<u8>| async move {
+                    BilateralTransportAdapter::queue_relay_frame(&address, &frame).await
+                })
+                .await
+        })
+    })
+}
+
+/// Install BOTH Path-B transports onto the global bilateral stack (see module docs). Idempotent-ish:
+/// installing again just replaces the seams. Returns `false` fail-closed if the wallet seed is
+/// unavailable (wallet locked) — nothing is installed in that case.
+///
+/// Android + explicit `on_device_installs` opt-in only. The reader is accept-enabling, so it never
+/// compiles into a default build; the device layer (bench / the owner's flip) enables the feature
+/// and calls this.
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+pub fn install_path_b_transports() -> bool {
+    use dsm_sdk::bluetooth::get_global_bluetooth_manager;
+
+    let seed: [u8; 32] = match dsm_sdk::sdk::recovery_sdk::RecoverySDK::get_cached_wallet_seed()
+        .and_then(|s| {
+            let a: Result<[u8; 32], _> = s.as_slice().try_into();
+            a.ok()
+        }) {
+        Some(s) => s,
+        None => {
+            log::warn!("[anchor-install] wallet seed unavailable — Path-B not installed");
+            return false;
+        }
+    };
+
+    // Sender side: service relay reads from A's local Pico.
+    if let Some(manager) = get_global_bluetooth_manager() {
+        manager
+            .transport_adapter()
+            .tropic_relay()
+            .set_local_pico(Arc::new(crate::usb_pico::android_usb_pico_transport()));
+        log::info!("[anchor-install] local Pico transport set on the bilateral relay router");
+    } else {
+        log::warn!("[anchor-install] no BluetoothManager — local Pico not set");
+        return false;
+    }
+
+    // Receiver side: the ACCEPT-ENABLING reader + verifier-pairing deriver.
+    crate::install_receiver_anchor(seed, adapter_round_trip());
+    log::info!("[anchor-install] RelayCounterReader + verifier deriver installed (Path-B active)");
+    true
+}
+
+/// JNI trigger for the receiver-side + sender-side Path-B install. Returns JNI_TRUE iff both
+/// transports were installed. Present only in `on_device_installs` builds (accept-enabling).
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+#[no_mangle]
+pub extern "system" fn Java_com_dsm_wallet_bridge_Unified_installPathBTransports(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+) -> jni::sys::jboolean {
+    u8::from(install_path_b_transports())
+}

--- a/crates/dsm-android-anchor/src/lib.rs
+++ b/crates/dsm-android-anchor/src/lib.rs
@@ -27,6 +27,7 @@ use dsm_sdk::bridge::{
     SeSlotWriter,
 };
 
+pub mod install;
 pub mod self_test;
 pub mod usb_pico;
 pub use usb_pico::{UsbPicoTransport, UsbTransceive};

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/DsmInitProvider.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/DsmInitProvider.kt
@@ -22,7 +22,11 @@ class DsmInitProvider : ContentProvider() {
 
             // Finally, resolve the class to ensure its static initializers run.
             Class.forName("com.dsm.wallet.bridge.Unified")
-            
+
+            // Cache the app context for the Phone->Pico USB transport (Path-B relay). Cheap + safe:
+            // it only opens the Pico lazily on the first counter read, and accepts no value by itself.
+            context?.let { com.dsm.wallet.bridge.LocalPicoUsb.init(it) }
+
             // Library loaded successfully - clear any previous incompatibility flag
             context?.let {
                 it.getSharedPreferences("dsm_system", android.content.Context.MODE_PRIVATE)

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/state.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/state.rs
@@ -33,6 +33,16 @@ pub fn parse_hex_32(hex: &str) -> Option<[u8; 32]> {
     Some(out)
 }
 
+/// Resolve a peer's current BLE address from its device_id (the reverse of
+/// [`register_ble_address_mapping`]). Used by the Path-B relay round-trip to address the sender.
+/// Returns `None` if the peer has no observed address yet (relay then fails closed).
+pub fn resolve_ble_address(device_id: &[u8; 32]) -> Option<String> {
+    match DEVICE_ID_TO_ADDR.lock() {
+        Ok(map) => map.get(device_id).cloned(),
+        Err(poisoned) => poisoned.into_inner().get(device_id).cloned(),
+    }
+}
+
 /// Register a BLE address mapping for a device_id in the in-memory resolution map.
 /// Called from BLE pairing flow (ble_events.rs) and on every reconnect identity
 /// observation so the map tracks the peer's current RPA.


### PR DESCRIPTION
## What this does

Wires the on-device Path-B relay transport so a live offline-bearer **receiver** can read the sender's TROPIC01 counter over BLE — **without** enabling acceptance in a default build.

New `install` module in the glue crate (`dsm-android-anchor`):
- **`adapter_round_trip()`** — the receiver `RelayRoundTrip`: resolve the peer's BLE address, then drive one relay round-trip through the global bilateral adapter's `TropicRelayRouter` (register the pending reply + send via `queue_relay_frame`). Every missing piece → fail-closed `RelayError`.
- **`install_path_b_transports()`** — sets the local Pico transport on the adapter router (sender services relay reads from its own chip) and installs the `RelayCounterReader` + verifier-pairing deriver (receiver).
- JNI trigger `Java_..._installPathBTransports`.

Plus: `dsm_sdk::jni::state::resolve_ble_address` (reverse device_id→address lookup), and `DsmInitProvider` caches the app context into `LocalPicoUsb` at process start.

## Safety — the accept-enabling install is gated OFF

The receiver-reader install is the step that (with a complete pin + matching counter) makes the canonical predicate accept. So the **entire** module body is `#[cfg(all(target_os = "android", feature = "on_device_installs"))]`, and that cargo feature is **off by default**.

**Proven:** the default arm64 `.so` exports `anchorCounterSelfTest` but **not** `installPathBTransports` — a default build literally cannot accept offline-bearer value (the reader never compiles in). The device layer enables the feature for the 2-phone bench test; wiring it into production init is the owner's explicit flip. (And even with the reader in, acceptance still needs a **complete pin** from the sender's SeSlotWriter disclosure — a separate, not-yet-built install — so the path is fail-closed twice over.)

## Verification

- Glue host 7/7; clippy + fmt clean (default **and** with `on_device_installs`)
- Accept-enabling path cross-compiles for arm64-v8a; default `.so` symbol audit confirms the gate
- `assembleDebug` green; `cargo tree --workspace -i tropic01` → no match

**STILL FAIL-CLOSED. No live claim.** Remaining to live: `SeSlotWriter` on-device impl → enable `on_device_installs` + call the trigger at the bench → 2-phone BLE transfer test → the explicit flip.