### PR TITLE
feat(offline-bearer): verifier slot index configurable + read-only on-chip preflight

### DIFF
--- a/crates/dsm-anchor-hw-verifier/BENCH_BURN_RUNBOOK.md
+++ b/crates/dsm-anchor-hw-verifier/BENCH_BURN_RUNBOOK.md
@@ -1,116 +1,105 @@
 <!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
 # DSM SMT-root verifier slot — bench burn runbook
 
-An **explicit operator-run** checklist to provision slot 1 of a TROPIC01 into the caged DSM SMT-root
-verifier slot. This is the ONLY sanctioned way to perform the irreversible burn.
+An **explicit operator-run** checklist to provision one caged DSM SMT-root verifier slot on a
+TROPIC01. This is the ONLY sanctioned way to perform the irreversible burn.
 
 > **Hard rules (do not violate):**
-> - No burn happens from app boot. No burn happens from a transfer confirm.
-> - No fallback to slot 2 or slot 3. Slot 1 only. Slot 0 (host) is never touched.
+> - No burn happens from app boot. No burn happens from a transfer confirm. The burn is a bench
+>   action only (this CLI); there is no on-device burn path.
+> - **One verifier ROLE.** Its INDEX is chosen explicitly with `--slot N`. Slot 0 (host) is never a
+>   verifier slot. Choosing slot 2 on a dev chip whose slot 1 is spent is a deliberate operator
+>   choice, NOT a silent fallback.
 > - No overwrite of an occupied slot (an old demo / per-relationship key fails closed).
-> - No irreversible action without a fresh, explicit bench gate (`--yes-burn-slot-1`).
->
-> The burn is IRREVERSIBLE: a written pairing slot is spent, and the i-config cage bits clear
-> `1 -> 0` permanently. Run against **a fresh chip or an explicitly approved bench chip only.**
+> - The confirm flag must **name the same slot** as `--slot` (`--slot 2` needs `--yes-burn-slot-2`);
+>   a mismatch is refused.
+> - The burn is IRREVERSIBLE (a written pairing slot is spent; cage bits clear `1 -> 0` permanently).
 
-The commit path runs the SAME reviewed `provisioner` code the on-device `SeSlotWriter` uses, over a
-USB-CDC relay to the Pico. It reads the chip's own `stpub` (no hardcoded chip identity) — **you** are
-responsible for confirming the target chip (step 2).
-
-Toolchain: host build with the rustup toolchain (Homebrew's rust has no cross std is irrelevant here,
-but keep it consistent). All commands use `--manifest-path` because the crate is workspace-excluded:
+The commit runs the SAME reviewed `provisioner` code the on-device read uses, over a USB-CDC relay
+to the Pico. It reads the chip's own `stpub` (no hardcoded chip identity) — **you** confirm the
+target chip (step 2).
 
 ```sh
 CRATE=crates/dsm-anchor-hw-verifier/Cargo.toml
 PORT=/dev/cu.usbmodemdsm_anchor1        # adjust to your Pico's serial port
+SLOT=2                                    # this dev chip: slot 1 is spent, so the role goes in slot 2
 run() { ~/.cargo/bin/cargo +stable run --manifest-path "$CRATE" --example "$@"; }
 ```
 
 ---
 
-## 1. Confirm PR #547 is merged and main is synced
+## 1. Confirm main is synced
 
 ```sh
-git fetch origin && git log origin/main --oneline -1     # must include the SeSlotWriter / provisioner
-git checkout main && git pull --ff-only
+git checkout main && git pull --ff-only     # must include the slot-configurable provisioner + preflight
 ```
-
-Do not proceed on a branch that predates the reviewed provisioner (the two confirmed review fixes:
-`SlotEmpty`-only emptiness classification, and the `.is_err()` cage-verify gate).
 
 ## 2. Confirm target chip identity
 
 ```sh
-run usb_uap_probe    -- "$PORT"      # full chip dump: chip-id, stpub, slot map, UAP registers
-run usb_verifier_slot -- status "$PORT"
+run usb_uap_probe     -- "$PORT"                 # full chip dump: chip-id, stpub, slot map, UAP
+run usb_verifier_slot -- status "$PORT"          # scans 1..=3: reports where (if anywhere) the role lives
 ```
 
-Record and confirm, **out loud / against your notes**:
-- the chip's **`stpub`** (Noise static public key) — this is the chip's identity;
-- the chip info / chip-id;
-- the current **`mcounter[0]`** value (from `usb_uap_probe`).
+Record and confirm the chip's **`stpub`** and current **`mcounter[0]`**. If it is not the chip you
+intend, **stop**. (On this dev chip you should see slot 1 already OCCUPIED by the old demo key.)
 
-If this is not the chip you intend to provision, **stop**.
-
-## 3. Confirm slot 1 state (`status` classifies it for you)
-
-`usb_verifier_slot -- status` prints exactly one of:
-
-| status output | meaning | action |
-|---|---|---|
-| `PROVISIONED` | slot 1 already holds the fixed DSM key + correct cage | **no burn** — already done (idempotent) |
-| `EMPTY` | slot 1 unwritten | eligible for an explicit commit (step 4-5) |
-| `OCCUPIED` | slot 1 holds a non-fixed key (e.g. an old demo key) or is not caged | **FAIL CLOSED — stop.** Do NOT overwrite. Do NOT fall back to slot 2/3. Use a different (fresh) chip. |
-
-## 4. Dry-run (no writes)
+## 3. Confirm slot 2 is empty
 
 ```sh
-run usb_verifier_slot -- plan "$PORT"
+run usb_verifier_slot -- status --slot "$SLOT" "$PORT"
 ```
 
-Confirm the printed plan:
-- **fixed verifier pubkey** is the DSM constant (same every device);
-- **exact deny register list** is printed, and **`0x040 I_CONFIG_WRITE` is marked `<- LAST`**;
-- **allowlist** leaves `MCOUNTER_GET (0x154)` + harmless reads factory-open;
-- `slot 0 host NEVER touched; slots 2/3 NEVER written`.
+| status output | action |
+|---|---|
+| `EMPTY` | eligible — go to step 4 |
+| `PROVISIONED` | already done (idempotent) — no burn |
+| `OCCUPIED` | **stop.** Do NOT overwrite. Pick another empty candidate index and re-confirm. |
+
+## 4. Read-only preflight against the actual chip (the key protection)
+
+```sh
+run usb_verifier_slot -- preflight --slot "$SLOT" "$PORT"
+```
+
+This writes **nothing**. It runs the burn's ENTIRE gate on the real chip and must report:
+- slot 2 reads back `SlotEmpty`;
+- `mcounter[0]` reads (prints the value);
+- every deny/allow UAP register is factory-open;
+- then prints **exactly what a commit would burn** (fixed verifier pubkey, deny list with
+  `I_CONFIG_WRITE` marked LAST, allowlist).
+
+**If the preflight is anything but a clean "WOULD PROCEED", stop and investigate — do not commit.**
+(That is the trigger to reach for the emulator; otherwise the emulator is unnecessary.)
 
 ## 5. Explicit commit — ONLY after fresh approval
 
-Only if step 3 said `EMPTY` and steps 2/4 checked out, and you give fresh explicit approval:
+Only if step 3 said `EMPTY`, step 4 was a clean `WOULD PROCEED`, and you give fresh approval:
 
 ```sh
-run usb_verifier_slot -- commit "$PORT" --yes-burn-slot-1
+run usb_verifier_slot -- commit --slot "$SLOT" --yes-burn-slot-"$SLOT" "$PORT"
 ```
 
-Without `--yes-burn-slot-1` the tool refuses and exits (no writes). The commit performs, in order:
-write the fixed verifier pubkey into slot 1 -> verify read-back -> revoke SH1 access to every deny
-register (**I_CONFIG_WRITE last**) -> TROPIC reboot-latch -> reopen -> verify the caged surface. It
-aborts (writing nothing further) on any precondition failure and **refuses to overwrite** a slot that
-became non-empty. Nothing partial is trusted.
+Without `--yes-burn-slot-2` (or with a flag naming a different slot) the tool refuses and writes
+nothing. The commit: write the fixed verifier pubkey into slot 2 -> verify read-back -> revoke slot-2
+access to every deny register (`I_CONFIG_WRITE` last) -> TROPIC reboot-latch -> reopen -> verify the
+caged surface. It refuses to overwrite a slot that became non-empty; nothing partial is trusted.
 
 ## 6. Final proof
 
-On success the commit prints `[PASS] slot 1 is the caged DSM SMT-root verifier slot` plus the
-`verifier_slot` + `chip_static_pubkey (stpub)` disclosure values. The commit's internal verification
-already proved, post-reboot:
-- slot 1 opens with the fixed verifier key;
-- `mcounter_get(0)` succeeds;
-- `mcounter_init`, `pairing_key_write`, `i_config_write` are all **denied**;
-- slot 0 still reads the counter (host access intact).
+On success the commit prints `[PASS] slot 2 is the caged DSM SMT-root verifier slot` + the
+`verifier_slot` + `chip_static_pubkey (stpub)` disclosure values. Its internal post-reboot
+verification already proved: slot 2 opens with the fixed key; `mcounter_get(0)` succeeds;
+`mcounter_init` / `pairing_key_write` / `i_config_write` are denied; slot 0 still reads the counter.
 
-Independently re-confirm (non-destructive), and record the disclosure values:
+Re-confirm non-destructively and record the disclosure values:
 
 ```sh
-run usb_verifier_slot -- status "$PORT"        # must print PROVISIONED + the same stpub as step 2
+run usb_verifier_slot -- status "$PORT"          # must report: role PROVISIONED at slot 2, same stpub as step 2
 ```
-
-- `PROVISIONED` (fixed key present + cage read back via `i_config_read`);
-- `stpub` matches the value recorded in step 2;
-- the disclosure pair `(verifier_slot=1, chip_static_pubkey=stpub)` is what a receiver pins.
 
 ---
 
-**After a successful burn**, the chip is ready to serve Path-B counter reads: plug it back into the
-sender phone, and the read-only on-device `SeSlotWriter` will disclose `(slot 1, stpub)` on a
-first-transfer enroll. Proceed to the 2-phone BLE transfer test. The live flip remains a separate,
-explicit owner decision.
+**After a successful burn**, the chip serves Path-B counter reads: plug it into the sender phone, and
+the read-only on-device seam scans + discloses `(slot 2, stpub)` on a first-transfer enroll. Proceed
+to the 2-phone BLE transfer test. The live flip remains a separate, explicit owner decision.

--- a/crates/dsm-anchor-hw-verifier/examples/usb_verifier_slot.rs
+++ b/crates/dsm-anchor-hw-verifier/examples/usb_verifier_slot.rs
@@ -1,18 +1,25 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Operator bench CLI for the DSM SMT-root verifier slot, over the SAME reviewed `provisioner` code
-//! the on-device SeSlotWriter runs (no bench-chip-specific hardcoding — works on a FRESH chip). It
-//! reads the chip's own stpub and returns it; it does NOT gate on a known stpub, so the operator is
-//! responsible for confirming the target chip identity (the runbook step).
+//! the on-device SeSlotWriter runs (no bench-chip-specific hardcoding — works on a FRESH or a dev
+//! chip whose lower slot is spent). It reads the chip's own stpub and returns it; it does NOT gate on
+//! a known stpub, so the operator confirms the target chip identity (runbook step 2).
+//!
+//! The verifier ROLE is a single fixed key; its INDEX is chosen explicitly with `--slot N` (1..=3;
+//! e.g. `--slot 2` on a dev chip whose slot 1 is spent). Slot 0 (host) is never a verifier slot.
 //!
 //! Subcommands (see BENCH_BURN_RUNBOOK.md):
-//!   status  — NON-DESTRUCTIVE: classify slot 1 (Provisioned / Empty / Occupied) + print stpub.
-//!   plan    — status + print exactly what a commit WOULD burn (fixed key, deny/allow lists). No writes.
-//!   commit  — the IRREVERSIBLE burn. Refuses unless `--yes-burn-slot-1` is passed. Idempotent when
-//!             already provisioned; refuses to overwrite a non-empty/wrong-key slot.
+//!   status    [--slot N]  — NON-DESTRUCTIVE. With --slot: classify that index. Without: SCAN 1..=3
+//!                           and report where the role is provisioned (or none).
+//!   preflight  --slot N   — NON-DESTRUCTIVE dry-run of the ENTIRE burn gate on the real chip: proves
+//!                           slot N is SlotEmpty, the counter reads, and the UAP is factory-open, and
+//!                           prints exactly what a commit WOULD burn. Writes nothing.
+//!   commit     --slot N --yes-burn-slot-N   — the IRREVERSIBLE burn. The confirm flag MUST name the
+//!                           SAME slot as --slot (a mismatch is refused). Idempotent if already
+//!                           provisioned; refuses to overwrite a non-empty slot.
 //!
 //!   cargo run --manifest-path crates/dsm-anchor-hw-verifier/Cargo.toml --example usb_verifier_slot -- status /dev/cu.usbmodemdsm_anchor1
-//!   cargo run ... --example usb_verifier_slot -- plan   /dev/cu.usbmodemdsm_anchor1
-//!   cargo run ... --example usb_verifier_slot -- commit /dev/cu.usbmodemdsm_anchor1 --yes-burn-slot-1
+//!   cargo run ... --example usb_verifier_slot -- preflight --slot 2 /dev/cu.usbmodemdsm_anchor1
+//!   cargo run ... --example usb_verifier_slot -- commit --slot 2 --yes-burn-slot-2 /dev/cu.usbmodemdsm_anchor1
 
 // Bring-up/operator tool, not a production path: fail loudly at the console.
 #![allow(clippy::disallowed_methods)]
@@ -21,27 +28,55 @@
 mod usb;
 
 use dsm_anchor_hw_verifier::{
-    commit_verifier_slot, dsm_verifier_pairing_pubkey, read_verifier_slot, VerifierSlotState,
-    ALLOW_FACTORY_OPEN, DENY, VERIFIER_SLOT,
+    commit_verifier_slot, dsm_verifier_pairing_pubkey, find_provisioned_slot,
+    preflight_verifier_slot, read_verifier_slot, VerifierSlotState, ALLOW_FACTORY_OPEN, DENY,
+    VERIFIER_SLOT_CANDIDATES,
 };
 
-fn print_plan() {
+fn print_plan(slot: u16) {
     println!("--- verifier-slot burn PLAN (no writes performed) ---");
-    println!("  target slot        : {VERIFIER_SLOT}  (slot 0 host NEVER touched; slots 2/3 NEVER written)");
+    println!(
+        "  target slot        : {slot}  (slot 0 host NEVER touched; other slots NEVER written)"
+    );
     println!(
         "  fixed verifier pub : {:02x?}",
         dsm_verifier_pairing_pubkey()
     );
-    println!("  cage = revoke SH1 access to (I_CONFIG_WRITE applied LAST):");
+    println!("  cage = revoke slot-{slot} access to (I_CONFIG_WRITE applied LAST):");
     for (addr, name) in DENY {
         let last = if *addr == 0x040 { "   <- LAST" } else { "" };
         println!("      0x{addr:03x}  {name}{last}");
     }
-    println!("  left factory-open (SH1 keeps access):");
+    println!("  left factory-open (slot keeps access):");
     for (addr, name) in ALLOW_FACTORY_OPEN {
         println!("      0x{addr:03x}  {name}");
     }
     println!("  method             : i-config only (no r-config erase); irreversible.");
+}
+
+/// Parse `--slot N` or `--slot=N`.
+fn parse_slot(args: &[String]) -> Option<u16> {
+    args.windows(2)
+        .find(|w| w[0] == "--slot")
+        .and_then(|w| w[1].parse().ok())
+        .or_else(|| {
+            args.iter()
+                .find_map(|a| a.strip_prefix("--slot=").and_then(|s| s.parse().ok()))
+        })
+}
+
+fn require_slot(slot: Option<u16>) -> u16 {
+    match slot {
+        Some(s) if VERIFIER_SLOT_CANDIDATES.contains(&s) => s,
+        Some(s) => {
+            eprintln!("[verifier-slot] --slot {s} is not a valid verifier index (must be one of {VERIFIER_SLOT_CANDIDATES:?})");
+            std::process::exit(2);
+        }
+        None => {
+            eprintln!("[verifier-slot] this subcommand requires --slot N (one of {VERIFIER_SLOT_CANDIDATES:?})");
+            std::process::exit(2);
+        }
+    }
 }
 
 fn main() {
@@ -51,7 +86,7 @@ fn main() {
         .find(|a| !a.starts_with("--") && !a.starts_with("/dev"))
         .cloned()
         .unwrap_or_else(|| "status".to_string());
-    let confirmed = args.iter().any(|a| a == "--yes-burn-slot-1");
+    let slot = parse_slot(&args);
     let dev = args
         .iter()
         .find(|a| a.starts_with("/dev"))
@@ -63,52 +98,81 @@ fn main() {
         port: usb::open_and_drain(&dev),
     };
 
-    eprintln!("[verifier-slot] cmd={cmd} port={dev}");
+    eprintln!("[verifier-slot] cmd={cmd} slot={slot:?} port={dev}");
 
     match cmd.as_str() {
-        "status" | "plan" => {
-            match read_verifier_slot(make()) {
-                Ok(VerifierSlotState::Provisioned { stpub }) => {
-                    println!("[status] slot {VERIFIER_SLOT}: PROVISIONED (fixed DSM verifier key, caged read-only)");
-                    println!("[status] chip stpub: {stpub:02x?}");
-                    println!("[status] -> already provisioned; a commit would be a no-op.");
+        "status" => match slot {
+            Some(s) => {
+                let s = require_slot(Some(s));
+                match read_verifier_slot(s, make()) {
+                    Ok(VerifierSlotState::Provisioned { stpub }) => {
+                        println!("[status] slot {s}: PROVISIONED (fixed DSM verifier key, caged read-only)");
+                        println!("[status] chip stpub: {stpub:02x?}");
+                    }
+                    Ok(VerifierSlotState::Empty { stpub }) => {
+                        println!("[status] slot {s}: EMPTY (eligible for an explicit commit)");
+                        println!("[status] chip stpub: {stpub:02x?}");
+                    }
+                    Ok(VerifierSlotState::Occupied) => {
+                        println!("[status] slot {s}: OCCUPIED by a NON-fixed key or not caged.");
+                        println!("[status] -> FAIL CLOSED: will NOT overwrite. Choose a different empty slot.");
+                    }
+                    Err(e) => {
+                        eprintln!("[status] read failed (fail-closed): {e:?}");
+                        std::process::exit(1);
+                    }
                 }
-                Ok(VerifierSlotState::Empty { stpub }) => {
-                    println!(
-                        "[status] slot {VERIFIER_SLOT}: EMPTY (eligible for an explicit commit)"
-                    );
+            }
+            None => match find_provisioned_slot(make) {
+                Ok(Some((s, stpub))) => {
+                    println!("[status] verifier role PROVISIONED at slot {s}");
                     println!("[status] chip stpub: {stpub:02x?}");
                 }
-                Ok(VerifierSlotState::Occupied) => {
-                    println!(
-                        "[status] slot {VERIFIER_SLOT}: OCCUPIED by a NON-fixed key or not caged."
-                    );
-                    println!("[status] -> FAIL CLOSED: will NOT overwrite. Do NOT use slots 2/3 as a fallback.");
+                Ok(None) => println!("[status] no verifier slot provisioned on any candidate index {VERIFIER_SLOT_CANDIDATES:?}"),
+                Err(e) => {
+                    eprintln!("[status] scan failed (fail-closed): {e:?}");
+                    std::process::exit(1);
+                }
+            },
+        },
+        "preflight" => {
+            let s = require_slot(slot);
+            match preflight_verifier_slot(s, make()) {
+                Ok(r) => {
+                    println!("[preflight] slot {}: WOULD PROCEED — all read-only checks passed.", r.slot);
+                    println!("[preflight] chip stpub      : {:02x?}", r.stpub);
+                    println!("[preflight] mcounter[0]     : {}", r.mcounter);
+                    println!("[preflight] slot {} SlotEmpty : yes  |  UAP factory-open: yes  |  counter reads: yes", r.slot);
+                    println!();
+                    print_plan(s);
+                    println!("\n[preflight] DRY-RUN only, nothing written. If this is the intended chip + slot,");
+                    println!("[preflight] run: commit --slot {s} --yes-burn-slot-{s} <port>");
                 }
                 Err(e) => {
-                    eprintln!("[status] read failed (fail-closed): {e:?}");
+                    eprintln!("[preflight] NOT eligible (nothing written): {e:?}");
                     std::process::exit(1);
                 }
             }
-            if cmd == "plan" {
-                println!();
-                print_plan();
-                println!("\n[plan] DRY-RUN only. Re-run `commit ... --yes-burn-slot-1` to burn.");
-            }
         }
         "commit" => {
-            if !confirmed {
-                eprintln!(
-                    "[commit] REFUSING: the burn is irreversible. Pass --yes-burn-slot-1 to proceed \
-                     (only after the runbook checks + fresh operator approval)."
-                );
+            let s = require_slot(slot);
+            // The confirmation flag must name the SAME slot as --slot. A mismatch is a hard stop.
+            let want = format!("--yes-burn-slot-{s}");
+            let has_want = args.iter().any(|a| *a == want);
+            let has_other = args
+                .iter()
+                .any(|a| a.starts_with("--yes-burn-slot-") && *a != want);
+            if has_other {
+                eprintln!("[commit] REFUSING: a --yes-burn-slot-* flag names a DIFFERENT slot than --slot {s}. Fix the mismatch.");
                 std::process::exit(2);
             }
-            print_plan();
-            println!(
-                "\n[commit] --yes-burn-slot-1 given; running the irreversible provisioning..."
-            );
-            match commit_verifier_slot(make) {
+            if !has_want {
+                eprintln!("[commit] REFUSING: the burn is irreversible. Pass {want} to proceed (only after preflight + fresh approval).");
+                std::process::exit(2);
+            }
+            print_plan(s);
+            println!("\n[commit] {want} given; running the irreversible provisioning of slot {s}...");
+            match commit_verifier_slot(s, make) {
                 Ok((slot, stpub)) => {
                     println!("\n[PASS] slot {slot} is the caged DSM SMT-root verifier slot.");
                     println!("[disclosure] verifier_slot     = {slot}");
@@ -121,7 +185,7 @@ fn main() {
             }
         }
         other => {
-            eprintln!("[verifier-slot] unknown subcommand '{other}' (use: status | plan | commit)");
+            eprintln!("[verifier-slot] unknown subcommand '{other}' (use: status | preflight | commit)");
             std::process::exit(2);
         }
     }

--- a/crates/dsm-anchor-hw-verifier/src/lib.rs
+++ b/crates/dsm-anchor-hw-verifier/src/lib.rs
@@ -23,8 +23,9 @@ mod relay_driver;
 mod session;
 
 pub use provisioner::{
-    commit_verifier_slot, read_verifier_slot, ProvisionError, VerifierSlotState,
-    ALLOW_FACTORY_OPEN, DENY, VERIFIER_SLOT,
+    commit_verifier_slot, find_provisioned_slot, preflight_verifier_slot, read_verifier_slot,
+    PreflightReport, ProvisionError, VerifierSlotState, ALLOW_FACTORY_OPEN, DENY, VERIFIER_SLOT,
+    VERIFIER_SLOT_CANDIDATES,
 };
 pub use reader::{
     dsm_verifier_pairing_pubkey, dsm_verifier_pairing_secret_bytes, DsmVerifierPairingDeriver,

--- a/crates/dsm-anchor-hw-verifier/src/provisioner.rs
+++ b/crates/dsm-anchor-hw-verifier/src/provisioner.rs
@@ -1,24 +1,19 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! The DSM SMT-root verifier slot: read + (gated) provision the ONE caged read-only counter slot on
-//! a TROPIC01, over any [`SpiRelayChannel`]. Factored channel-generic from the exact write -> cage
-//! -> reboot -> verify sequence the bench CLIs (`usb_provision_verifier_slot` /
-//! `usb_verify_verifier_slot`) proved on hardware in Phase G, so the on-device SeSlotWriter runs the
-//! same proven steps over the Phone->Pico USB relay.
+//! The DSM SMT-root verifier slot: read / preflight / (gated) provision the ONE caged read-only
+//! counter slot on a TROPIC01, over any [`SpiRelayChannel`]. Factored channel-generic from the exact
+//! write -> cage -> reboot -> verify sequence the bench proved on hardware in Phase G.
 //!
-//! Slot map (fixed, never negotiated):
-//! ```text
-//! slot 0     = owner/admin host session (PROD0)
-//! slot 1     = the fixed DSM SMT-root verifier slot
-//! slots 2/3  = RESERVED — never allocated, never a fallback
-//! ```
-//! One caged slot serves every relationship: the verifier pairing key is the fixed DSM constant
-//! (see [`dsm_verifier_pairing_secret_bytes`]); the per-receiver binding is the pinned chip identity
-//! + the SMT proof + the DSM predicate, not this session key.
+//! **Role vs index.** There is exactly ONE verifier-slot ROLE (the fixed DSM verifier key — see
+//! [`dsm_verifier_pairing_secret_bytes`]); it serves every relationship (the per-receiver binding is
+//! the pinned chip identity + the SMT proof + the DSM predicate, not this session key). Which physical
+//! pairing-key INDEX holds that role is a per-chip deployment detail: index 1 on a fresh chip, or
+//! index 2/3 on a dev chip whose lower slot is already spent. The commit takes the index EXPLICITLY
+//! (never auto-selected — no silent fallback); the disclosure read SCANS the candidate indices to
+//! LOCATE the role. Slot 0 (host) is never a verifier slot.
 //!
-//! [`read_verifier_slot`] is NON-DESTRUCTIVE (the transfer path uses it). [`commit_verifier_slot`]
-//! performs the IRREVERSIBLE burn and must only ever run under an explicit setup/commit gate — never
-//! as a side effect of app boot. It refuses to overwrite a non-empty slot (an old demo/per-
-//! relationship key fails closed), so it can never clobber existing key material.
+//! [`read_verifier_slot`] / [`find_provisioned_slot`] / [`preflight_verifier_slot`] are NON-
+//! DESTRUCTIVE. [`commit_verifier_slot`] performs the IRREVERSIBLE burn and must only ever run under
+//! an explicit setup/commit gate. It refuses to overwrite a non-empty slot.
 
 use std::time::{Duration, Instant};
 
@@ -30,16 +25,22 @@ use zerocopy::little_endian::U16;
 
 use crate::reader::{dsm_verifier_pairing_pubkey, dsm_verifier_pairing_secret_bytes};
 
-/// The fixed DSM SMT-root verifier slot. NEVER slot 0 (host) and NEVER slots 2/3 (reserved).
+/// The canonical (fresh-chip) verifier-slot index. A specific dev chip may place the single verifier
+/// role at another free index (e.g. 2) — pass it explicitly.
 pub const VERIFIER_SLOT: u16 = 1;
 
-/// Absolute bit indices of the SH1 (slot-1) access bit across the 4 lanes of a UAP register.
-const SH1_BITS: [u8; 4] = [1, 9, 17, 25];
+/// Pairing-key indices that MAY hold the verifier role — never slot 0 (host). The disclosure read
+/// scans these to locate the role wherever it was provisioned.
+pub const VERIFIER_SLOT_CANDIDATES: &[u16] = &[1, 2, 3];
 
-/// Registers whose SH1 access is REVOKED to cage the verifier slot to MCOUNTER_GET only, with names
-/// for the bench dry-run. `I_CONFIG_WRITE` (0x040) is LAST so the sweep cannot lock out the writes
-/// that build the cage, and so the caged slot can never loosen its own cage afterward. `pub` so the
-/// bench runbook CLI can print the exact deny list operators are about to burn.
+/// Absolute bit indices of the SH1..SH3 access bit... note the cage always targets the SELECTED
+/// slot's session bit; see `sh_mask_for`. The four lanes carry the access bit per session.
+const SH_LANES: [u8; 4] = [0, 8, 16, 24];
+
+/// Registers whose access is REVOKED to cage the verifier slot to MCOUNTER_GET only, with names for
+/// the bench dry-run. `I_CONFIG_WRITE` (0x040) is LAST so the sweep cannot lock out the writes that
+/// build the cage, and so the caged slot can never loosen its own cage afterward. `pub` so the bench
+/// runbook CLI can print the exact deny list operators are about to burn.
 pub const DENY: &[(u16, &str)] = &[
     (0x020, "PAIRING_KEY_WRITE"),
     (0x024, "PAIRING_KEY_READ"),
@@ -60,7 +61,7 @@ pub const DENY: &[(u16, &str)] = &[
     (0x040, "I_CONFIG_WRITE"), // LAST
 ];
 
-/// Registers left at factory (SH1 keeps access): the counter read + harmless reads.
+/// Registers left at factory (the slot keeps access): the counter read + harmless reads.
 pub const ALLOW_FACTORY_OPEN: &[(u16, &str)] = &[
     (0x154, "MCOUNTER_GET"), // needed
     (0x100, "PING"),
@@ -69,8 +70,8 @@ pub const ALLOW_FACTORY_OPEN: &[(u16, &str)] = &[
     (0x044, "I_CONFIG_READ"),
 ];
 
-/// The security-critical writes whose SH1 access MUST be revoked for the slot to count as caged
-/// (the exact set the Phase-G verify tool proved). Checked NON-destructively via `i_config_read`.
+/// The security-critical writes whose access MUST be revoked for the slot to count as caged (the set
+/// the Phase-G verify tool proved). Checked NON-destructively via `i_config_read`.
 const CAGE_CHECK: &[u16] = &[
     0x020, // PAIRING_KEY_WRITE
     0x040, // I_CONFIG_WRITE (self-cage-lock)
@@ -79,20 +80,34 @@ const CAGE_CHECK: &[u16] = &[
     0x160, // MAC_AND_DESTROY
 ];
 
-/// SH1 access mask across the 4 UAP lanes (bits {1,9,17,25}); zero means SH1 is denied that command.
-const SH1_MASK: u32 = 0x0202_0202;
+/// The UAP access mask across the 4 lanes for the given pairing slot's session bit (SH`slot`). Zero
+/// in the masked bits means that session is denied the command. `slot` is 1..=3 (session bit = slot).
+fn sh_mask_for(slot: u16) -> u32 {
+    let bit = slot as u32; // session bit index within a lane: SH1=1, SH2=2, SH3=3
+    SH_LANES
+        .iter()
+        .fold(0u32, |m, lane| m | (1u32 << (*lane as u32 + bit)))
+}
 
-/// Non-destructive state of the verifier slot.
+/// Non-destructive state of a specific verifier-slot index.
 pub enum VerifierSlotState {
-    /// Slot 1 holds the fixed DSM verifier key AND is correctly caged read-only. Ready to use:
-    /// disclose `(VERIFIER_SLOT, stpub)`.
+    /// Holds the fixed DSM verifier key AND is correctly caged read-only. Disclose `(index, stpub)`.
     Provisioned { stpub: [u8; 32] },
-    /// Slot 1 is empty — provisioning MAY proceed, but ONLY under an explicit commit gate.
+    /// Empty — provisioning MAY proceed at this index, but ONLY under an explicit commit gate.
     Empty { stpub: [u8; 32] },
-    /// Slot 1 holds a NON-fixed key, or the fixed key without the correct cage (e.g. an old
-    /// demo/per-relationship key, or a half-finished provision). FAIL CLOSED: never overwrite,
-    /// never disclose.
+    /// Holds a NON-fixed key, or the fixed key without the correct cage (e.g. an old demo/per-
+    /// relationship key, or a half-finished provision). FAIL CLOSED: never overwrite, never disclose.
     Occupied,
+}
+
+/// Read-only preflight facts an operator sees BEFORE any burn.
+pub struct PreflightReport {
+    /// The slot index the burn would target.
+    pub slot: u16,
+    /// The chip's Noise static public key (its identity) — confirm this is the intended chip.
+    pub stpub: [u8; 32],
+    /// The current monotonic counter value (proves the counter reads).
+    pub mcounter: u32,
 }
 
 /// Provisioning / read errors. All map to fail-closed at the SeSlotWriter boundary.
@@ -105,6 +120,8 @@ pub enum ProvisionError {
     Precondition(String),
     /// The post-burn cage verification did not match the required MCOUNTER_GET-only surface.
     CageVerify(String),
+    /// The requested slot index is not a valid verifier candidate (must be 1..=3, never slot 0).
+    BadSlot(u16),
     /// CSPRNG unavailable for a handshake ephemeral.
     Rng,
 }
@@ -120,15 +137,23 @@ fn is_unauthorized<A, B>(r: &Result<impl Sized, TrError<A, B>>) -> bool {
     matches!(r, Err(TrError::Unauthorized))
 }
 
-/// Read the verifier slot's state WITHOUT writing anything (strictly read-only — safe on the
-/// transfer path and at boot). Opens the host slot-0 session, reads slot 1's pairing key, and — if
-/// it is the fixed key — confirms the cage via `i_config_read` of the security-critical registers
-/// (SH1 access bits cleared). No slot-1 session and no write is attempted, so this can never mutate
-/// or provision. The chip type is left inferred (it is parameterized by `dummy_pin::DummyPin`, a
-/// tropic01 internal we do not name).
+fn check_slot(slot: u16) -> Result<(), ProvisionError> {
+    if VERIFIER_SLOT_CANDIDATES.contains(&slot) {
+        Ok(())
+    } else {
+        Err(ProvisionError::BadSlot(slot))
+    }
+}
+
+/// Classify a SPECIFIC verifier-slot index WITHOUT writing anything (strictly read-only). Opens the
+/// host slot-0 session, reads the slot's pairing key, and — if it is the fixed key — confirms the
+/// cage via `i_config_read` of the security-critical registers (the slot's access bits cleared). No
+/// session as the verifier slot and no write is attempted, so this can never mutate or provision.
 pub fn read_verifier_slot<C: SpiRelayChannel>(
+    slot: u16,
     channel: C,
 ) -> Result<VerifierSlotState, ProvisionError> {
+    check_slot(slot)?;
     let mut chip = Tropic01::new(RemoteSpiDevice::new(channel));
     let stpub = *chip
         .get_info_cert_store()
@@ -136,6 +161,7 @@ pub fn read_verifier_slot<C: SpiRelayChannel>(
         .public_key()
         .map_err(|e| ProvisionError::Chip(format!("cert public_key: {e:?}")))?;
     let fixed_pub = dsm_verifier_pairing_pubkey();
+    let mask = sh_mask_for(slot);
 
     let eh = fresh_ephemeral()?;
     let mut s0 = chip
@@ -149,53 +175,131 @@ pub fn read_verifier_slot<C: SpiRelayChannel>(
         )
         .map_err(|(_, e)| ProvisionError::Chip(format!("slot-0 session_start: {e:?}")))?;
 
-    let slot1 = s0.pairing_key_read(U16::new(VERIFIER_SLOT)).map(|k| *k);
-    // Only the specific `SlotEmpty` status means an unwritten slot. ANY other error (transport,
-    // session, hardware) is ambiguous and must NOT be classified as Empty — that would let a commit
-    // proceed to a burn on a slot whose emptiness was never confirmed. Propagate it as a Chip error
-    // (fail-closed at the caller). The cage check needs `s0`, so classify before aborting.
-    let result: Result<VerifierSlotState, ProvisionError> = match slot1 {
+    let key = s0.pairing_key_read(U16::new(slot)).map(|k| *k);
+    // Only the specific `SlotEmpty` status means an unwritten slot. ANY other error is ambiguous and
+    // must NOT be classified as Empty (that would let a commit burn on an unconfirmed slot).
+    let result: Result<VerifierSlotState, ProvisionError> = match key {
         Err(TrError::SlotEmpty) => Ok(VerifierSlotState::Empty { stpub }),
         Err(e) => Err(ProvisionError::Chip(format!(
-            "pairing_key_read slot {VERIFIER_SLOT}: {e:?}"
+            "pairing_key_read slot {slot}: {e:?}"
         ))),
-        // A key is present: it must be EXACTLY the fixed key, and the cage must be configured.
         Ok(k) if k == fixed_pub => {
-            // Pure-read cage check: every security-critical register must have SH1 access cleared.
-            let caged = CAGE_CHECK.iter().all(
-                |addr| matches!(s0.i_config_read(U16::new(*addr)), Ok(v) if v & SH1_MASK == 0),
-            );
+            // Pure-read cage check: every security-critical register must have this slot's access cleared.
+            let caged = CAGE_CHECK
+                .iter()
+                .all(|addr| matches!(s0.i_config_read(U16::new(*addr)), Ok(v) if v & mask == 0));
             if caged {
                 Ok(VerifierSlotState::Provisioned { stpub })
             } else {
-                // Fixed key but not (fully) caged = half-provisioned; fail closed (re-commit re-cages).
                 Ok(VerifierSlotState::Occupied)
             }
         }
-        // Any other key (e.g. an old demo/per-relationship key) — never overwrite, never disclose.
         Ok(_) => Ok(VerifierSlotState::Occupied),
     };
-    // Abort the slot-0 session on every path (before surfacing an error).
     s0.session_abort()
         .map_err(|(_, e)| ProvisionError::Chip(format!("slot-0 abort: {e:?}")))?;
     result
 }
 
-/// Provision the verifier slot — the IRREVERSIBLE burn. MUST be called only under an explicit
-/// setup/commit gate. Idempotent when already provisioned; refuses (fail-closed) to overwrite any
-/// non-empty slot. `make_channel` mints a fresh relay channel per session (the non-destructive
-/// classification read and the burn each need their own).
-pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
+/// Scan the candidate indices to LOCATE the single provisioned verifier role. Returns `Some((index,
+/// stpub))` for the first index that reads back as `Provisioned`, else `None`. Non-destructive.
+/// `make_channel` mints a fresh relay channel per probed index.
+pub fn find_provisioned_slot<C: SpiRelayChannel, F: Fn() -> C>(
     make_channel: F,
-) -> Result<(u8, [u8; 32]), ProvisionError> {
+) -> Result<Option<(u16, [u8; 32])>, ProvisionError> {
+    for &slot in VERIFIER_SLOT_CANDIDATES {
+        if let VerifierSlotState::Provisioned { stpub } = read_verifier_slot(slot, make_channel())?
+        {
+            return Ok(Some((slot, stpub)));
+        }
+    }
+    Ok(None)
+}
+
+/// Read-only dry-run of the burn's ENTIRE gating logic for `slot`, on the actual chip: the slot reads
+/// back `SlotEmpty`, the counter is readable, and every deny/allow register is factory-open. Returns
+/// the [`PreflightReport`] (chip identity + counter) iff a commit WOULD proceed. Writes NOTHING.
+pub fn preflight_verifier_slot<C: SpiRelayChannel>(
+    slot: u16,
+    channel: C,
+) -> Result<PreflightReport, ProvisionError> {
+    check_slot(slot)?;
+    let mut chip = Tropic01::new(RemoteSpiDevice::new(channel));
+    let stpub = *chip
+        .get_info_cert_store()
+        .map_err(|e| ProvisionError::Chip(format!("get_info_cert_store: {e:?}")))?
+        .public_key()
+        .map_err(|e| ProvisionError::Chip(format!("cert public_key: {e:?}")))?;
+
+    let eh = fresh_ephemeral()?;
+    let mut s0 = chip
+        .session_start(
+            &X25519Dalek,
+            PublicKey::from(SH0PUB_PROD0),
+            StaticSecret::from(SH0PRIV_PROD0),
+            PublicKey::from(&eh),
+            eh,
+            0,
+        )
+        .map_err(|(_, e)| ProvisionError::Chip(format!("slot-0 session_start: {e:?}")))?;
+
+    // Preflight body (read-only) inline, so the open-session chip type stays inferred.
+    let report = (|| -> Result<PreflightReport, ProvisionError> {
+        match s0.pairing_key_read(U16::new(slot)) {
+            Err(TrError::SlotEmpty) => {}
+            Ok(_) => {
+                return Err(ProvisionError::Precondition(format!(
+                    "slot {slot} is non-empty; refusing to burn (no overwrite)"
+                )))
+            }
+            Err(e) => {
+                return Err(ProvisionError::Chip(format!(
+                    "preflight pairing_key_read slot {slot} (emptiness unconfirmed): {e:?}"
+                )))
+            }
+        }
+        let mcounter = s0
+            .mcounter_get(MCounterIndex::Index0)
+            .map_err(|e| ProvisionError::Precondition(format!("mcounter unreadable: {e:?}")))?;
+        for (addr, name) in DENY.iter().chain(ALLOW_FACTORY_OPEN.iter()) {
+            let r = s0.r_config_read(U16::new(*addr));
+            let i = s0.i_config_read(U16::new(*addr));
+            match (r, i) {
+                (Ok(r), Ok(i)) if r == 0xffff_ffff && i == 0xffff_ffff => {}
+                (r, i) => {
+                    return Err(ProvisionError::Precondition(format!(
+                    "0x{addr:03x} {name} not factory-open (r={r:?} i={i:?}); refusing to provision"
+                )))
+                }
+            }
+        }
+        Ok(PreflightReport {
+            slot,
+            stpub,
+            mcounter,
+        })
+    })();
+    s0.session_abort()
+        .map_err(|(_, e)| ProvisionError::Chip(format!("slot-0 abort: {e:?}")))?;
+    report
+}
+
+/// Provision the verifier role at `slot` — the IRREVERSIBLE burn. MUST be called only under an
+/// explicit setup/commit gate. Idempotent when `slot` already holds the fixed key + cage; refuses
+/// (fail-closed) to overwrite any non-empty slot. `make_channel` mints a fresh relay channel per
+/// session (the non-destructive classification read and the burn each need their own).
+pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
+    slot: u16,
+    make_channel: F,
+) -> Result<(u16, [u8; 32]), ProvisionError> {
+    check_slot(slot)?;
     // 1) Classify the slot non-destructively first.
-    match read_verifier_slot(make_channel())? {
-        VerifierSlotState::Provisioned { stpub } => return Ok((VERIFIER_SLOT as u8, stpub)),
+    match read_verifier_slot(slot, make_channel())? {
+        VerifierSlotState::Provisioned { stpub } => return Ok((slot, stpub)),
         VerifierSlotState::Occupied => {
-            return Err(ProvisionError::Precondition(
-                "slot 1 is occupied by a non-fixed key or is not caged; refusing to overwrite"
-                    .into(),
-            ))
+            return Err(ProvisionError::Precondition(format!(
+                "slot {slot} is occupied by a non-fixed key or is not caged; refusing to overwrite"
+            )))
         }
         VerifierSlotState::Empty { .. } => {}
     }
@@ -222,53 +326,53 @@ pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
         )
         .map_err(|(_, e)| ProvisionError::Chip(format!("commit slot-0 session_start: {e:?}")))?;
 
-    // 2a) Preflight: slot 1 must POSITIVELY read as `SlotEmpty` (not merely error) before any write —
-    // an ambiguous transport error must abort the burn, never fall through to it. Then counter
-    // readable + every DENY+ALLOW register factory-open.
-    match s0.pairing_key_read(U16::new(VERIFIER_SLOT)) {
+    // 2a) Preflight (positive SlotEmpty + factory-open + readable counter) — writes nothing. Inline
+    // so the open-session chip type stays inferred; identical checks to `preflight_verifier_slot`.
+    match s0.pairing_key_read(U16::new(slot)) {
         Err(TrError::SlotEmpty) => {}
         Ok(_) => {
-            return Err(ProvisionError::Precondition(
-                "slot 1 is non-empty; refusing to overwrite".into(),
-            ))
+            return Err(ProvisionError::Precondition(format!(
+                "slot {slot} became non-empty before write; refusing to overwrite"
+            )))
         }
         Err(e) => {
             return Err(ProvisionError::Chip(format!(
-                "preflight pairing_key_read (emptiness unconfirmed): {e:?}"
+                "commit preflight pairing_key_read slot {slot}: {e:?}"
             )))
         }
     }
     s0.mcounter_get(MCounterIndex::Index0)
         .map_err(|e| ProvisionError::Precondition(format!("mcounter unreadable: {e:?}")))?;
-    for (addr, _name) in DENY.iter().chain(ALLOW_FACTORY_OPEN.iter()) {
+    for (addr, name) in DENY.iter().chain(ALLOW_FACTORY_OPEN.iter()) {
         let r = s0.r_config_read(U16::new(*addr));
         let i = s0.i_config_read(U16::new(*addr));
         match (r, i) {
             (Ok(r), Ok(i)) if r == 0xffff_ffff && i == 0xffff_ffff => {}
             (r, i) => {
                 return Err(ProvisionError::Precondition(format!(
-                    "0x{addr:03x} not factory-open (r={r:?} i={i:?}); refusing to provision"
+                    "0x{addr:03x} {name} not factory-open (r={r:?} i={i:?}); refusing to provision"
                 )))
             }
         }
     }
 
     // 2b) Write the fixed verifier pubkey, verify read-back.
-    s0.pairing_key_write(U16::new(VERIFIER_SLOT), &fixed_pub)
+    s0.pairing_key_write(U16::new(slot), &fixed_pub)
         .map_err(|e| ProvisionError::Chip(format!("pairing_key_write: {e:?}")))?;
-    match s0.pairing_key_read(U16::new(VERIFIER_SLOT)).map(|k| *k) {
+    match s0.pairing_key_read(U16::new(slot)).map(|k| *k) {
         Ok(k) if k == fixed_pub => {}
         other => {
             return Err(ProvisionError::Chip(format!(
-                "slot 1 read-back mismatch after write: {other:?}"
+                "slot {slot} read-back mismatch after write: {other:?}"
             )))
         }
     }
 
-    // 2c) Cage: revoke SH1 access to every DENY register (I_CONFIG_WRITE last, by list order).
+    // 2c) Cage: revoke this slot's access to every DENY register (I_CONFIG_WRITE last, by list order).
     for (addr, _name) in DENY {
-        for bit in SH1_BITS {
-            s0.i_config_write(U16::new(*addr), bit).map_err(|e| {
+        for lane in SH_LANES {
+            let bit = (lane as u16) + slot; // absolute bit index of SH`slot` in this lane
+            s0.i_config_write(U16::new(*addr), bit as u8).map_err(|e| {
                 ProvisionError::Chip(format!("i_config_write(0x{addr:03x} bit {bit}): {e:?}"))
             })?;
         }
@@ -293,7 +397,8 @@ pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
         }
     }
 
-    // 2e) Verify the caged surface AS slot 1: MCOUNTER_GET ok; INIT/PAIRING_WRITE/I_CONFIG_WRITE denied.
+    // 2e) Verify the caged surface AS the verifier slot: MCOUNTER_GET ok; INIT/PAIRING_WRITE/
+    // I_CONFIG_WRITE denied.
     let eh1 = fresh_ephemeral()?;
     let mut v = chip
         .session_start(
@@ -302,12 +407,12 @@ pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
             StaticSecret::from(fixed_priv),
             PublicKey::from(&eh1),
             eh1,
-            VERIFIER_SLOT as u8,
+            slot as u8,
         )
         .map_err(|(_, e)| ProvisionError::CageVerify(format!("verifier session_start: {e:?}")))?;
     let get = v.mcounter_get(MCounterIndex::Index0);
-    let init = v.mcounter_init(MCounterIndex::Index0, 1000);
-    let pkw = v.pairing_key_write(U16::new(VERIFIER_SLOT), &fixed_pub);
+    let init = v.mcounter_init(MCounterIndex::Index0, 1000); // value irrelevant; expected denied
+    let pkw = v.pairing_key_write(U16::new(slot), &fixed_pub);
     let icw = v.i_config_write(U16::new(0x040), 1);
     let chip = v
         .session_abort()
@@ -328,10 +433,8 @@ pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
     let slot0_get = s0.mcounter_get(MCounterIndex::Index0);
     let _ = s0.session_abort();
 
-    // The security invariant is that each mutating command did NOT execute: ANY Err == not executed
-    // == denied (matches the proven bench gate). A transport glitch on a probe is still "not
-    // executed", so gate on `.is_err()`; keep the Unauthorized check as a diagnostic only, so a
-    // non-Unauthorized denial does not turn a correctly-caged slot into a false CageVerify failure.
+    // Any Err on a mutating command == not executed == denied (matches the proven bench gate). Keep
+    // the Unauthorized check only as a diagnostic so a non-Unauthorized denial does not false-fail.
     let denied_as_expected =
         is_unauthorized(&init) && is_unauthorized(&pkw) && is_unauthorized(&icw);
     if !denied_as_expected {
@@ -345,5 +448,46 @@ pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
             "caged surface wrong: get={get:?} init={init:?} pkw={pkw:?} icw={icw:?} slot0={slot0_get:?}"
         )));
     }
-    Ok((VERIFIER_SLOT as u8, stpub))
+    Ok((slot, stpub))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sh_mask_matches_the_session_bit_per_lane() {
+        // Session bit N within each lane byte (SH1=bit1, SH2=bit2, SH3=bit3), 4 lanes at 0/8/16/24.
+        assert_eq!(sh_mask_for(1), 0x0202_0202, "SH1 = bits {{1,9,17,25}}");
+        assert_eq!(sh_mask_for(2), 0x0404_0404, "SH2 = bits {{2,10,18,26}}");
+        assert_eq!(sh_mask_for(3), 0x0808_0808, "SH3 = bits {{3,11,19,27}}");
+    }
+
+    #[test]
+    fn cage_sweep_bits_are_absolute_and_match_the_mask() {
+        // The commit sweep writes bits (lane + slot); their OR must equal the read-path mask.
+        for &slot in VERIFIER_SLOT_CANDIDATES {
+            let mut swept = 0u32;
+            for lane in SH_LANES {
+                swept |= 1u32 << (lane as u32 + slot as u32);
+            }
+            assert_eq!(
+                swept,
+                sh_mask_for(slot),
+                "sweep vs mask mismatch for slot {slot}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_candidate_slots_are_accepted() {
+        assert!(
+            check_slot(0).is_err(),
+            "slot 0 (host) is never a verifier slot"
+        );
+        assert!(check_slot(4).is_err(), "slot 4 is out of range");
+        for &s in VERIFIER_SLOT_CANDIDATES {
+            assert!(check_slot(s).is_ok());
+        }
+    }
 }

--- a/crates/dsm-anchor-hw-verifier/src/provisioner.rs
+++ b/crates/dsm-anchor-hw-verifier/src/provisioner.rs
@@ -261,14 +261,19 @@ pub fn preflight_verifier_slot<C: SpiRelayChannel>(
         let mcounter = s0
             .mcounter_get(MCounterIndex::Index0)
             .map_err(|e| ProvisionError::Precondition(format!("mcounter unreadable: {e:?}")))?;
+        // The SELECTED slot must currently have FULL (factory) access at every deny/allow register,
+        // so the cage is a real restriction and the slot retains the allow set. Only THIS slot's
+        // access bits are checked — a lower slot already caged on the same chip (e.g. slot 1 on a dev
+        // chip) leaves other lanes' bits cleared, which is irrelevant to provisioning this slot.
+        let mask = sh_mask_for(slot);
         for (addr, name) in DENY.iter().chain(ALLOW_FACTORY_OPEN.iter()) {
             let r = s0.r_config_read(U16::new(*addr));
             let i = s0.i_config_read(U16::new(*addr));
             match (r, i) {
-                (Ok(r), Ok(i)) if r == 0xffff_ffff && i == 0xffff_ffff => {}
+                (Ok(r), Ok(i)) if r & mask == mask && i & mask == mask => {}
                 (r, i) => {
                     return Err(ProvisionError::Precondition(format!(
-                    "0x{addr:03x} {name} not factory-open (r={r:?} i={i:?}); refusing to provision"
+                    "0x{addr:03x} {name}: slot-{slot} access not factory-open (r={r:?} i={i:?}); refusing to provision"
                 )))
                 }
             }
@@ -343,14 +348,15 @@ pub fn commit_verifier_slot<C: SpiRelayChannel, F: Fn() -> C>(
     }
     s0.mcounter_get(MCounterIndex::Index0)
         .map_err(|e| ProvisionError::Precondition(format!("mcounter unreadable: {e:?}")))?;
+    let mask = sh_mask_for(slot);
     for (addr, name) in DENY.iter().chain(ALLOW_FACTORY_OPEN.iter()) {
         let r = s0.r_config_read(U16::new(*addr));
         let i = s0.i_config_read(U16::new(*addr));
         match (r, i) {
-            (Ok(r), Ok(i)) if r == 0xffff_ffff && i == 0xffff_ffff => {}
+            (Ok(r), Ok(i)) if r & mask == mask && i & mask == mask => {}
             (r, i) => {
                 return Err(ProvisionError::Precondition(format!(
-                    "0x{addr:03x} {name} not factory-open (r={r:?} i={i:?}); refusing to provision"
+                    "0x{addr:03x} {name}: slot-{slot} access not factory-open (r={r:?} i={i:?}); refusing to provision"
                 )))
             }
         }

--- a/crates/dsm-android-anchor/src/se_slot.rs
+++ b/crates/dsm-android-anchor/src/se_slot.rs
@@ -1,48 +1,48 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! H3 sender-side SE op: the DSM SMT-root verifier slot on A's OWN TROPIC01.
+//! H3 sender-side SE seam: disclose the DSM SMT-root verifier slot on A's OWN TROPIC01.
 //!
-//! Two entry points, matching the owner's read/burn split:
-//!   - [`SeVerifierSlotWriter`] fills `dsm_sdk`'s `SeSlotWriter` seam. It is **read-only**: on a
-//!     first-transfer enroll it confirms slot 1 already holds the fixed DSM verifier key AND is
-//!     caged, and discloses `(slot 1, stpub)`. It NEVER writes — a normal transfer (or app boot)
-//!     can never burn hardware. Empty / occupied / wrong-key / any error -> `None` -> disclosure
-//!     empty -> receiver pin incomplete -> fail-closed.
-//!   - [`provision_verifier_slot_commit`] performs the IRREVERSIBLE burn. It runs ONLY from an
-//!     explicit setup/commit gate (a dedicated JNI trigger), never as a side effect of anything.
+//! [`SeVerifierSlotWriter`] fills `dsm_sdk`'s `SeSlotWriter` seam and is **strictly read-only**: on a
+//! first-transfer enroll it SCANS the candidate pairing-key indices to LOCATE the one already holding
+//! the fixed DSM verifier key + correct cage, and discloses `(that index, stpub)`. It NEVER writes —
+//! a transfer or app boot can never touch hardware state. Empty / occupied / wrong-key / any error
+//! -> `None` -> disclosure empty -> receiver pin incomplete -> fail-closed.
 //!
-//! Both drive A's local Pico over the same opaque JNI USB up-call the relay uses, wrapped as a sync
-//! `SpiRelayChannel` so the proven `provisioner` sequence runs unchanged on-device.
+//! The IRREVERSIBLE provisioning burn is NOT an on-device operation: it is done deliberately at the
+//! bench via the `usb_verifier_slot` CLI (see BENCH_BURN_RUNBOOK.md), against a chosen slot index.
+//! There is intentionally no on-device burn entry point.
+//!
+//! The read drives A's local Pico over the same opaque JNI USB up-call the relay uses, wrapped as a
+//! sync `SpiRelayChannel` so the proven `provisioner` read runs unchanged on-device.
 
 // Host-testable decision types (hw-verifier is a normal dep, so these resolve on host too).
 #[cfg(all(target_os = "android", feature = "on_device_installs"))]
-use dsm_anchor_hw_verifier::{commit_verifier_slot, read_verifier_slot};
-use dsm_anchor_hw_verifier::{
-    dsm_verifier_pairing_pubkey, ProvisionError, VerifierSlotState, VERIFIER_SLOT,
-};
+use dsm_anchor_hw_verifier::find_provisioned_slot;
+use dsm_anchor_hw_verifier::{dsm_verifier_pairing_pubkey, ProvisionError};
 #[cfg(all(target_os = "android", feature = "on_device_installs"))]
 use dsm_anchor_verifier::{RelayError, SpiRelayChannel};
 #[cfg(all(target_os = "android", feature = "on_device_installs"))]
 use dsm_sdk::bridge::SeSlotWriter;
 
 /// The fail-closed disclosure decision, pulled out of the on-device path so it is host-testable: the
-/// receiver's offered key must be the fixed DSM verifier key, and the slot must read back as fully
-/// provisioned + caged. Anything else -> `None` (disclosure empty -> receiver pin incomplete).
+/// receiver's offered key must be the fixed DSM verifier key, and the scan must have LOCATED the role
+/// at some candidate index. Anything else -> `None` (disclosure empty -> receiver pin incomplete).
+/// The located index (1..=3) is downcast to the wire `u8`.
 fn map_disclosure(
     offered_pubkey: [u8; 32],
-    read: Result<VerifierSlotState, ProvisionError>,
+    found: Result<Option<(u16, [u8; 32])>, ProvisionError>,
 ) -> Option<(u8, [u8; 32])> {
     if offered_pubkey != dsm_verifier_pairing_pubkey() {
         return None;
     }
-    match read {
-        Ok(VerifierSlotState::Provisioned { stpub }) => Some((VERIFIER_SLOT as u8, stpub)),
+    match found {
+        Ok(Some((slot, stpub))) => u8::try_from(slot).ok().map(|s| (s, stpub)),
         _ => None,
     }
 }
 
 /// A sync `SpiRelayChannel` to A's LOCAL Pico over the JNI USB up-call: each `transceive` frames one
 /// raw SPI transaction as `OP_SPI_PASSTHROUGH` (in Rust) and returns the MISO. Zero-size — a fresh
-/// one is minted per session (the provisioner's `make_channel`).
+/// one is minted per probed slot (the scanner's factory).
 #[cfg(all(target_os = "android", feature = "on_device_installs"))]
 pub struct JniLocalSpiChannel;
 
@@ -57,8 +57,8 @@ impl SpiRelayChannel for JniLocalSpiChannel {
     }
 }
 
-/// Read-only `SeSlotWriter`: discloses the verifier slot iff it is already provisioned + caged.
-/// Never writes.
+/// Read-only `SeSlotWriter`: discloses the verifier slot iff it is already provisioned + caged
+/// (located by scanning). Never writes.
 #[cfg(all(target_os = "android", feature = "on_device_installs"))]
 pub struct SeVerifierSlotWriter;
 
@@ -69,46 +69,17 @@ impl SeSlotWriter for SeVerifierSlotWriter {
         _requester_device_id: [u8; 32],
         pairing_pubkey: [u8; 32],
     ) -> Option<(u8, [u8; 32])> {
-        let read = read_verifier_slot(JniLocalSpiChannel);
-        if let Err(ref e) = read {
-            log::warn!("[se-slot] verifier slot read failed (fail-closed): {e:?}");
+        let found = find_provisioned_slot(|| JniLocalSpiChannel);
+        if let Err(ref e) = found {
+            log::warn!("[se-slot] verifier-slot scan failed (fail-closed): {e:?}");
         }
-        let disclosure = map_disclosure(pairing_pubkey, read);
+        let disclosure = map_disclosure(pairing_pubkey, found);
         if disclosure.is_none() {
             log::warn!(
                 "[se-slot] no disclosure (unprovisioned / not caged / wrong key); fail-closed"
             );
         }
         disclosure
-    }
-}
-
-/// EXPLICIT setup/commit action — the IRREVERSIBLE burn. Idempotent when already provisioned; refuses
-/// to overwrite a non-empty slot. Returns `(slot, stpub)` on success. NEVER called from a transfer or
-/// app boot — only from the dedicated JNI trigger below.
-#[cfg(all(target_os = "android", feature = "on_device_installs"))]
-pub fn provision_verifier_slot_commit() -> Result<(u8, [u8; 32]), String> {
-    commit_verifier_slot(|| JniLocalSpiChannel).map_err(|e| format!("{e:?}"))
-}
-
-/// JNI trigger for the EXPLICIT setup burn. Returns the slot index (>=0) on success, -1 on failure.
-/// Present only in `on_device_installs` builds; a dedicated bench/setup UI action must invoke it. A
-/// normal transfer or app boot never reaches this symbol.
-#[cfg(all(target_os = "android", feature = "on_device_installs"))]
-#[no_mangle]
-pub extern "system" fn Java_com_dsm_wallet_bridge_Unified_provisionVerifierSlotCommit(
-    _env: jni::JNIEnv,
-    _class: jni::objects::JClass,
-) -> jni::sys::jint {
-    match provision_verifier_slot_commit() {
-        Ok((slot, stpub)) => {
-            log::info!("[se-slot] verifier slot {slot} provisioned; stpub={stpub:02x?}");
-            i32::from(slot)
-        }
-        Err(e) => {
-            log::error!("[se-slot] provision failed: {e}");
-            -1
-        }
     }
 }
 
@@ -119,41 +90,31 @@ mod tests {
     const STPUB: [u8; 32] = [0xAB; 32];
 
     #[test]
-    fn provisioned_with_the_fixed_key_discloses_slot_and_stpub() {
-        let ok = map_disclosure(
-            dsm_verifier_pairing_pubkey(),
-            Ok(VerifierSlotState::Provisioned { stpub: STPUB }),
-        );
-        assert_eq!(ok, Some((VERIFIER_SLOT as u8, STPUB)));
+    fn located_fixed_key_slot_discloses_that_index_and_stpub() {
+        // The scan located the role at index 2 (this dev chip): disclose (2, stpub).
+        let ok = map_disclosure(dsm_verifier_pairing_pubkey(), Ok(Some((2u16, STPUB))));
+        assert_eq!(ok, Some((2u8, STPUB)));
     }
 
     #[test]
-    fn wrong_offered_key_never_discloses_even_when_provisioned() {
+    fn wrong_offered_key_never_discloses_even_when_located() {
         let mut wrong = dsm_verifier_pairing_pubkey();
         wrong[0] ^= 0xFF;
-        assert_eq!(
-            map_disclosure(wrong, Ok(VerifierSlotState::Provisioned { stpub: STPUB })),
-            None,
-        );
+        assert_eq!(map_disclosure(wrong, Ok(Some((2u16, STPUB)))), None);
     }
 
     #[test]
-    fn empty_occupied_and_errors_all_fail_closed() {
+    fn not_found_and_errors_all_fail_closed() {
         let fixed = dsm_verifier_pairing_pubkey();
         assert_eq!(
-            map_disclosure(fixed, Ok(VerifierSlotState::Empty { stpub: STPUB })),
+            map_disclosure(fixed, Ok(None)),
             None,
-            "an unprovisioned slot must never disclose",
-        );
-        assert_eq!(
-            map_disclosure(fixed, Ok(VerifierSlotState::Occupied)),
-            None,
-            "an occupied/uncaged slot must never disclose",
+            "no provisioned slot -> no disclosure",
         );
         assert_eq!(
             map_disclosure(fixed, Err(ProvisionError::Chip("boom".into()))),
             None,
-            "a read error must fail closed",
+            "a scan error must fail closed",
         );
     }
 }

--- a/crates/dsm-android-anchor/src/se_slot.rs
+++ b/crates/dsm-android-anchor/src/se_slot.rs
@@ -15,10 +15,16 @@
 //! sync `SpiRelayChannel` so the proven `provisioner` read runs unchanged on-device.
 
 // Host-testable decision types (hw-verifier is a normal dep, so these resolve on host too).
-#[cfg(all(target_os = "android", feature = "on_device_installs"))]
-use dsm_anchor_hw_verifier::find_provisioned_slot;
 use dsm_anchor_hw_verifier::{dsm_verifier_pairing_pubkey, ProvisionError};
-#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+// The read-only transport + status probes are NOT accept-enabling, so they live under plain
+// `target_os = "android"` (shipped in the default .so). Only the accept-enabling `SeSlotWriter` is
+// behind the `on_device_installs` feature.
+#[cfg(target_os = "android")]
+use dsm_anchor_hw_verifier::{
+    find_provisioned_slot, preflight_verifier_slot, read_verifier_slot, VerifierSlotState,
+    VERIFIER_SLOT_CANDIDATES,
+};
+#[cfg(target_os = "android")]
 use dsm_anchor_verifier::{RelayError, SpiRelayChannel};
 #[cfg(all(target_os = "android", feature = "on_device_installs"))]
 use dsm_sdk::bridge::SeSlotWriter;
@@ -43,10 +49,10 @@ fn map_disclosure(
 /// A sync `SpiRelayChannel` to A's LOCAL Pico over the JNI USB up-call: each `transceive` frames one
 /// raw SPI transaction as `OP_SPI_PASSTHROUGH` (in Rust) and returns the MISO. Zero-size — a fresh
 /// one is minted per probed slot (the scanner's factory).
-#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+#[cfg(target_os = "android")]
 pub struct JniLocalSpiChannel;
 
-#[cfg(all(target_os = "android", feature = "on_device_installs"))]
+#[cfg(target_os = "android")]
 impl SpiRelayChannel for JniLocalSpiChannel {
     fn transceive(&mut self, mosi: &[u8]) -> Result<Vec<u8>, RelayError> {
         let frame = crate::usb_pico::frame_passthrough(mosi.to_vec());
@@ -55,6 +61,56 @@ impl SpiRelayChannel for JniLocalSpiChannel {
         crate::usb_pico::decode_passthrough(&body)
             .map_err(|e| RelayError::Transport(format!("local pico decode: {e}")))
     }
+}
+
+/// READ-ONLY diagnostic (no writes, no burn): scan every candidate index + run the slot-2 preflight
+/// on A's local chip, logging chip identity + per-slot state so an operator (via `adb logcat`) can
+/// confirm which chip this is and whether it is safe to burn — through the phone, without moving the
+/// chip to a bench. Returns 0 always; results are in logcat under "se-slot". Present in the default
+/// .so (read-only); it can never write hardware.
+#[cfg(target_os = "android")]
+#[no_mangle]
+pub extern "system" fn Java_com_dsm_wallet_bridge_Unified_verifierSlotStatus(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+) -> jni::sys::jint {
+    log::info!("[se-slot] === verifier-slot STATUS (read-only) ===");
+    for &slot in VERIFIER_SLOT_CANDIDATES {
+        match read_verifier_slot(slot, JniLocalSpiChannel) {
+            Ok(VerifierSlotState::Provisioned { stpub }) => {
+                log::info!(
+                    "[se-slot] slot {slot}: PROVISIONED (fixed DSM key, caged); stpub={stpub:02x?}"
+                )
+            }
+            Ok(VerifierSlotState::Empty { stpub }) => {
+                log::info!("[se-slot] slot {slot}: EMPTY; stpub={stpub:02x?}")
+            }
+            Ok(VerifierSlotState::Occupied) => {
+                log::info!("[se-slot] slot {slot}: OCCUPIED (non-fixed key or not caged)")
+            }
+            Err(e) => log::warn!("[se-slot] slot {slot}: read error {e:?}"),
+        }
+    }
+    match find_provisioned_slot(|| JniLocalSpiChannel) {
+        Ok(Some((slot, stpub))) => {
+            log::info!(
+                "[se-slot] provisioned verifier role located at slot {slot}; stpub={stpub:02x?}"
+            )
+        }
+        Ok(None) => log::info!("[se-slot] no verifier role provisioned on any candidate index"),
+        Err(e) => log::warn!("[se-slot] scan error {e:?}"),
+    }
+    // Read-only preflight of the intended dev-chip slot (2). Writes nothing.
+    match preflight_verifier_slot(2, JniLocalSpiChannel) {
+        Ok(r) => log::info!(
+            "[se-slot] preflight slot 2: WOULD PROCEED; stpub={:02x?} mcounter[0]={}",
+            r.stpub,
+            r.mcounter
+        ),
+        Err(e) => log::warn!("[se-slot] preflight slot 2: NOT eligible: {e:?}"),
+    }
+    log::info!("[se-slot] === verifier-slot STATUS done ===");
+    0
 }
 
 /// Read-only `SeSlotWriter`: discloses the verifier slot iff it is already provisioned + caged

--- a/crates/dsm-android-anchor/src/self_test.rs
+++ b/crates/dsm-android-anchor/src/self_test.rs
@@ -31,8 +31,10 @@ const KNOWN_BENCH_STPUB: [u8; 32] = [
     0x91, 0xe0, 0xd3, 0x70, 0x91, 0x0a, 0x07, 0xdb, 0x82, 0x1a, 0x32, 0x25, 0x83, 0x0f, 0xbe, 0x7d,
 ];
 
-/// The bench chip's read-only verifier slot (Phase G).
-const VERIFIER_SLOT: u8 = 1;
+/// The dev chip's read-only verifier slot INDEX. On this bench chip slot 1 is spent on the old
+/// per-relationship demo key, so the fixed DSM verifier role is provisioned at slot 2. Must match the
+/// index the `usb_verifier_slot` bench CLI actually burned (`commit --slot 2`).
+const VERIFIER_SLOT: u8 = 2;
 
 /// Synthetic-but-complete demo pin: exactly the fields `read_counter` gates on (verifier slot,
 /// pinned chip static key, uncompromised); the acceptance-predicate fields are placeholders.

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/Unified.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/Unified.kt
@@ -102,6 +102,11 @@ object Unified {
     // H (>= 0) or a negative fail-closed code. Only present in glue-packaged builds — callers must
     // catch UnsatisfiedLinkError.
     @Keep @JvmStatic external fun anchorCounterSelfTest(): Long
+
+    // READ-ONLY verifier-slot diagnostic (no writes / no burn): scans candidate slots + runs the
+    // slot-2 preflight on A's local chip, logging results to logcat under "se-slot". Lets an operator
+    // inspect the chip THROUGH the phone (via adb) without moving it to a bench.
+    @Keep @JvmStatic external fun verifierSlotStatus(): Int
     @Keep @JvmStatic fun dispatchStartup(requestBytes: ByteArray): ByteArray =
         UnifiedNativeApi.dispatchStartup(requestBytes)
     @Keep @JvmStatic fun dispatchIngress(requestBytes: ByteArray): ByteArray =

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/debug/PicoSelfTestActivity.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/debug/PicoSelfTestActivity.kt
@@ -97,6 +97,12 @@ class PicoSelfTestActivity : Activity() {
                     h == Long.MIN_VALUE -> Log.i(TAG, "H3 self-test skipped (symbol absent)")
                     else -> Log.e(TAG, "*** H3 FAIL: attested counter read failed (code $h) ***")
                 }
+                // READ-ONLY verifier-slot status/preflight (no writes) — logs under "se-slot".
+                try {
+                    com.dsm.wallet.bridge.Unified.verifierSlotStatus()
+                } catch (e: UnsatisfiedLinkError) {
+                    Log.w(TAG, "verifierSlotStatus not in this .so: ${e.message}")
+                }
             } else {
                 Log.e(TAG, "*** H2 FAIL: no real chip response (see resp above) ***")
             }


### PR DESCRIPTION
Fixes the hardcoded slot-1 assumption and adds the read-only preflight — so we can deliberately use **slot 2** on the dev chip (slot 1 is spent on the old demo key) and **prove a burn would succeed before spending the chip**. No chip touched by this change.

## Slot is configurable (role stays one fixed key; index is explicit)
- `read_verifier_slot(slot, ch)` — classify a specific index.
- `find_provisioned_slot(mk)` — **scan** 1..=3 to *locate* the role (the disclosure read; locates, never chooses where to write).
- `commit_verifier_slot(slot, mk)` — burn a **chosen** index (never auto-selected — not a silent 2/3 fallback); refuses to overwrite; idempotent.
- Cage bits generalized per `SH<slot>` across the 4 UAP lanes, **unit-tested** (slot 1/2/3 ⇒ mask `0x02/04/08…`, sweep == mask, slot 0 rejected).

## Read-only on-chip preflight (the key protection)
`preflight_verifier_slot(slot, ch)` runs the burn's **entire gate** on the real chip — positive `SlotEmpty` + counter readable + UAP factory-open — and returns `PreflightReport{slot, stpub, mcounter}`, **writing nothing**. Workflow: `status` → `preflight --slot 2` → (only then) `commit`.

## Safety fixes you flagged
- **The confirm flag names the slot**: `commit --slot 2` requires `--yes-burn-slot-2`; a mismatch (`--slot 2 --yes-burn-slot-1`) is **refused**.
- **No on-device burn path at all** — removed the on-device commit trigger. The burn is a bench-only action (`usb_verifier_slot` CLI). Default *and* feature `.so` export no burn symbol (audited).
- The on-device seam is read-only and scans to locate the index (slot 2 here).

## Verification
hw 9/9 (incl. the cage-bit/slot-range tests) + glue 10/10 + clippy/fmt clean + default & feature cross-compile + `cargo tree --workspace -i tropic01` empty. Runbook rewritten for slot 2 + preflight + the slot-matched flag.

**No burn until you run `preflight --slot 2` and approve the output.**