### PR TITLE
feat(offline-bearer): fixed DSM verifier key for the SMT-root counter path (one caged slot)

### DIFF
--- a/crates/dsm-anchor-hw-verifier/examples/usb_provision_verifier_slot.rs
+++ b/crates/dsm-anchor-hw-verifier/examples/usb_provision_verifier_slot.rs
@@ -21,7 +21,7 @@
 #[path = "shared/usb.rs"]
 mod usb;
 
-use dsm_anchor_hw_verifier::{derive_pairing_pubkey, derive_pairing_secret_bytes};
+use dsm_anchor_hw_verifier::{dsm_verifier_pairing_pubkey, dsm_verifier_pairing_secret_bytes};
 use dsm_anchor_verifier::RemoteSpiDevice;
 use std::time::{Duration, Instant};
 
@@ -41,11 +41,9 @@ const VERIFIER_SLOT: u16 = 1;
 /// Absolute bit indices of the SH1 (session/slot-1) access bit across the 4 lanes of a UAP register.
 const SH1_BITS: [u8; 4] = [1, 9, 17, 25];
 
-/// Bench-demo B verifier pairing key = the reader's own derivation over a fixed demo (B seed, A
-/// peer). Slot 1 will PERMANENTLY hold this key; a real 2-device run re-provisions a fresh chip/slot
-/// with the real receiver's key. Kept identical to `RelayCounterReader`'s derivation on purpose.
-const B_DEMO_SEED: [u8; 32] = [0xB0; 32];
-const A_DEMO_PEER: [u8; 32] = [0xA0; 32];
+// The verifier pairing key is the FIXED DSM verifier key (the SAME one `RelayCounterReader` opens
+// the session with — the SMT-root counter path uses one caged slot for all relationships). Slot 1
+// PERMANENTLY holds this well-known key; every receiver reads through it.
 
 /// Registers whose SH1 access must be REVOKED. I_CONFIG_WRITE is last so the verifier can never
 /// loosen its own cage; ordering is otherwise cosmetic (we act as SH0, never clearing SH0 bits).
@@ -94,8 +92,8 @@ fn main() {
     }
     let dev = dev.unwrap_or_else(usb::find_port);
 
-    let b_pub = derive_pairing_pubkey(&B_DEMO_SEED, &A_DEMO_PEER);
-    let b_priv = derive_pairing_secret_bytes(&B_DEMO_SEED, &A_DEMO_PEER);
+    let b_pub = dsm_verifier_pairing_pubkey();
+    let b_priv = dsm_verifier_pairing_secret_bytes();
 
     // ---- Plan (printed before ANY write) --------------------------------------------------------
     println!("=== Phase-G verifier-slot provisioning PLAN (bench TROPIC01) ===");

--- a/crates/dsm-anchor-hw-verifier/examples/usb_verify_verifier_slot.rs
+++ b/crates/dsm-anchor-hw-verifier/examples/usb_verify_verifier_slot.rs
@@ -17,7 +17,7 @@ mod usb;
 
 use std::time::{Duration, Instant};
 
-use dsm_anchor_hw_verifier::{derive_pairing_pubkey, derive_pairing_secret_bytes};
+use dsm_anchor_hw_verifier::{dsm_verifier_pairing_pubkey, dsm_verifier_pairing_secret_bytes};
 use dsm_anchor_verifier::RemoteSpiDevice;
 use tropic01::keys::{SH0PRIV_PROD0, SH0PUB_PROD0};
 use tropic01::{Error as TrError, MCounterIndex, StartupReq, Tropic01, X25519Dalek};
@@ -25,8 +25,6 @@ use x25519_dalek::{PublicKey, StaticSecret};
 use zerocopy::little_endian::U16;
 
 const VERIFIER_SLOT: u16 = 1;
-const B_DEMO_SEED: [u8; 32] = [0xB0; 32];
-const A_DEMO_PEER: [u8; 32] = [0xA0; 32];
 
 /// The bench chip's pinned Noise static key (captured by usb_uap_probe / provisioning). Verification
 /// asserts the relay reached THIS chip before trusting anything it reports.
@@ -50,8 +48,8 @@ fn is_unauthorized<A, B>(r: &Result<impl Sized, TrError<A, B>>) -> bool {
 
 fn main() {
     let dev = std::env::args().nth(1).unwrap_or_else(usb::find_port);
-    let b_pub = derive_pairing_pubkey(&B_DEMO_SEED, &A_DEMO_PEER);
-    let b_priv = derive_pairing_secret_bytes(&B_DEMO_SEED, &A_DEMO_PEER);
+    let b_pub = dsm_verifier_pairing_pubkey();
+    let b_priv = dsm_verifier_pairing_secret_bytes();
 
     eprintln!("[verify] port = {dev}");
     let port = usb::open_and_drain(&dev);

--- a/crates/dsm-anchor-hw-verifier/src/lib.rs
+++ b/crates/dsm-anchor-hw-verifier/src/lib.rs
@@ -22,8 +22,8 @@ mod relay_driver;
 mod session;
 
 pub use reader::{
-    derive_pairing_pubkey, derive_pairing_secret_bytes, RelayCounterReader, RelayRoundTrip,
-    SeedPairingDeriver,
+    dsm_verifier_pairing_pubkey, dsm_verifier_pairing_secret_bytes, DsmVerifierPairingDeriver,
+    RelayCounterReader, RelayRoundTrip,
 };
 pub use relay_driver::read_counter_over_relay;
 pub use session::{read_live_counter, VerifierError, VerifierSessionCredential};

--- a/crates/dsm-anchor-hw-verifier/src/reader.rs
+++ b/crates/dsm-anchor-hw-verifier/src/reader.rs
@@ -3,14 +3,14 @@
 //! SDK's [`AnchorCounterReader`] seam by joining the pinned enrollment
 //! ([`FusedAnchorPin`]) to the real libtropic verifier session
 //! ([`read_counter_over_relay`]) over a caller-supplied relay transport, and
-//! [`SeedPairingDeriver`] fills the [`VerifierPairingDeriver`] seam with the SAME per-counterparty
-//! pairing key derivation — so the pubkey B offers in the first-transfer enroll request is, by
+//! [`DsmVerifierPairingDeriver`] fills the [`VerifierPairingDeriver`] seam with the fixed DSM
+//! verifier pubkey — so the pubkey B offers in the first-transfer enroll request is, by
 //! construction, the key its future counter reads authenticate with.
 //!
-//! Key handling follows the DSM idiom: nothing is persisted. B's X25519 verifier pairing keypair
-//! is re-derived at use time from B's identity seed + the counterparty device id
-//! (`BLAKE3("DSM/anchor/verifier-pairing/v1" ‖ seed ‖ peer)`), and the handshake ephemeral is
-//! fresh CSPRNG per session.
+//! Key handling: the verifier pairing keypair is a FIXED, well-known DSM constant
+//! (`dsm_verifier_pairing_secret_bytes` — see the SMT-root-counter rationale there), the same on
+//! every device, so a SINGLE caged read-only slot serves every counterparty. Nothing is persisted;
+//! the handshake ephemeral is fresh CSPRNG per session.
 //!
 //! Fail-closed: an INCOMPLETE pin (no verifier slot, no pinned chip static key, or a compromised
 //! anchor) returns `None` WITHOUT touching the transport — mirroring the SDK-side
@@ -44,42 +44,47 @@ pub type RelayRoundTrip = Arc<
         + Sync,
 >;
 
-/// The raw 32-byte seed for B's per-counterparty verifier pairing key, before the X25519 clamp.
-/// Single source of truth for the derivation (the reader, the deriver, and hardware provisioning
-/// tooling all go through here). `#[doc(hidden)]`: device-layer/bring-up use only.
+/// The raw 32-byte secret of the FIXED, well-known DSM verifier pairing keypair, before the X25519
+/// clamp. Single source of truth (the reader, the deriver, and hardware provisioning tooling all go
+/// through here). `#[doc(hidden)]`: device-layer/bring-up use only.
+///
+/// Rationale — the SMT-root counter path: the verifier slot exposes the physical monotonic counter
+/// that advances along the device's SMT-root state-transition path — the compressed correctness
+/// point for ALL relationships — so a SINGLE caged read-only slot serves every counterparty. There
+/// is no per-relationship pairing key; the per-receiver binding is the pinned chip identity (stpub)
+/// + the SMT proof under the committed root + the DSM transition predicate (`H == H0 − (u_i+1)`),
+/// none of which use this session key. The session may only READ the counter (the slot is caged to
+/// MCOUNTER_GET), so the secret being well-known grants nothing more. This also sidesteps the hard
+/// 3-slot pairing budget (`PAIRING_KEY_SLOT_MAX = 3`) that per-relationship keying would exhaust.
+/// Derived by domain separation so it is fixed, documented, and reproducible on every device.
 #[doc(hidden)]
-pub fn derive_pairing_secret_bytes(seed: &[u8; 32], peer_device_id: &[u8; 32]) -> [u8; 32] {
-    let mut buf = [0u8; 64];
-    buf[..32].copy_from_slice(seed);
-    buf[32..].copy_from_slice(peer_device_id);
-    dsm::crypto::blake3::domain_hash_bytes("DSM/anchor/verifier-pairing/v1", &buf)
+pub fn dsm_verifier_pairing_secret_bytes() -> [u8; 32] {
+    dsm::crypto::blake3::domain_hash_bytes("DSM/anchor/verifier-pairing/well-known/v1", &[])
 }
 
-/// Derive B's per-counterparty X25519 verifier pairing SECRET from B's identity seed. Deterministic
-/// (re-derivable after restore, nothing persisted) and per-peer (a compromise of one pairing key
-/// never crosses relationships). `StaticSecret::from` applies the X25519 clamp.
-fn derive_pairing_secret(seed: &[u8; 32], peer_device_id: &[u8; 32]) -> StaticSecret {
-    StaticSecret::from(derive_pairing_secret_bytes(seed, peer_device_id))
+/// The fixed DSM verifier pairing SECRET (X25519-clamped). Same on every device.
+fn dsm_verifier_pairing_secret() -> StaticSecret {
+    StaticSecret::from(dsm_verifier_pairing_secret_bytes())
 }
 
-/// The pairing PUBLIC key for `derive_pairing_secret` — what B offers in the enroll request and
-/// what A provisions into the read-only verifier slot.
-pub fn derive_pairing_pubkey(seed: &[u8; 32], peer_device_id: &[u8; 32]) -> [u8; 32] {
-    PublicKey::from(&derive_pairing_secret(seed, peer_device_id)).to_bytes()
+/// The public half of the fixed DSM verifier keypair — provisioned once into the caged verifier slot
+/// and offered (redundantly, since it is well-known) in the first-transfer enroll request.
+pub fn dsm_verifier_pairing_pubkey() -> [u8; 32] {
+    PublicKey::from(&dsm_verifier_pairing_secret()).to_bytes()
 }
 
 /// Fills `dsm_sdk`'s [`AnchorCounterReader`] seam: B's real Path-B counter read over the relay.
 /// Install on-device via `dsm_sdk::bridge::install_anchor_counter_reader`.
 pub struct RelayCounterReader {
-    seed: [u8; 32],
     transport: RelayRoundTrip,
 }
 
 impl RelayCounterReader {
-    /// `seed` is B's identity seed root for pairing-key derivation; `transport` performs one relay
-    /// round-trip to the sender's Pico (B -> A -> Pico A -> A -> B).
-    pub fn new(seed: [u8; 32], transport: RelayRoundTrip) -> Self {
-        Self { seed, transport }
+    /// `transport` performs one relay round-trip to the sender's Pico (B -> A -> Pico A -> A -> B).
+    /// The verifier pairing key is the fixed DSM keypair (see [`dsm_verifier_pairing_secret_bytes`]),
+    /// so no per-relationship seed is needed.
+    pub fn new(transport: RelayRoundTrip) -> Self {
+        Self { transport }
     }
 }
 
@@ -102,7 +107,7 @@ impl AnchorCounterReader for RelayCounterReader {
             }
         };
 
-        let sh_priv = derive_pairing_secret(&self.seed, &peer_device_id);
+        let sh_priv = dsm_verifier_pairing_secret();
         let cred = VerifierSessionCredential {
             slot,
             sh_pub: PublicKey::from(&sh_priv).to_bytes(),
@@ -132,22 +137,22 @@ impl AnchorCounterReader for RelayCounterReader {
     }
 }
 
-/// Fills `dsm_sdk`'s [`VerifierPairingDeriver`] seam with the SAME derivation the reader uses, so
-/// the enroll-request pubkey and the read-time keypair can never diverge. Install on-device via
+/// Fills `dsm_sdk`'s [`VerifierPairingDeriver`] seam with the fixed DSM verifier pubkey the reader
+/// authenticates with, so the enroll-request pubkey and the read-time keypair can never diverge.
+/// Peer-independent (one caged slot serves all relationships). Install on-device via
 /// `dsm_sdk::bridge::install_verifier_pairing_deriver`.
-pub struct SeedPairingDeriver {
-    seed: [u8; 32],
-}
+#[derive(Default)]
+pub struct DsmVerifierPairingDeriver;
 
-impl SeedPairingDeriver {
-    pub fn new(seed: [u8; 32]) -> Self {
-        Self { seed }
+impl DsmVerifierPairingDeriver {
+    pub fn new() -> Self {
+        Self
     }
 }
 
-impl VerifierPairingDeriver for SeedPairingDeriver {
-    fn verifier_pairing_pubkey(&self, peer_device_id: [u8; 32]) -> Option<[u8; 32]> {
-        Some(derive_pairing_pubkey(&self.seed, &peer_device_id))
+impl VerifierPairingDeriver for DsmVerifierPairingDeriver {
+    fn verifier_pairing_pubkey(&self, _peer_device_id: [u8; 32]) -> Option<[u8; 32]> {
+        Some(dsm_verifier_pairing_pubkey())
     }
 }
 
@@ -182,7 +187,7 @@ mod tests {
     #[tokio::test]
     async fn incomplete_or_compromised_pin_returns_none_without_touching_the_transport() {
         let (transport, calls) = counting_dead_transport();
-        let reader = RelayCounterReader::new([0x42; 32], transport);
+        let reader = RelayCounterReader::new(transport);
         for p in [
             pin(None, None, true),                 // pre-HW admit shape
             pin(Some(2), None, true),              // slot without pinned chip identity
@@ -202,7 +207,7 @@ mod tests {
     #[tokio::test]
     async fn complete_pin_reaches_the_transport_and_a_dead_relay_fails_closed() {
         let (transport, calls) = counting_dead_transport();
-        let reader = RelayCounterReader::new([0x42; 32], transport);
+        let reader = RelayCounterReader::new(transport);
         let h = reader
             .read_counter([0x11; 32], [0x22; 32], pin(Some(2), Some([0xCC; 32]), true))
             .await;
@@ -214,23 +219,28 @@ mod tests {
     }
 
     #[test]
-    fn enroll_request_pubkey_and_read_time_keypair_are_the_same_derivation() {
-        let seed = [0x42; 32];
-        let peer = [0x11; 32];
-        let deriver = SeedPairingDeriver::new(seed);
-        let offered = deriver.verifier_pairing_pubkey(peer).expect("pubkey");
-        // The reader derives its session keypair from the same seed+peer: the pubkeys must match.
-        let session_pub = PublicKey::from(&derive_pairing_secret(&seed, &peer)).to_bytes();
+    fn enroll_request_pubkey_and_read_time_keypair_are_the_fixed_verifier_key() {
+        // The pubkey B offers in the enroll request is the fixed verifier pubkey, and it is the
+        // public half of the exact secret the reader opens the session with — they cannot diverge.
+        let offered = DsmVerifierPairingDeriver::new()
+            .verifier_pairing_pubkey([0x11; 32])
+            .expect("pubkey");
+        let session_pub = PublicKey::from(&dsm_verifier_pairing_secret()).to_bytes();
         assert_eq!(offered, session_pub);
-        assert_eq!(offered, derive_pairing_pubkey(&seed, &peer));
+        assert_eq!(offered, dsm_verifier_pairing_pubkey());
     }
 
     #[test]
-    fn pairing_keys_are_per_peer_and_per_seed() {
-        let a = derive_pairing_pubkey(&[0x42; 32], &[0x11; 32]);
-        let b = derive_pairing_pubkey(&[0x42; 32], &[0x12; 32]);
-        let c = derive_pairing_pubkey(&[0x43; 32], &[0x11; 32]);
-        assert_ne!(a, b, "different peers must get different pairing keys");
-        assert_ne!(a, c, "different seeds must get different pairing keys");
+    fn verifier_pairing_key_is_fixed_across_peers() {
+        // One caged slot serves all relationships: the offered pubkey is identical regardless of the
+        // counterparty (the per-receiver binding is the pin/SMT/predicate, not this key).
+        let d = DsmVerifierPairingDeriver::new();
+        assert_eq!(
+            d.verifier_pairing_pubkey([0x11; 32]),
+            d.verifier_pairing_pubkey([0x12; 32]),
+            "the verifier pairing key must not depend on the counterparty"
+        );
+        // And it is stable across calls (a well-known protocol constant).
+        assert_eq!(dsm_verifier_pairing_pubkey(), dsm_verifier_pairing_pubkey());
     }
 }

--- a/crates/dsm-android-anchor/src/install.rs
+++ b/crates/dsm-android-anchor/src/install.rs
@@ -7,13 +7,14 @@
 //!   1. SENDER side — `set_local_pico(android_usb_pico_transport())` on the bilateral adapter's
 //!      `TropicRelayRouter`, so an inbound `from_receiver` relay frame is forwarded to A's Pico and
 //!      the MISO replied. (Being READABLE is not acceptance.)
-//!   2. RECEIVER side — `install_receiver_anchor(seed, round_trip)`: the reader + verifier-pairing
-//!      deriver. The `round_trip` closure resolves the peer's BLE address, then drives ONE relay
-//!      round-trip through the adapter's router (`round_trip` registers the pending reply + sends
-//!      via `queue_relay_frame`). This is the ACCEPT-ENABLING install: with the reader present AND a
-//!      COMPLETE pin (verifier slot + pinned stpub, from the sender's SeSlotWriter disclosure) AND a
-//!      matching counter, the canonical predicate accepts. It stays fail-closed while any of those
-//!      is absent — in particular the SeSlotWriter is a separate install, so no pin completes yet.
+//!   2. RECEIVER side — `install_receiver_anchor(round_trip)`: the reader + verifier-pairing deriver
+//!      (fixed DSM verifier key — no seed). The `round_trip` closure resolves the peer's BLE address,
+//!      then drives ONE relay round-trip through the adapter's router (`round_trip` registers the
+//!      pending reply + sends via `queue_relay_frame`). This is the ACCEPT-ENABLING install: with the
+//!      reader present AND a COMPLETE pin (verifier slot + pinned stpub, from the sender's
+//!      SeSlotWriter disclosure) AND a matching counter, the canonical predicate accepts. It stays
+//!      fail-closed while any is absent — in particular the SeSlotWriter is a separate install, so no
+//!      pin completes yet.
 //!
 //! NOT auto-called from `initDsmSdk`: the reader install is gated behind an explicit device-layer
 //! trigger (bench for the 2-phone test; the production flip is the owner's call).
@@ -56,8 +57,8 @@ fn adapter_round_trip() -> RelayRoundTrip {
 }
 
 /// Install BOTH Path-B transports onto the global bilateral stack (see module docs). Idempotent-ish:
-/// installing again just replaces the seams. Returns `false` fail-closed if the wallet seed is
-/// unavailable (wallet locked) — nothing is installed in that case.
+/// installing again just replaces the seams. Returns `false` fail-closed if the BluetoothManager is
+/// not yet registered — nothing is installed in that case.
 ///
 /// Android + explicit `on_device_installs` opt-in only. The reader is accept-enabling, so it never
 /// compiles into a default build; the device layer (bench / the owner's flip) enables the feature
@@ -66,32 +67,19 @@ fn adapter_round_trip() -> RelayRoundTrip {
 pub fn install_path_b_transports() -> bool {
     use dsm_sdk::bluetooth::get_global_bluetooth_manager;
 
-    let seed: [u8; 32] = match dsm_sdk::sdk::recovery_sdk::RecoverySDK::get_cached_wallet_seed()
-        .and_then(|s| {
-            let a: Result<[u8; 32], _> = s.as_slice().try_into();
-            a.ok()
-        }) {
-        Some(s) => s,
-        None => {
-            log::warn!("[anchor-install] wallet seed unavailable — Path-B not installed");
-            return false;
-        }
-    };
-
     // Sender side: service relay reads from A's local Pico.
-    if let Some(manager) = get_global_bluetooth_manager() {
-        manager
-            .transport_adapter()
-            .tropic_relay()
-            .set_local_pico(Arc::new(crate::usb_pico::android_usb_pico_transport()));
-        log::info!("[anchor-install] local Pico transport set on the bilateral relay router");
-    } else {
-        log::warn!("[anchor-install] no BluetoothManager — local Pico not set");
+    let Some(manager) = get_global_bluetooth_manager() else {
+        log::warn!("[anchor-install] no BluetoothManager — Path-B not installed");
         return false;
-    }
+    };
+    manager
+        .transport_adapter()
+        .tropic_relay()
+        .set_local_pico(Arc::new(crate::usb_pico::android_usb_pico_transport()));
+    log::info!("[anchor-install] local Pico transport set on the bilateral relay router");
 
-    // Receiver side: the ACCEPT-ENABLING reader + verifier-pairing deriver.
-    crate::install_receiver_anchor(seed, adapter_round_trip());
+    // Receiver side: the ACCEPT-ENABLING reader + verifier-pairing deriver (fixed key, no seed).
+    crate::install_receiver_anchor(adapter_round_trip());
     log::info!("[anchor-install] RelayCounterReader + verifier deriver installed (Path-B active)");
     true
 }

--- a/crates/dsm-android-anchor/src/lib.rs
+++ b/crates/dsm-android-anchor/src/lib.rs
@@ -21,7 +21,7 @@
 
 use std::sync::Arc;
 
-use dsm_anchor_hw_verifier::{RelayCounterReader, RelayRoundTrip, SeedPairingDeriver};
+use dsm_anchor_hw_verifier::{DsmVerifierPairingDeriver, RelayCounterReader, RelayRoundTrip};
 use dsm_sdk::bridge::{
     install_anchor_counter_reader, install_se_slot_writer, install_verifier_pairing_deriver,
     SeSlotWriter,
@@ -32,19 +32,20 @@ pub mod self_test;
 pub mod usb_pico;
 pub use usb_pico::{UsbPicoTransport, UsbTransceive};
 
-/// Install the RECEIVER-side anchor impls, both derived from B's wallet seed (nothing persisted):
+/// Install the RECEIVER-side anchor impls (nothing persisted; the verifier pairing key is the fixed
+/// DSM constant, so no seed is needed):
 /// - [`RelayCounterReader`] — B opens its own authenticated libtropic session to the sender's
 ///   TROPIC01 over the relay and reads the live counter `H`. `round_trip` is the device-layer BLE
 ///   bridge carrying one raw-SPI transaction B -> A -> Pico A -> A -> B (H3 supplies it, wrapping
 ///   `TropicRelayRouter::round_trip` + `queue_relay_frame`).
-/// - [`SeedPairingDeriver`] — B's per-counterparty X25519 verifier pairing pubkey it offers in the
-///   first-transfer enroll request; the SAME derivation the reader authenticates with.
+/// - [`DsmVerifierPairingDeriver`] — the fixed DSM verifier pubkey B offers in the first-transfer
+///   enroll request; the SAME key the reader authenticates with (one caged slot serves all peers).
 ///
 /// Until this runs, `dsm_sdk`'s counter reader is absent and every offline-bearer transfer recovers
 /// online. The reader itself still fail-closes on an incomplete pin (no verifier slot / chip key).
-pub fn install_receiver_anchor(wallet_seed: [u8; 32], round_trip: RelayRoundTrip) {
-    install_anchor_counter_reader(Arc::new(RelayCounterReader::new(wallet_seed, round_trip)));
-    install_verifier_pairing_deriver(Arc::new(SeedPairingDeriver::new(wallet_seed)));
+pub fn install_receiver_anchor(round_trip: RelayRoundTrip) {
+    install_anchor_counter_reader(Arc::new(RelayCounterReader::new(round_trip)));
+    install_verifier_pairing_deriver(Arc::new(DsmVerifierPairingDeriver::new()));
 }
 
 /// Install the SENDER-side SE verifier-slot provisioner: on a first-transfer enroll request, A
@@ -99,7 +100,7 @@ mod tests {
         assert!(dsm_sdk::bridge::verifier_pairing_deriver().is_none());
         assert!(dsm_sdk::bridge::se_slot_writer().is_none());
 
-        install_receiver_anchor([0xB0; 32], dead_round_trip());
+        install_receiver_anchor(dead_round_trip());
         install_sender_slot_writer(Arc::new(NoopSlotWriter));
 
         assert!(dsm_sdk::bridge::anchor_counter_reader().is_some());

--- a/crates/dsm-android-anchor/src/self_test.rs
+++ b/crates/dsm-android-anchor/src/self_test.rs
@@ -6,10 +6,11 @@
 //! the REAL Phone->Pico USB transport proven in H2. The ONLY substitutions vs production are the
 //! loopback `round_trip` (in-process instead of BLE — the H4 seam) and the demo pin below.
 //!
-//! Bench-only wiring: the demo verifier identity (`B_DEMO_SEED`/`A_DEMO_PEER`) is the pairing key
-//! Phase G burned into the bench chip's READ-ONLY verifier slot 1, and `KNOWN_BENCH_STPUB` is that
-//! chip's pinned Noise static key (anti-substitution). A full production pin comes from the
-//! first-transfer enroll/disclosure flow instead. Expected result on the bench chip: `H = 1000`.
+//! Bench-only wiring: the reader authenticates with the FIXED DSM verifier key, so the bench chip's
+//! verifier slot must hold `dsm_verifier_pairing_pubkey()` (a fresh chip/slot provisioned with the
+//! fixed key — see `usb_provision_verifier_slot`). `KNOWN_BENCH_STPUB` is that chip's pinned Noise
+//! static key (anti-substitution). A full production pin comes from the first-transfer enroll/
+//! disclosure flow instead. Expected result on a provisioned bench chip: `H = 1000`.
 
 use std::sync::Arc;
 
@@ -19,9 +20,8 @@ use dsm_sdk::bluetooth::tropic_relay::{
     AnchorCounterReader, LocalPicoTransport, TropicRelayRouter,
 };
 
-/// Phase-G demo verifier identity: the bench chip's slot-1 pairing key is
-/// `derive_pairing_pubkey(B_DEMO_SEED, A_DEMO_PEER)` (see `usb_provision_verifier_slot`).
-const B_DEMO_SEED: [u8; 32] = [0xB0; 32];
+/// A dummy peer device id — for the loopback it only labels the relay round-trip (the verifier
+/// pairing key is the fixed DSM constant, independent of the peer).
 const A_DEMO_PEER: [u8; 32] = [0xA0; 32];
 
 /// The bench chip's pinned Noise static key (captured at provisioning; asserted by
@@ -75,7 +75,7 @@ fn loopback_round_trip(router: Arc<TropicRelayRouter>) -> RelayRoundTrip {
 pub async fn demo_counter_read_via_local_pico(pico: Arc<dyn LocalPicoTransport>) -> Option<u32> {
     let router = Arc::new(TropicRelayRouter::new());
     router.set_local_pico(pico);
-    let reader = RelayCounterReader::new(B_DEMO_SEED, loopback_round_trip(router));
+    let reader = RelayCounterReader::new(loopback_round_trip(router));
     // Any 32-byte correlation id works for the single in-process exchange.
     let commitment = [0x5Eu8; 32];
     reader


### PR DESCRIPTION
## The model

The TROPIC01 monotonic counter is the **physical progression witness for the device's SMT-root state-transition path** — the compressed correctness point for *all* relationships. So **one caged read-only verifier slot, provisioned once with a fixed well-known DSM verifier keypair, serves every counterparty.**

There is no per-relationship key. The per-receiver binding is:
1. the pinned chip identity (`stpub`, anti-substitution),
2. the live counter,
3. the SMT proof under the committed root,
4. the DSM transition predicate (`H == H0 − (u_i+1)`).

None of those use the session pairing key — the session may only **read** the monotonic counter (the slot is caged to `MCOUNTER_GET`), so a well-known secret grants nothing more. This also sidesteps the hard **3-slot pairing budget** (`PAIRING_KEY_SLOT_MAX = 3`) that per-relationship keying would permanently exhaust after 3 counterparties.

## Changes

- **`reader.rs`**: `dsm_verifier_pairing_secret_bytes/_pubkey()` — a fixed keypair, domain-derived (`BLAKE3 "DSM/anchor/verifier-pairing/well-known/v1"`), reproducible on every device. `RelayCounterReader` and `DsmVerifierPairingDeriver` (was `SeedPairingDeriver`) drop the seed. Tests: the offered enroll pubkey **equals** the reader's session secret's pubkey; the key is identical across peers and stable across calls.
- **`dsm-android-anchor`**: `install_receiver_anchor(round_trip)` drops the wallet-seed arg; `install_path_b_transports` no longer fetches the seed; self-test uses the fixed-key reader.
- **Bench tools** provision/verify slot 1 with the fixed key.

## Verification

- hw-verifier 6/6 (incl. two new fixed-key tests) + examples build
- glue 7/7; clippy + fmt clean (default **and** `on_device_installs`); default + feature cross-compile for arm64-v8a
- `cargo tree --workspace -i tropic01` → no match

**Still fail-closed, no live claim.** Note: the current demo-keyed bench chip (slot 1) must be re-provisioned on a fresh chip/slot with the fixed key before the H3 hardware self-test passes again.