### PR TITLE
feat(offline-bearer): SeSlotWriter — caged DSM SMT-root verifier slot (read/burn split, gated off)

### DIFF
--- a/crates/dsm-anchor-hw-verifier/Cargo.toml
+++ b/crates/dsm-anchor-hw-verifier/Cargo.toml
@@ -21,11 +21,12 @@ tokio = { version = "1", default-features = false, features = ["sync", "rt", "rt
 dsm_sdk = { path = "../../dsm_client/deterministic_state_machine/dsm_sdk" }
 dsm = { path = "../../dsm_client/deterministic_state_machine/dsm" }
 log = "0.4"
+# The verifier-slot provisioner constructs the U16 config-register addresses (same zerocopy major as
+# tropic01).
+zerocopy = { version = "0.8", default-features = false }
 
 [dev-dependencies]
 # Hardware bring-up proof (examples/usb_counter_read.rs): drive a real TROPIC01 counter read over
 # the USB-CDC raw-SPI passthrough. dsm-anchor-core supplies the ApplianceRequest/Response codec.
 dsm-anchor-core = { path = "../dsm-anchor-core" }
 serialport = "4"
-# UAP probe example constructs the U16 config addresses (same zerocopy major as tropic01).
-zerocopy = { version = "0.8", default-features = false }

--- a/crates/dsm-anchor-hw-verifier/src/lib.rs
+++ b/crates/dsm-anchor-hw-verifier/src/lib.rs
@@ -17,10 +17,14 @@
 // production; production code in this crate does not use them).
 #![cfg_attr(test, allow(clippy::disallowed_methods))]
 
+mod provisioner;
 mod reader;
 mod relay_driver;
 mod session;
 
+pub use provisioner::{
+    commit_verifier_slot, read_verifier_slot, ProvisionError, VerifierSlotState, VERIFIER_SLOT,
+};
 pub use reader::{
     dsm_verifier_pairing_pubkey, dsm_verifier_pairing_secret_bytes, DsmVerifierPairingDeriver,
     RelayCounterReader, RelayRoundTrip,

--- a/crates/dsm-anchor-hw-verifier/src/provisioner.rs
+++ b/crates/dsm-anchor-hw-verifier/src/provisioner.rs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The DSM SMT-root verifier slot: read + (gated) provision the ONE caged read-only counter slot on
+//! a TROPIC01, over any [`SpiRelayChannel`]. Factored channel-generic from the exact write -> cage
+//! -> reboot -> verify sequence the bench CLIs (`usb_provision_verifier_slot` /
+//! `usb_verify_verifier_slot`) proved on hardware in Phase G, so the on-device SeSlotWriter runs the
+//! same proven steps over the Phone->Pico USB relay.
+//!
+//! Slot map (fixed, never negotiated):
+//! ```text
+//! slot 0     = owner/admin host session (PROD0)
+//! slot 1     = the fixed DSM SMT-root verifier slot
+//! slots 2/3  = RESERVED — never allocated, never a fallback
+//! ```
+//! One caged slot serves every relationship: the verifier pairing key is the fixed DSM constant
+//! (see [`dsm_verifier_pairing_secret_bytes`]); the per-receiver binding is the pinned chip identity
+//! + the SMT proof + the DSM predicate, not this session key.
+//!
+//! [`read_verifier_slot`] is NON-DESTRUCTIVE (the transfer path uses it). [`commit_verifier_slot`]
+//! performs the IRREVERSIBLE burn and must only ever run under an explicit setup/commit gate — never
+//! as a side effect of app boot. It refuses to overwrite a non-empty slot (an old demo/per-
+//! relationship key fails closed), so it can never clobber existing key material.
+
+use std::time::{Duration, Instant};
+
+use dsm_anchor_verifier::{RemoteSpiDevice, SpiRelayChannel};
+use tropic01::keys::{SH0PRIV_PROD0, SH0PUB_PROD0};
+use tropic01::{Error as TrError, MCounterIndex, StartupReq, Tropic01, X25519Dalek};
+use x25519_dalek::{PublicKey, StaticSecret};
+use zerocopy::little_endian::U16;
+
+use crate::reader::{dsm_verifier_pairing_pubkey, dsm_verifier_pairing_secret_bytes};
+
+/// The fixed DSM SMT-root verifier slot. NEVER slot 0 (host) and NEVER slots 2/3 (reserved).
+pub const VERIFIER_SLOT: u16 = 1;
+
+/// Absolute bit indices of the SH1 (slot-1) access bit across the 4 lanes of a UAP register.
+const SH1_BITS: [u8; 4] = [1, 9, 17, 25];
+
+/// Registers whose SH1 access is REVOKED to cage the verifier slot to MCOUNTER_GET only.
+/// `I_CONFIG_WRITE` (0x040) is LAST so the sweep cannot lock out the writes that build the cage, and
+/// so the caged slot can never loosen its own cage afterward.
+const DENY: &[u16] = &[
+    0x020, // PAIRING_KEY_WRITE
+    0x024, // PAIRING_KEY_READ
+    0x028, // PAIRING_KEY_INVALIDATE
+    0x030, // R_CONFIG_WRITE_ERASE
+    0x110, // R_MEM_DATA_WRITE
+    0x114, // R_MEM_DATA_READ
+    0x118, // R_MEM_DATA_ERASE
+    0x130, // ECC_KEY_GENERATE
+    0x134, // ECC_KEY_STORE
+    0x138, // ECC_KEY_READ
+    0x13C, // ECC_KEY_ERASE
+    0x140, // ECDSA_SIGN
+    0x144, // EDDSA_SIGN
+    0x150, // MCOUNTER_INIT
+    0x158, // MCOUNTER_UPDATE
+    0x160, // MAC_AND_DESTROY
+    0x040, // I_CONFIG_WRITE — LAST
+];
+
+/// Registers left at factory (SH1 keeps access): the counter read + harmless reads.
+const ALLOW_FACTORY_OPEN: &[u16] = &[
+    0x154, // MCOUNTER_GET (needed)
+    0x100, // PING
+    0x120, // RANDOM_VALUE_GET
+    0x034, // R_CONFIG_READ
+    0x044, // I_CONFIG_READ
+];
+
+/// The security-critical writes whose SH1 access MUST be revoked for the slot to count as caged
+/// (the exact set the Phase-G verify tool proved). Checked NON-destructively via `i_config_read`.
+const CAGE_CHECK: &[u16] = &[
+    0x020, // PAIRING_KEY_WRITE
+    0x040, // I_CONFIG_WRITE (self-cage-lock)
+    0x150, // MCOUNTER_INIT
+    0x158, // MCOUNTER_UPDATE
+    0x160, // MAC_AND_DESTROY
+];
+
+/// SH1 access mask across the 4 UAP lanes (bits {1,9,17,25}); zero means SH1 is denied that command.
+const SH1_MASK: u32 = 0x0202_0202;
+
+/// Non-destructive state of the verifier slot.
+pub enum VerifierSlotState {
+    /// Slot 1 holds the fixed DSM verifier key AND is correctly caged read-only. Ready to use:
+    /// disclose `(VERIFIER_SLOT, stpub)`.
+    Provisioned { stpub: [u8; 32] },
+    /// Slot 1 is empty — provisioning MAY proceed, but ONLY under an explicit commit gate.
+    Empty { stpub: [u8; 32] },
+    /// Slot 1 holds a NON-fixed key, or the fixed key without the correct cage (e.g. an old
+    /// demo/per-relationship key, or a half-finished provision). FAIL CLOSED: never overwrite,
+    /// never disclose.
+    Occupied,
+}
+
+/// Provisioning / read errors. All map to fail-closed at the SeSlotWriter boundary.
+#[derive(Debug)]
+pub enum ProvisionError {
+    /// The relay/chip transport failed (session, SPI, or a libtropic op).
+    Chip(String),
+    /// A precondition for the irreversible burn did not hold (slot not empty, UAP not factory-open,
+    /// counter unreadable). Nothing was written.
+    Precondition(String),
+    /// The post-burn cage verification did not match the required MCOUNTER_GET-only surface.
+    CageVerify(String),
+    /// CSPRNG unavailable for a handshake ephemeral.
+    Rng,
+}
+
+fn fresh_ephemeral() -> Result<StaticSecret, ProvisionError> {
+    let b: [u8; 32] = dsm::crypto::rng::random_bytes(32)
+        .try_into()
+        .map_err(|_| ProvisionError::Rng)?;
+    Ok(StaticSecret::from(b))
+}
+
+fn is_unauthorized<A, B>(r: &Result<impl Sized, TrError<A, B>>) -> bool {
+    matches!(r, Err(TrError::Unauthorized))
+}
+
+/// Read the verifier slot's state WITHOUT writing anything (strictly read-only — safe on the
+/// transfer path and at boot). Opens the host slot-0 session, reads slot 1's pairing key, and — if
+/// it is the fixed key — confirms the cage via `i_config_read` of the security-critical registers
+/// (SH1 access bits cleared). No slot-1 session and no write is attempted, so this can never mutate
+/// or provision. The chip type is left inferred (it is parameterized by `dummy_pin::DummyPin`, a
+/// tropic01 internal we do not name).
+pub fn read_verifier_slot<C: SpiRelayChannel>(
+    channel: C,
+) -> Result<VerifierSlotState, ProvisionError> {
+    let mut chip = Tropic01::new(RemoteSpiDevice::new(channel));
+    let stpub = *chip
+        .get_info_cert_store()
+        .map_err(|e| ProvisionError::Chip(format!("get_info_cert_store: {e:?}")))?
+        .public_key()
+        .map_err(|e| ProvisionError::Chip(format!("cert public_key: {e:?}")))?;
+    let fixed_pub = dsm_verifier_pairing_pubkey();
+
+    let eh = fresh_ephemeral()?;
+    let mut s0 = chip
+        .session_start(
+            &X25519Dalek,
+            PublicKey::from(SH0PUB_PROD0),
+            StaticSecret::from(SH0PRIV_PROD0),
+            PublicKey::from(&eh),
+            eh,
+            0,
+        )
+        .map_err(|(_, e)| ProvisionError::Chip(format!("slot-0 session_start: {e:?}")))?;
+
+    let slot1 = s0.pairing_key_read(U16::new(VERIFIER_SLOT)).map(|k| *k);
+    // Only the specific `SlotEmpty` status means an unwritten slot. ANY other error (transport,
+    // session, hardware) is ambiguous and must NOT be classified as Empty — that would let a commit
+    // proceed to a burn on a slot whose emptiness was never confirmed. Propagate it as a Chip error
+    // (fail-closed at the caller). The cage check needs `s0`, so classify before aborting.
+    let result: Result<VerifierSlotState, ProvisionError> = match slot1 {
+        Err(TrError::SlotEmpty) => Ok(VerifierSlotState::Empty { stpub }),
+        Err(e) => Err(ProvisionError::Chip(format!(
+            "pairing_key_read slot {VERIFIER_SLOT}: {e:?}"
+        ))),
+        // A key is present: it must be EXACTLY the fixed key, and the cage must be configured.
+        Ok(k) if k == fixed_pub => {
+            // Pure-read cage check: every security-critical register must have SH1 access cleared.
+            let caged = CAGE_CHECK.iter().all(
+                |addr| matches!(s0.i_config_read(U16::new(*addr)), Ok(v) if v & SH1_MASK == 0),
+            );
+            if caged {
+                Ok(VerifierSlotState::Provisioned { stpub })
+            } else {
+                // Fixed key but not (fully) caged = half-provisioned; fail closed (re-commit re-cages).
+                Ok(VerifierSlotState::Occupied)
+            }
+        }
+        // Any other key (e.g. an old demo/per-relationship key) — never overwrite, never disclose.
+        Ok(_) => Ok(VerifierSlotState::Occupied),
+    };
+    // Abort the slot-0 session on every path (before surfacing an error).
+    s0.session_abort()
+        .map_err(|(_, e)| ProvisionError::Chip(format!("slot-0 abort: {e:?}")))?;
+    result
+}
+
+/// Provision the verifier slot — the IRREVERSIBLE burn. MUST be called only under an explicit
+/// setup/commit gate. Idempotent when already provisioned; refuses (fail-closed) to overwrite any
+/// non-empty slot. `make_channel` mints a fresh relay channel per session (the non-destructive
+/// classification read and the burn each need their own).
+pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
+    make_channel: F,
+) -> Result<(u8, [u8; 32]), ProvisionError> {
+    // 1) Classify the slot non-destructively first.
+    match read_verifier_slot(make_channel())? {
+        VerifierSlotState::Provisioned { stpub } => return Ok((VERIFIER_SLOT as u8, stpub)),
+        VerifierSlotState::Occupied => {
+            return Err(ProvisionError::Precondition(
+                "slot 1 is occupied by a non-fixed key or is not caged; refusing to overwrite"
+                    .into(),
+            ))
+        }
+        VerifierSlotState::Empty { .. } => {}
+    }
+
+    // 2) Empty -> burn, on a fresh channel/session.
+    let fixed_pub = dsm_verifier_pairing_pubkey();
+    let fixed_priv = dsm_verifier_pairing_secret_bytes();
+    let mut chip = Tropic01::new(RemoteSpiDevice::new(make_channel()));
+    let stpub = *chip
+        .get_info_cert_store()
+        .map_err(|e| ProvisionError::Chip(format!("get_info_cert_store: {e:?}")))?
+        .public_key()
+        .map_err(|e| ProvisionError::Chip(format!("cert public_key: {e:?}")))?;
+
+    let eh = fresh_ephemeral()?;
+    let mut s0 = chip
+        .session_start(
+            &X25519Dalek,
+            PublicKey::from(SH0PUB_PROD0),
+            StaticSecret::from(SH0PRIV_PROD0),
+            PublicKey::from(&eh),
+            eh,
+            0,
+        )
+        .map_err(|(_, e)| ProvisionError::Chip(format!("commit slot-0 session_start: {e:?}")))?;
+
+    // 2a) Preflight: slot 1 must POSITIVELY read as `SlotEmpty` (not merely error) before any write —
+    // an ambiguous transport error must abort the burn, never fall through to it. Then counter
+    // readable + every DENY+ALLOW register factory-open.
+    match s0.pairing_key_read(U16::new(VERIFIER_SLOT)) {
+        Err(TrError::SlotEmpty) => {}
+        Ok(_) => {
+            return Err(ProvisionError::Precondition(
+                "slot 1 is non-empty; refusing to overwrite".into(),
+            ))
+        }
+        Err(e) => {
+            return Err(ProvisionError::Chip(format!(
+                "preflight pairing_key_read (emptiness unconfirmed): {e:?}"
+            )))
+        }
+    }
+    s0.mcounter_get(MCounterIndex::Index0)
+        .map_err(|e| ProvisionError::Precondition(format!("mcounter unreadable: {e:?}")))?;
+    for addr in DENY.iter().chain(ALLOW_FACTORY_OPEN.iter()) {
+        let r = s0.r_config_read(U16::new(*addr));
+        let i = s0.i_config_read(U16::new(*addr));
+        match (r, i) {
+            (Ok(r), Ok(i)) if r == 0xffff_ffff && i == 0xffff_ffff => {}
+            (r, i) => {
+                return Err(ProvisionError::Precondition(format!(
+                    "0x{addr:03x} not factory-open (r={r:?} i={i:?}); refusing to provision"
+                )))
+            }
+        }
+    }
+
+    // 2b) Write the fixed verifier pubkey, verify read-back.
+    s0.pairing_key_write(U16::new(VERIFIER_SLOT), &fixed_pub)
+        .map_err(|e| ProvisionError::Chip(format!("pairing_key_write: {e:?}")))?;
+    match s0.pairing_key_read(U16::new(VERIFIER_SLOT)).map(|k| *k) {
+        Ok(k) if k == fixed_pub => {}
+        other => {
+            return Err(ProvisionError::Chip(format!(
+                "slot 1 read-back mismatch after write: {other:?}"
+            )))
+        }
+    }
+
+    // 2c) Cage: revoke SH1 access to every DENY register (I_CONFIG_WRITE last, by list order).
+    for addr in DENY {
+        for bit in SH1_BITS {
+            s0.i_config_write(U16::new(*addr), bit).map_err(|e| {
+                ProvisionError::Chip(format!("i_config_write(0x{addr:03x} bit {bit}): {e:?}"))
+            })?;
+        }
+    }
+
+    // 2d) Reboot the TROPIC01 so the i-config cage latches (config is boot-latched), then reopen.
+    let mut chip = s0
+        .session_abort()
+        .map_err(|(_, e)| ProvisionError::Chip(format!("post-write abort: {e:?}")))?;
+    chip.startup_req(StartupReq::Reboot)
+        .map_err(|e| ProvisionError::Chip(format!("startup_req(Reboot): {e:?}")))?;
+    let dl = Instant::now() + Duration::from_secs(10);
+    loop {
+        match chip.get_info_chip_id() {
+            Ok(_) => break,
+            Err(_) if Instant::now() < dl => {}
+            Err(e) => {
+                return Err(ProvisionError::Chip(format!(
+                    "chip did not return after reboot: {e:?}"
+                )))
+            }
+        }
+    }
+
+    // 2e) Verify the caged surface AS slot 1: MCOUNTER_GET ok; INIT/PAIRING_WRITE/I_CONFIG_WRITE denied.
+    let eh1 = fresh_ephemeral()?;
+    let mut v = chip
+        .session_start(
+            &X25519Dalek,
+            PublicKey::from(fixed_pub),
+            StaticSecret::from(fixed_priv),
+            PublicKey::from(&eh1),
+            eh1,
+            VERIFIER_SLOT as u8,
+        )
+        .map_err(|(_, e)| ProvisionError::CageVerify(format!("verifier session_start: {e:?}")))?;
+    let get = v.mcounter_get(MCounterIndex::Index0);
+    let init = v.mcounter_init(MCounterIndex::Index0, 1000);
+    let pkw = v.pairing_key_write(U16::new(VERIFIER_SLOT), &fixed_pub);
+    let icw = v.i_config_write(U16::new(0x040), 1);
+    let chip = v
+        .session_abort()
+        .map_err(|(_, e)| ProvisionError::CageVerify(format!("verifier abort: {e:?}")))?;
+
+    // 2f) Slot 0 must still read the counter (host access intact).
+    let eh0 = fresh_ephemeral()?;
+    let mut s0 = chip
+        .session_start(
+            &X25519Dalek,
+            PublicKey::from(SH0PUB_PROD0),
+            StaticSecret::from(SH0PRIV_PROD0),
+            PublicKey::from(&eh0),
+            eh0,
+            0,
+        )
+        .map_err(|(_, e)| ProvisionError::CageVerify(format!("slot-0 re-open: {e:?}")))?;
+    let slot0_get = s0.mcounter_get(MCounterIndex::Index0);
+    let _ = s0.session_abort();
+
+    // The security invariant is that each mutating command did NOT execute: ANY Err == not executed
+    // == denied (matches the proven bench gate). A transport glitch on a probe is still "not
+    // executed", so gate on `.is_err()`; keep the Unauthorized check as a diagnostic only, so a
+    // non-Unauthorized denial does not turn a correctly-caged slot into a false CageVerify failure.
+    let denied_as_expected =
+        is_unauthorized(&init) && is_unauthorized(&pkw) && is_unauthorized(&icw);
+    if !denied_as_expected {
+        log::warn!(
+            "[provisioner] cage-verify: a denial used a non-Unauthorized code (still denied)"
+        );
+    }
+    let pass = get.is_ok() && init.is_err() && pkw.is_err() && icw.is_err() && slot0_get.is_ok();
+    if !pass {
+        return Err(ProvisionError::CageVerify(format!(
+            "caged surface wrong: get={get:?} init={init:?} pkw={pkw:?} icw={icw:?} slot0={slot0_get:?}"
+        )));
+    }
+    Ok((VERIFIER_SLOT as u8, stpub))
+}

--- a/crates/dsm-android-anchor/src/install.rs
+++ b/crates/dsm-android-anchor/src/install.rs
@@ -81,6 +81,15 @@ pub fn install_path_b_transports() -> bool {
     // Receiver side: the ACCEPT-ENABLING reader + verifier-pairing deriver (fixed key, no seed).
     crate::install_receiver_anchor(adapter_round_trip());
     log::info!("[anchor-install] RelayCounterReader + verifier deriver installed (Path-B active)");
+
+    // Sender side: the READ-ONLY SE slot writer — discloses (slot, stpub) iff the verifier slot is
+    // already provisioned + caged. It NEVER burns; the burn is the separate explicit setup trigger
+    // (`provisionVerifierSlotCommit`). Until the slot is provisioned, the disclosure stays empty and
+    // the receiver's pin is incomplete -> fail-closed.
+    crate::install_sender_slot_writer(std::sync::Arc::new(crate::se_slot::SeVerifierSlotWriter));
+    log::info!(
+        "[anchor-install] read-only SeSlotWriter installed (disclosure fail-closed until setup)"
+    );
     true
 }
 

--- a/crates/dsm-android-anchor/src/lib.rs
+++ b/crates/dsm-android-anchor/src/lib.rs
@@ -28,6 +28,7 @@ use dsm_sdk::bridge::{
 };
 
 pub mod install;
+pub mod se_slot;
 pub mod self_test;
 pub mod usb_pico;
 pub use usb_pico::{UsbPicoTransport, UsbTransceive};

--- a/crates/dsm-android-anchor/src/se_slot.rs
+++ b/crates/dsm-android-anchor/src/se_slot.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! H3 sender-side SE op: the DSM SMT-root verifier slot on A's OWN TROPIC01.
+//!
+//! Two entry points, matching the owner's read/burn split:
+//!   - [`SeVerifierSlotWriter`] fills `dsm_sdk`'s `SeSlotWriter` seam. It is **read-only**: on a
+//!     first-transfer enroll it confirms slot 1 already holds the fixed DSM verifier key AND is
+//!     caged, and discloses `(slot 1, stpub)`. It NEVER writes — a normal transfer (or app boot)
+//!     can never burn hardware. Empty / occupied / wrong-key / any error -> `None` -> disclosure
+//!     empty -> receiver pin incomplete -> fail-closed.
+//!   - [`provision_verifier_slot_commit`] performs the IRREVERSIBLE burn. It runs ONLY from an
+//!     explicit setup/commit gate (a dedicated JNI trigger), never as a side effect of anything.
+//!
+//! Both drive A's local Pico over the same opaque JNI USB up-call the relay uses, wrapped as a sync
+//! `SpiRelayChannel` so the proven `provisioner` sequence runs unchanged on-device.
+
+// Host-testable decision types (hw-verifier is a normal dep, so these resolve on host too).
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+use dsm_anchor_hw_verifier::{commit_verifier_slot, read_verifier_slot};
+use dsm_anchor_hw_verifier::{
+    dsm_verifier_pairing_pubkey, ProvisionError, VerifierSlotState, VERIFIER_SLOT,
+};
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+use dsm_anchor_verifier::{RelayError, SpiRelayChannel};
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+use dsm_sdk::bridge::SeSlotWriter;
+
+/// The fail-closed disclosure decision, pulled out of the on-device path so it is host-testable: the
+/// receiver's offered key must be the fixed DSM verifier key, and the slot must read back as fully
+/// provisioned + caged. Anything else -> `None` (disclosure empty -> receiver pin incomplete).
+fn map_disclosure(
+    offered_pubkey: [u8; 32],
+    read: Result<VerifierSlotState, ProvisionError>,
+) -> Option<(u8, [u8; 32])> {
+    if offered_pubkey != dsm_verifier_pairing_pubkey() {
+        return None;
+    }
+    match read {
+        Ok(VerifierSlotState::Provisioned { stpub }) => Some((VERIFIER_SLOT as u8, stpub)),
+        _ => None,
+    }
+}
+
+/// A sync `SpiRelayChannel` to A's LOCAL Pico over the JNI USB up-call: each `transceive` frames one
+/// raw SPI transaction as `OP_SPI_PASSTHROUGH` (in Rust) and returns the MISO. Zero-size — a fresh
+/// one is minted per session (the provisioner's `make_channel`).
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+pub struct JniLocalSpiChannel;
+
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+impl SpiRelayChannel for JniLocalSpiChannel {
+    fn transceive(&mut self, mosi: &[u8]) -> Result<Vec<u8>, RelayError> {
+        let frame = crate::usb_pico::frame_passthrough(mosi.to_vec());
+        let body = crate::usb_pico::jni_usb_transceive(frame)
+            .map_err(|e| RelayError::Transport(format!("local pico up-call: {e}")))?;
+        crate::usb_pico::decode_passthrough(&body)
+            .map_err(|e| RelayError::Transport(format!("local pico decode: {e}")))
+    }
+}
+
+/// Read-only `SeSlotWriter`: discloses the verifier slot iff it is already provisioned + caged.
+/// Never writes.
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+pub struct SeVerifierSlotWriter;
+
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+impl SeSlotWriter for SeVerifierSlotWriter {
+    fn provision_verifier_slot(
+        &self,
+        _requester_device_id: [u8; 32],
+        pairing_pubkey: [u8; 32],
+    ) -> Option<(u8, [u8; 32])> {
+        let read = read_verifier_slot(JniLocalSpiChannel);
+        if let Err(ref e) = read {
+            log::warn!("[se-slot] verifier slot read failed (fail-closed): {e:?}");
+        }
+        let disclosure = map_disclosure(pairing_pubkey, read);
+        if disclosure.is_none() {
+            log::warn!(
+                "[se-slot] no disclosure (unprovisioned / not caged / wrong key); fail-closed"
+            );
+        }
+        disclosure
+    }
+}
+
+/// EXPLICIT setup/commit action — the IRREVERSIBLE burn. Idempotent when already provisioned; refuses
+/// to overwrite a non-empty slot. Returns `(slot, stpub)` on success. NEVER called from a transfer or
+/// app boot — only from the dedicated JNI trigger below.
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+pub fn provision_verifier_slot_commit() -> Result<(u8, [u8; 32]), String> {
+    commit_verifier_slot(|| JniLocalSpiChannel).map_err(|e| format!("{e:?}"))
+}
+
+/// JNI trigger for the EXPLICIT setup burn. Returns the slot index (>=0) on success, -1 on failure.
+/// Present only in `on_device_installs` builds; a dedicated bench/setup UI action must invoke it. A
+/// normal transfer or app boot never reaches this symbol.
+#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+#[no_mangle]
+pub extern "system" fn Java_com_dsm_wallet_bridge_Unified_provisionVerifierSlotCommit(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+) -> jni::sys::jint {
+    match provision_verifier_slot_commit() {
+        Ok((slot, stpub)) => {
+            log::info!("[se-slot] verifier slot {slot} provisioned; stpub={stpub:02x?}");
+            i32::from(slot)
+        }
+        Err(e) => {
+            log::error!("[se-slot] provision failed: {e}");
+            -1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const STPUB: [u8; 32] = [0xAB; 32];
+
+    #[test]
+    fn provisioned_with_the_fixed_key_discloses_slot_and_stpub() {
+        let ok = map_disclosure(
+            dsm_verifier_pairing_pubkey(),
+            Ok(VerifierSlotState::Provisioned { stpub: STPUB }),
+        );
+        assert_eq!(ok, Some((VERIFIER_SLOT as u8, STPUB)));
+    }
+
+    #[test]
+    fn wrong_offered_key_never_discloses_even_when_provisioned() {
+        let mut wrong = dsm_verifier_pairing_pubkey();
+        wrong[0] ^= 0xFF;
+        assert_eq!(
+            map_disclosure(wrong, Ok(VerifierSlotState::Provisioned { stpub: STPUB })),
+            None,
+        );
+    }
+
+    #[test]
+    fn empty_occupied_and_errors_all_fail_closed() {
+        let fixed = dsm_verifier_pairing_pubkey();
+        assert_eq!(
+            map_disclosure(fixed, Ok(VerifierSlotState::Empty { stpub: STPUB })),
+            None,
+            "an unprovisioned slot must never disclose",
+        );
+        assert_eq!(
+            map_disclosure(fixed, Ok(VerifierSlotState::Occupied)),
+            None,
+            "an occupied/uncaged slot must never disclose",
+        );
+        assert_eq!(
+            map_disclosure(fixed, Err(ProvisionError::Chip("boom".into()))),
+            None,
+            "a read error must fail closed",
+        );
+    }
+}

--- a/crates/dsm-android-anchor/src/usb_pico.rs
+++ b/crates/dsm-android-anchor/src/usb_pico.rs
@@ -28,23 +28,39 @@ pub struct UsbPicoTransport {
     usb: UsbTransceive,
 }
 
+/// Build the length-prefixed `OP_SPI_PASSTHROUGH` request frame for a raw SPI MOSI (LE32 body len ++
+/// `ApplianceRequest`). Shared by the async relay transport and the sync SE-provisioning channel.
+pub(crate) fn frame_passthrough(mosi: Vec<u8>) -> Vec<u8> {
+    let req = pb::ApplianceRequest {
+        op: pb::Op::SpiPassthrough as i32,
+        spi_payload: mosi,
+        ..Default::default()
+    };
+    let body = encode_request(&req);
+    let mut frame = (body.len() as u32).to_le_bytes().to_vec();
+    frame.extend_from_slice(&body);
+    frame
+}
+
+/// Decode an `ApplianceResponse` body (already length-stripped by Kotlin) and return `spi_response`,
+/// or a fail-closed `DsmError` on a malformed frame / `ok=false`.
+pub(crate) fn decode_passthrough(resp_body: &[u8]) -> Result<Vec<u8>, DsmError> {
+    let resp = decode_response(resp_body).map_err(|e| {
+        DsmError::invalid_operation(format!("usb-pico: decode ApplianceResponse: {e:?}"))
+    })?;
+    if !resp.ok {
+        return Err(DsmError::invalid_operation(format!(
+            "usb-pico: passthrough error code {}",
+            resp.error
+        )));
+    }
+    Ok(resp.spi_response)
+}
+
 impl UsbPicoTransport {
     /// `usb` performs one opaque USB round-trip (request frame bytes -> response body bytes).
     pub fn new(usb: UsbTransceive) -> Self {
         Self { usb }
-    }
-
-    /// Build the length-prefixed `OP_SPI_PASSTHROUGH` request frame for a raw SPI MOSI.
-    fn frame_request(mosi: Vec<u8>) -> Vec<u8> {
-        let req = pb::ApplianceRequest {
-            op: pb::Op::SpiPassthrough as i32,
-            spi_payload: mosi,
-            ..Default::default()
-        };
-        let body = encode_request(&req);
-        let mut frame = (body.len() as u32).to_le_bytes().to_vec();
-        frame.extend_from_slice(&body);
-        frame
     }
 }
 
@@ -52,7 +68,7 @@ impl LocalPicoTransport for UsbPicoTransport {
     fn spi_passthrough(&self, mosi: Vec<u8>) -> PicoFuture<Result<Vec<u8>, DsmError>> {
         let usb = self.usb.clone();
         Box::pin(async move {
-            let frame = Self::frame_request(mosi);
+            let frame = frame_passthrough(mosi);
             log::debug!("[usb-pico] passthrough req len={}", frame.len());
             let resp_body = match usb(frame) {
                 Ok(b) => b,
@@ -62,63 +78,57 @@ impl LocalPicoTransport for UsbPicoTransport {
                 }
             };
             log::debug!("[usb-pico] passthrough resp len={}", resp_body.len());
-            let resp = decode_response(&resp_body).map_err(|e| {
-                log::warn!("[usb-pico] malformed passthrough response (recover online): {e:?}");
-                DsmError::invalid_operation(format!("usb-pico: decode ApplianceResponse: {e:?}"))
-            })?;
-            if !resp.ok {
-                log::warn!(
-                    "[usb-pico] Pico reported passthrough error code {} (recover online)",
-                    resp.error
-                );
-                return Err(DsmError::invalid_operation(format!(
-                    "usb-pico: passthrough error code {}",
-                    resp.error
-                )));
-            }
-            Ok(resp.spi_response)
+            decode_passthrough(&resp_body).inspect_err(|e| {
+                log::warn!("[usb-pico] passthrough response rejected (recover online): {e}");
+            })
         })
     }
 }
 
-/// The on-device constructor: `usb` up-calls Kotlin's opaque `Unified.picoUsbTransceive([B)[B`,
-/// which does the actual USB-OTG round-trip to the Pico. Mirrors `queue_follow_up_chunks`'
-/// `with_env` + re-derive-mutable-JNIEnv pattern. Any JNI/USB failure -> `Err` (fail-closed). A
-/// null return from Kotlin (no device / permission / timeout) is treated as a USB failure. This
-/// path is Android-only; host builds/tests use `UsbPicoTransport::new` with a mock.
+/// The raw opaque USB round-trip: up-call Kotlin's `Unified.picoUsbTransceive([B)[B`, which does the
+/// actual USB-OTG round-trip to A's own Pico. Mirrors `queue_follow_up_chunks`' `with_env` +
+/// re-derive-mutable-JNIEnv pattern. Any JNI/USB failure -> `Err` (fail-closed); a null return from
+/// Kotlin (no device / permission / timeout) is a USB failure. Shared by the async
+/// [`UsbPicoTransport`] (relay reads) and the sync SE-provisioning SPI channel.
+#[cfg(target_os = "android")]
+pub(crate) fn jni_usb_transceive(frame: Vec<u8>) -> Result<Vec<u8>, DsmError> {
+    use jni::objects::{JByteArray, JObject, JValue};
+    dsm_sdk::jni::jni_common::with_env(|env| -> Result<Vec<u8>, String> {
+        // Re-derive a mutable JNIEnv from the raw handle (same as queue_follow_up_chunks).
+        let mut env = unsafe { jni::JNIEnv::from_raw(env.get_raw() as *mut _) }
+            .map_err(|e| format!("clone JNIEnv: {e}"))?;
+        let cls = dsm_sdk::jni::jni_common::find_class_with_app_loader(
+            &mut env,
+            "com/dsm/wallet/bridge/Unified",
+        )?;
+        let arr = env
+            .byte_array_from_slice(&frame)
+            .map_err(|e| format!("byte_array_from_slice: {e}"))?;
+        let arr_obj = JObject::from(arr);
+        let res = env
+            .call_static_method(
+                &cls,
+                "picoUsbTransceive",
+                "([B)[B",
+                &[JValue::Object(&arr_obj)],
+            )
+            .map_err(|e| format!("call picoUsbTransceive: {e}"))?;
+        let obj = res.l().map_err(|e| format!("result not object: {e}"))?;
+        if obj.is_null() {
+            return Err("picoUsbTransceive returned null (USB failure)".to_string());
+        }
+        env.convert_byte_array(JByteArray::from(obj))
+            .map_err(|e| format!("convert_byte_array: {e}"))
+    })
+    .map_err(|e| DsmError::invalid_operation(format!("usb-pico JNI up-call: {e}")))
+}
+
+/// The on-device async transport for the relay reads: frames `OP_SPI_PASSTHROUGH` in Rust and hands
+/// the opaque bytes to [`jni_usb_transceive`]. Host builds/tests use `UsbPicoTransport::new` with a
+/// mock.
 #[cfg(target_os = "android")]
 pub fn android_usb_pico_transport() -> UsbPicoTransport {
-    use jni::objects::{JByteArray, JObject, JValue};
-    UsbPicoTransport::new(Arc::new(|frame: Vec<u8>| -> Result<Vec<u8>, DsmError> {
-        dsm_sdk::jni::jni_common::with_env(|env| -> Result<Vec<u8>, String> {
-            // Re-derive a mutable JNIEnv from the raw handle (same as queue_follow_up_chunks).
-            let mut env = unsafe { jni::JNIEnv::from_raw(env.get_raw() as *mut _) }
-                .map_err(|e| format!("clone JNIEnv: {e}"))?;
-            let cls = dsm_sdk::jni::jni_common::find_class_with_app_loader(
-                &mut env,
-                "com/dsm/wallet/bridge/Unified",
-            )?;
-            let arr = env
-                .byte_array_from_slice(&frame)
-                .map_err(|e| format!("byte_array_from_slice: {e}"))?;
-            let arr_obj = JObject::from(arr);
-            let res = env
-                .call_static_method(
-                    &cls,
-                    "picoUsbTransceive",
-                    "([B)[B",
-                    &[JValue::Object(&arr_obj)],
-                )
-                .map_err(|e| format!("call picoUsbTransceive: {e}"))?;
-            let obj = res.l().map_err(|e| format!("result not object: {e}"))?;
-            if obj.is_null() {
-                return Err("picoUsbTransceive returned null (USB failure)".to_string());
-            }
-            env.convert_byte_array(JByteArray::from(obj))
-                .map_err(|e| format!("convert_byte_array: {e}"))
-        })
-        .map_err(|e| DsmError::invalid_operation(format!("usb-pico JNI up-call: {e}")))
-    }))
+    UsbPicoTransport::new(Arc::new(jni_usb_transceive))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

The sender-side SE op for the ONE caged read-only counter slot (slot 1) holding the fixed DSM verifier key. Split per the owner's rule: **READ is safe (transfer path), BURN is an explicit gated action only.**

### `provisioner` (dsm-anchor-hw-verifier, channel-generic)
- **`read_verifier_slot`** — strictly non-destructive: opens slot 0, reads slot 1's key, and if it's the fixed key confirms the cage via `i_config_read` (SH1 bits cleared). No slot-1 session, no write. Only the specific `SlotEmpty` status counts as empty; any other error propagates as a Chip error (fail-closed), never `Empty`.
- **`commit_verifier_slot`** — the IRREVERSIBLE burn, mirroring the Phase-G proven sequence (preflight positively requiring `SlotEmpty` + factory-open UAP + readable counter → `pairing_key_write` + read-back → i-config cage sweep, `I_CONFIG_WRITE` last → `StartupReq::Reboot` + poll → reopen as slot 1, verify MCOUNTER_GET-only → slot 0 intact). Idempotent; refuses to overwrite a non-empty/wrong-key slot.

### `glue` (dsm-android-anchor)
- `SeVerifierSlotWriter` fills the seam **read-only** via a pure host-testable `map_disclosure`; `JniLocalSpiChannel` (sync SPI over the JNI USB up-call); `provisionVerifierSlotCommit` JNI trigger = the **only** burn entry.
- `usb_pico`: extracted `frame_passthrough`/`decode_passthrough`/`jni_usb_transceive`, shared by the async transport + sync channel.

## Safety

Everything is behind the `on_device_installs` feature (**off by default**). The default arm64 `.so` exports **neither** `installPathBTransports` **nor** `provisionVerifierSlotCommit` (symbol-audited) — a shipped/boot build cannot burn. The read path cannot mutate; the burn requires the explicit gated trigger and refuses to overwrite existing key material.

## Review

A 4-dimension adversarial workflow (constraints / fail-closed / sequence / security) ran with per-finding verification. The scary "malicious chip spoofs the cage" / "unauthenticated stpub" findings were **refuted** (the sender reads its *own* local chip; the receiver independently pins + verifies `stpub` via its authenticated session). **2 findings confirmed + fixed:**
1. cage-verify gated on `is_unauthorized` → now `.is_err()` (matches the proven bench; a transport glitch on a denied-op probe no longer fakes a `CageVerify` failure).
2. `pairing_key_read` error classification → only `Error::SlotEmpty` (0x15, verified from tropic01 source) maps to `Empty`; any other error propagates fail-closed. Commit preflight tightened to *positively* require `SlotEmpty` before any write.

## Verification

hw 6/6 + glue 10/10 (fail-closed disclosure matrix) + clippy/fmt clean + default & feature cross-compile + `cargo tree --workspace -i tropic01` empty.

**Still fail-closed, no live claim. No chip touched** — the burn is the owner's explicit bench action. Remaining: explicit hardware burn on a fresh chip → 2-phone BLE transfer → the flip.