### PR TITLE
fix(bootstrap): allow pre-genesis wallet creation (generateMnemonic + createGenesisV2)

### DIFF
--- a/crates/dsm-android-anchor/Cargo.lock
+++ b/crates/dsm-android-anchor/Cargo.lock
@@ -1025,6 +1025,7 @@ dependencies = [
  "tokio",
  "tropic01",
  "x25519-dalek",
+ "zerocopy",
 ]
 
 [[package]]

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/ui/MainActivity.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/ui/MainActivity.kt
@@ -993,7 +993,10 @@ class MainActivity : AppCompatActivity(), NfcAdapter.ReaderCallback {
                 return
             }
 
-            val isLongRunningGenesisRequest = method == "createGenesis"
+            // Both genesis routes: the legacy MPC path AND the canonical mnemonic-rooted v2 path.
+            // Each must publish a fresh session snapshot after completing — without it React never
+            // sees phase=wallet_ready and the UI sits on the start screen despite the wallet existing.
+            val isLongRunningGenesisRequest = method == "createGenesis" || method == "createGenesisV2"
 
             // Genesis + heavy JNI run on the dedicated executor to avoid starving the general
             // bridge worker pool (Genesis v2 is mnemonic-rooted; no silicon enrollment).
@@ -1013,9 +1016,9 @@ class MainActivity : AppCompatActivity(), NfcAdapter.ReaderCallback {
                     if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_PORT_POST_MESSAGE)) {
                         port.postMessage(WebMessageCompat(responseWithId))
                     }
-                    // After genesis finalizes, Rust SDK_READY flips to true. Publish a fresh
+                    // After genesis completes, Rust has_identity/SDK_READY are true. Publish a fresh
                     // session snapshot so React can transition to wallet_ready immediately.
-                    runOnUiThread { publishSessionState("createGenesis") }
+                    runOnUiThread { publishSessionState(method) }
                 }
                 return
             }

--- a/dsm_client/deterministic_state_machine/Cargo.lock
+++ b/dsm_client/deterministic_state_machine/Cargo.lock
@@ -1206,6 +1206,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsm-anchor-verifier"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal",
+ "tokio",
+]
+
+[[package]]
 name = "dsm_sdk"
 version = "0.1.0-beta.3"
 dependencies = [
@@ -1231,6 +1239,7 @@ dependencies = [
  "dirs",
  "dsm",
  "dsm-anchor-core",
+ "dsm-anchor-verifier",
  "env_logger 0.11.10",
  "erased-serde",
  "fastrand",
@@ -1358,6 +1367,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "env_filter"
@@ -2642,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+checksum = "1a6ceddfe3ce334925e96bf420fdb2dcee5bed6c632a168ece622676dadeaf8a"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -2656,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+checksum = "9cfe16fbe8a314aeec0b861ac24e60b1e123e97634bab045475b9d6a18416fd8"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
@@ -187,24 +187,44 @@ pub trait AppRouter: Send + Sync {
 /// App router storage. Uses RwLock to allow replacement (MinimalBootstrapRouter → AppRouterImpl).
 static APP_ROUTER: Lazy<RwLock<Option<Arc<dyn AppRouter>>>> = Lazy::new(|| RwLock::new(None));
 
-/// True once the *full* [`AppRouterImpl`] has replaced the MinimalBootstrapRouter in [`APP_ROUTER`].
-/// `app_router().is_some()` cannot distinguish the two (both occupy the single slot), so the
-/// post-genesis / post-unlock hot-swap paths key idempotency off this flag instead — otherwise
-/// `ensureAppRouterInstalled` would either rebuild the router on every call or (its original bug)
-/// short-circuit on the *minimal* router and never upgrade. Prod never resets `APP_ROUTER` (the
-/// only resets are `#[cfg(test)]`), so this flag only clears in those test resets.
-static FULL_APP_ROUTER_INSTALLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+/// The device_id the *full* [`AppRouterImpl`] currently in [`APP_ROUTER`] was built for; `None`
+/// while the MinimalBootstrapRouter (or nothing) occupies the slot. `app_router().is_some()`
+/// cannot distinguish the two (both occupy the single slot), so the post-genesis / post-unlock
+/// hot-swap paths key idempotency off this marker instead — otherwise `ensureAppRouterInstalled`
+/// would either rebuild the router on every call or (its original bug) short-circuit on the
+/// *minimal* router and never upgrade.
+///
+/// Identity-keyed (not a bool) because `AppRouterImpl::new` SNAPSHOTS the identity at construction
+/// (ContactManager, CoreSDK device info, wallet storage namespace): a bare "installed" bit would
+/// keep reporting ready if AppState's identity ever changed under it, silently serving routes as
+/// the OLD identity. Prod never resets `APP_ROUTER` (the only resets are `#[cfg(test)]`), so this
+/// marker only clears in those test resets.
+static FULL_APP_ROUTER_IDENTITY: Lazy<RwLock<Option<Vec<u8>>>> = Lazy::new(|| RwLock::new(None));
 
-/// Whether the full app router (not the MinimalBootstrapRouter) is installed.
+/// Whether the full app router (not the MinimalBootstrapRouter) is installed AND was built for the
+/// CURRENT AppState identity. A mismatch (identity changed since the swap) reports `false` so
+/// install paths rebuild rather than serve routes under a stale identity.
 #[must_use]
 pub fn full_app_router_installed() -> bool {
-    FULL_APP_ROUTER_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
+    let installed_for = match FULL_APP_ROUTER_IDENTITY.read() {
+        Ok(g) => g.clone(),
+        Err(_) => return false,
+    };
+    match (
+        installed_for,
+        crate::sdk::app_state::AppState::get_device_id(),
+    ) {
+        (Some(installed), Some(current)) => installed == current,
+        _ => false,
+    }
 }
 
-/// Mark the full app router as installed. Called by the install helper after a successful swap.
-pub(crate) fn mark_full_app_router_installed() {
-    FULL_APP_ROUTER_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
+/// Record the device_id the full app router was built for. Called by the install helper after a
+/// successful swap.
+pub(crate) fn mark_full_app_router_installed(device_id: Vec<u8>) {
+    if let Ok(mut g) = FULL_APP_ROUTER_IDENTITY.write() {
+        *g = Some(device_id);
+    }
 }
 
 /// Install (or replace) the SDK app router.
@@ -341,7 +361,9 @@ pub(crate) unsafe fn reset_bridge_handlers_for_tests() {
     if let Ok(mut guard) = APP_ROUTER.write() {
         *guard = None;
     }
-    FULL_APP_ROUTER_INSTALLED.store(false, std::sync::atomic::Ordering::Release);
+    if let Ok(mut guard) = FULL_APP_ROUTER_IDENTITY.write() {
+        *guard = None;
+    }
     if let Ok(mut guard) = UNILATERAL_HANDLER.write() {
         *guard = None;
     }
@@ -812,7 +834,9 @@ mod tests {
         if let Ok(mut guard) = APP_ROUTER.write() {
             *guard = None;
         }
-        FULL_APP_ROUTER_INSTALLED.store(false, std::sync::atomic::Ordering::Release);
+        if let Ok(mut guard) = FULL_APP_ROUTER_IDENTITY.write() {
+            *guard = None;
+        }
         if let Ok(mut guard) = UNILATERAL_HANDLER.write() {
             *guard = None;
         }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
@@ -187,6 +187,26 @@ pub trait AppRouter: Send + Sync {
 /// App router storage. Uses RwLock to allow replacement (MinimalBootstrapRouter → AppRouterImpl).
 static APP_ROUTER: Lazy<RwLock<Option<Arc<dyn AppRouter>>>> = Lazy::new(|| RwLock::new(None));
 
+/// True once the *full* [`AppRouterImpl`] has replaced the MinimalBootstrapRouter in [`APP_ROUTER`].
+/// `app_router().is_some()` cannot distinguish the two (both occupy the single slot), so the
+/// post-genesis / post-unlock hot-swap paths key idempotency off this flag instead — otherwise
+/// `ensureAppRouterInstalled` would either rebuild the router on every call or (its original bug)
+/// short-circuit on the *minimal* router and never upgrade. Prod never resets `APP_ROUTER` (the
+/// only resets are `#[cfg(test)]`), so this flag only clears in those test resets.
+static FULL_APP_ROUTER_INSTALLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the full app router (not the MinimalBootstrapRouter) is installed.
+#[must_use]
+pub fn full_app_router_installed() -> bool {
+    FULL_APP_ROUTER_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
+}
+
+/// Mark the full app router as installed. Called by the install helper after a successful swap.
+pub(crate) fn mark_full_app_router_installed() {
+    FULL_APP_ROUTER_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
+}
+
 /// Install (or replace) the SDK app router.
 ///
 /// This is called:
@@ -321,6 +341,7 @@ pub(crate) unsafe fn reset_bridge_handlers_for_tests() {
     if let Ok(mut guard) = APP_ROUTER.write() {
         *guard = None;
     }
+    FULL_APP_ROUTER_INSTALLED.store(false, std::sync::atomic::Ordering::Release);
     if let Ok(mut guard) = UNILATERAL_HANDLER.write() {
         *guard = None;
     }
@@ -791,6 +812,7 @@ mod tests {
         if let Ok(mut guard) = APP_ROUTER.write() {
             *guard = None;
         }
+        FULL_APP_ROUTER_INSTALLED.store(false, std::sync::atomic::Ordering::Release);
         if let Ok(mut guard) = UNILATERAL_HANDLER.write() {
             *guard = None;
         }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/mod.rs
@@ -45,5 +45,7 @@ pub mod token_routes;
 pub mod transfer_helpers;
 pub mod wallet_routes;
 pub use recovery_impl::RecoveryImpl;
-pub(crate) use system_routes::handle_system_genesis_query;
+pub(crate) use system_routes::{
+    handle_create_genesis_v2_query, handle_generate_mnemonic_query, handle_system_genesis_query,
+};
 pub use unilateral_impl::UniImpl;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/system_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/system_routes.rs
@@ -222,6 +222,35 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
         req.network_id.clone()
     };
 
+    // Genesis v2 lifecycle rail: drive the frontend securing screen through the SAME native
+    // events as the legacy bootstrap path (EventBridge maps these to `genesis.securing-device*`
+    // topics the useGenesisFlow hook already renders). The frontend is pure rendering — progress
+    // truth lives here. Emission is best-effort: a failed WebView dispatch must never fail the
+    // wallet creation itself.
+    use crate::generated::genesis_lifecycle_event::Kind as LifecycleKind;
+    let emit = |kind: LifecycleKind, progress: u32| {
+        if let Err(e) = crate::ingress::push_genesis_lifecycle_event(kind as i32, progress) {
+            log::warn!(
+                "system.createGenesisV2: lifecycle event dispatch failed (non-fatal): {:?}",
+                e
+            );
+        }
+    };
+    // Hold phase=securing_device for any concurrent session-state read until this function
+    // exits (success OR error), mirroring the finalize_bootstrap_core scope-guard discipline —
+    // otherwise a mid-genesis snapshot would report needs_genesis and flash the start screen.
+    crate::sdk::session_manager::BOOTSTRAP_SECURING.store(true, std::sync::atomic::Ordering::SeqCst);
+    struct ClearSecuringOnDrop;
+    impl Drop for ClearSecuringOnDrop {
+        fn drop(&mut self) {
+            crate::sdk::session_manager::BOOTSTRAP_SECURING
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+    let _clear_securing = ClearSecuringOnDrop;
+    emit(LifecycleKind::GenesisKindStarted, 0);
+    emit(LifecycleKind::GenesisKindSecuringDevice, 0);
+
     // 1. Derive + cache the wallet seed from the mnemonic (the unlocked-session secret).
     if let Err(e) = crate::sdk::recovery_sdk::RecoverySDK::derive_and_cache_key(&req.mnemonic) {
         return err(format!(
@@ -236,6 +265,7 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
             )
         }
     };
+    emit(LifecycleKind::GenesisKindSecuringProgress, 30);
 
     // 2. Canonical mnemonic-rooted genesis (self-attested AttA; no silicon/random/MPC).
     let aph = dsm::core::identity::genesis_session::genesis_authority_policy_hash();
@@ -254,6 +284,7 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
             ))
         }
     };
+    emit(LifecycleKind::GenesisKindSecuringProgress, 60);
     let genesis_state = &outcome.state;
     let devid = match genesis_state.device_id {
         Some(d) => d,
@@ -322,6 +353,32 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
             "system.createGenesisV2: SDK context init failed: {e}"
         ));
     }
+    emit(LifecycleKind::GenesisKindSecuringProgress, 85);
+
+    // 5b. Hot-swap the MinimalBootstrapRouter for the full AppRouter now that the canonical identity
+    //     exists (device_id set + wallet seed cached above). Without this the bootstrap router stays
+    //     installed for the rest of the session and every post-genesis route (identity.pairingQR,
+    //     wallet.*, contacts.*) fails with "requires genesis". The core adapter reads the router slot
+    //     live, so the swap takes effect on the very next query.
+    match crate::init::install_full_app_router_self_config() {
+        Ok(true) => {}
+        Ok(false) => {
+            return err(
+                "system.createGenesisV2: canonical identity not ready after genesis (fail closed)"
+                    .into(),
+            )
+        }
+        Err(e) => {
+            return err(format!(
+                "system.createGenesisV2: full AppRouter install failed: {e}"
+            ))
+        }
+    }
+
+    // Success rail (mirrors finalize_bootstrap_core): complete → ok. The wallet_ready screen
+    // transition itself rides the fresh session snapshot Kotlin publishes after this response.
+    emit(LifecycleKind::GenesisKindSecuringComplete, 0);
+    emit(LifecycleKind::GenesisKindOk, 0);
 
     // 6. Return the genesis envelope (device_entropy carries the PUBLIC genesis_nonce in v2).
     let resp = generated::GenesisCreated {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/system_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/system_routes.rs
@@ -222,6 +222,22 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
         req.network_id.clone()
     };
 
+    // FAIL CLOSED on re-genesis: one wallet identity per process/app-data. The full router,
+    // ContactManager, and SDK context all snapshot the identity when they are built — a second
+    // successful genesis in the same process would rewrite AppState/persisted genesis to a NEW
+    // identity while those keep serving the OLD one (silent split-brain, and the user's newly
+    // backed-up mnemonic would not recover the chain actually being advanced). This guard sits
+    // BEFORE derive_and_cache_key so a rejected retry can't clobber the cached wallet seed either.
+    // (A retry after a genuine mid-genesis failure is still possible: the error paths below roll
+    // has_identity back.)
+    if crate::sdk::app_state::AppState::get_has_identity() {
+        return err(
+            "system.createGenesisV2: an identity already exists on this device; wipe app data or \
+             restore instead of re-running genesis (fail closed)"
+                .into(),
+        );
+    }
+
     // Genesis v2 lifecycle rail: drive the frontend securing screen through the SAME native
     // events as the legacy bootstrap path (EventBridge maps these to `genesis.securing-device*`
     // topics the useGenesisFlow hook already renders). The frontend is pure rendering — progress
@@ -239,7 +255,8 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
     // Hold phase=securing_device for any concurrent session-state read until this function
     // exits (success OR error), mirroring the finalize_bootstrap_core scope-guard discipline —
     // otherwise a mid-genesis snapshot would report needs_genesis and flash the start screen.
-    crate::sdk::session_manager::BOOTSTRAP_SECURING.store(true, std::sync::atomic::Ordering::SeqCst);
+    crate::sdk::session_manager::BOOTSTRAP_SECURING
+        .store(true, std::sync::atomic::Ordering::SeqCst);
     struct ClearSecuringOnDrop;
     impl Drop for ClearSecuringOnDrop {
         fn drop(&mut self) {
@@ -347,9 +364,18 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
         smt_root.to_vec(),
     );
     crate::sdk::app_state::AppState::set_has_identity(true);
+    // Any failure AFTER has_identity=true must roll it back before returning the error envelope:
+    // Kotlin publishes a session snapshot after EVERY createGenesisV2 response, and with
+    // has_identity left true a failed genesis would compute phase=wallet_ready — landing the user
+    // on a wallet screen whose router/context never came up (fail-open). Rolled back, the snapshot
+    // honestly reports needs_genesis and the user can retry.
+    let fail_rolled_back = |msg: String| {
+        crate::sdk::app_state::AppState::set_has_identity(false);
+        err(msg)
+    };
     let entropy = crate::derive_production_entropy(&devid, &g, &wallet_seed);
     if let Err(e) = crate::initialize_sdk_context(devid.to_vec(), g.to_vec(), entropy) {
-        return err(format!(
+        return fail_rolled_back(format!(
             "system.createGenesisV2: SDK context init failed: {e}"
         ));
     }
@@ -363,13 +389,13 @@ pub(crate) fn handle_create_genesis_v2_query(q: AppQuery) -> AppResult {
     match crate::init::install_full_app_router_self_config() {
         Ok(true) => {}
         Ok(false) => {
-            return err(
+            return fail_rolled_back(
                 "system.createGenesisV2: canonical identity not ready after genesis (fail closed)"
                     .into(),
             )
         }
         Err(e) => {
-            return err(format!(
+            return fail_rolled_back(format!(
                 "system.createGenesisV2: full AppRouter install failed: {e}"
             ))
         }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/ingress.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/ingress.rs
@@ -81,7 +81,11 @@ fn push_canonical_envelope_event(payload: pb::envelope::Payload) -> Result<(), p
     Ok(())
 }
 
-fn push_genesis_lifecycle_event(kind: i32, progress: u32) -> Result<(), pb::Error> {
+/// Push a genesis lifecycle event to the WebView (EventBridge maps kinds to the
+/// `genesis.securing-device*` topics the frontend renders). `pub(crate)` so the canonical
+/// Genesis v2 route (`system.createGenesisV2` in `handlers::system_routes`) drives the SAME
+/// securing-screen rail as this legacy bootstrap path.
+pub(crate) fn push_genesis_lifecycle_event(kind: i32, progress: u32) -> Result<(), pb::Error> {
     push_canonical_envelope_event(pb::envelope::Payload::GenesisLifecycle(
         pb::GenesisLifecycleEvent { kind, progress },
     ))

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/init.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/init.rs
@@ -157,6 +157,58 @@ impl SdkConfig {
     }
 }
 
+/// Hot-swap the MinimalBootstrapRouter for the full [`AppRouterImpl`] once the canonical identity is
+/// ready (device_id present + wallet seed cached). This is the single install path for the
+/// *warm* swap — used by `system.createGenesisV2` (fresh wallet) and the JNI `ensureAppRouterInstalled`
+/// (post-unlock on restart) — both of which have no [`SdkConfig`] in hand, so it derives one from the
+/// storage-endpoint registry (falling back to env config). The cold-boot path in [`init_dsm_sdk`]
+/// keeps its caller-supplied `SdkConfig`.
+///
+/// Idempotent: keyed off [`crate::bridge::full_app_router_installed`] so repeated calls don't rebuild
+/// the router. The core adapter reads the router slot live, so the swap takes effect on the next
+/// query without touching the adapter registration.
+///
+/// Returns `Ok(true)` when the full router is installed (now or already), `Ok(false)` when the
+/// canonical identity is not yet ready, and `Err` on a hard construction/install failure.
+pub(crate) fn install_full_app_router_self_config() -> Result<bool, String> {
+    if crate::bridge::full_app_router_installed() {
+        return Ok(true);
+    }
+    let canonical_identity_ready = crate::sdk::app_state::AppState::get_device_id().is_some()
+        && crate::sdk::recovery_sdk::RecoverySDK::get_cached_wallet_seed().is_some();
+    if !canonical_identity_ready {
+        return Ok(false);
+    }
+    // Storage endpoints: registry first, env config fallback (same source as cold boot).
+    let storage_endpoints = match crate::network::list_storage_endpoints() {
+        Ok(list) if !list.is_empty() => list,
+        _ => match crate::network::NetworkConfigLoader::load_env_config() {
+            Ok(env) => env.nodes.into_iter().map(|n| n.endpoint).collect(),
+            Err(_) => Vec::new(),
+        },
+    };
+    let cfg = SdkConfig {
+        node_id: "default".to_string(),
+        storage_endpoints,
+        enable_offline: false,
+    };
+    let app_router = Arc::new(
+        AppRouterImpl::new(cfg).map_err(|e| format!("Failed to create AppRouter: {:?}", e))?,
+    );
+    install_sdk_app_router(app_router)
+        .map_err(|e| format!("Failed to install app router: {:?}", e))?;
+    install_app_router_adapter(crate::runtime::get_runtime().handle().clone());
+    // Receiver-admit fold parity with the cold-boot full-router branch: pinned fused-anchor store so
+    // an admitted counterparty pin survives restarts. Does NOT enable live offline-bearer acceptance
+    // (the counter reader is a separate device-layer install; an incomplete pin fail-closes Path-B).
+    crate::bridge::install_anchor_enrollment_store(Arc::new(
+        crate::sdk::anchor_enrollment_store::SqliteAnchorEnrollmentStore::new(),
+    ));
+    crate::bridge::mark_full_app_router_installed();
+    log::info!("[SDK] Full AppRouter hot-swapped in (canonical identity ready)");
+    Ok(true)
+}
+
 /// Core bilateral handler that wraps SDK's async BiImpl
 struct CoreBilateralBridge {
     sdk_handler: Arc<dyn crate::bridge::BilateralHandler>,
@@ -442,6 +494,7 @@ pub fn init_dsm_sdk(cfg: &SdkConfig) -> Result<(), String> {
         crate::bridge::install_anchor_enrollment_store(Arc::new(
             crate::sdk::anchor_enrollment_store::SqliteAnchorEnrollmentStore::new(),
         ));
+        crate::bridge::mark_full_app_router_installed();
         log::info!("[SDK Init] Full AppRouter installed (device identity ready)");
     } else {
         // Install minimal bootstrap router for pre-genesis queries

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/init.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/init.rs
@@ -21,7 +21,8 @@ use crate::bridge::install_bilateral_handler as install_sdk_bilateral_handler;
 use crate::bridge::install_unilateral_handler as install_sdk_unilateral_handler;
 use crate::bridge::install_app_router as install_sdk_app_router;
 use crate::handlers::{
-    AppRouterImpl, BiImpl, UniImpl, handle_system_genesis_query, install_app_router_adapter,
+    handle_create_genesis_v2_query, handle_generate_mnemonic_query, handle_system_genesis_query,
+    install_app_router_adapter, AppRouterImpl, BiImpl, UniImpl,
 };
 use dsm::types::proto as pb;
 use prost::Message;
@@ -475,6 +476,12 @@ pub fn init_dsm_sdk(cfg: &SdkConfig) -> Result<(), String> {
                         }
                     }
                     "system.genesis" => handle_system_genesis_query(q),
+                    // Pre-genesis wallet CREATION is the bootstrap itself and must be allowed here:
+                    // generateMnemonic is pure (OsRng -> BIP39), and createGenesisV2 derives the
+                    // wallet seed + establishes the identity — after which a re-init installs the full
+                    // router. Without these, a fresh device can never create a wallet (chicken-and-egg).
+                    "system.generateMnemonic" => handle_generate_mnemonic_query(),
+                    "system.createGenesisV2" => handle_create_genesis_v2_query(q),
                     _ => AppResult {
                         success: false,
                         data: Vec::new(),

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/init.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/init.rs
@@ -171,10 +171,19 @@ impl SdkConfig {
 /// Returns `Ok(true)` when the full router is installed (now or already), `Ok(false)` when the
 /// canonical identity is not yet ready, and `Err` on a hard construction/install failure.
 pub(crate) fn install_full_app_router_self_config() -> Result<bool, String> {
+    // Identity-keyed idempotency: true only when the installed full router was built for the
+    // CURRENT identity (see bridge::full_app_router_installed) — an identity mismatch falls
+    // through and rebuilds instead of serving routes under a stale snapshot.
     if crate::bridge::full_app_router_installed() {
         return Ok(true);
     }
-    let canonical_identity_ready = crate::sdk::app_state::AppState::get_device_id().is_some()
+    // has_identity participates so a rolled-back failed genesis (which clears it) reads as
+    // not-ready here even while device_id/seed linger in the session.
+    let device_id = match crate::sdk::app_state::AppState::get_device_id() {
+        Some(d) => d,
+        None => return Ok(false),
+    };
+    let canonical_identity_ready = crate::sdk::app_state::AppState::get_has_identity()
         && crate::sdk::recovery_sdk::RecoverySDK::get_cached_wallet_seed().is_some();
     if !canonical_identity_ready {
         return Ok(false);
@@ -204,7 +213,7 @@ pub(crate) fn install_full_app_router_self_config() -> Result<bool, String> {
     crate::bridge::install_anchor_enrollment_store(Arc::new(
         crate::sdk::anchor_enrollment_store::SqliteAnchorEnrollmentStore::new(),
     ));
-    crate::bridge::mark_full_app_router_installed();
+    crate::bridge::mark_full_app_router_installed(device_id);
     log::info!("[SDK] Full AppRouter hot-swapped in (canonical identity ready)");
     Ok(true)
 }
@@ -475,10 +484,11 @@ pub fn init_dsm_sdk(cfg: &SdkConfig) -> Result<(), String> {
     // WebView/bridge re-inits after createGenesisV2). Therefore, we must always prefer the
     // full router when identity is available, even if a MinimalBootstrapRouter was installed
     // earlier.
-    let canonical_identity_ready = crate::sdk::app_state::AppState::get_device_id().is_some()
+    let boot_device_id = crate::sdk::app_state::AppState::get_device_id();
+    let canonical_identity_ready = boot_device_id.is_some()
         && crate::sdk::recovery_sdk::RecoverySDK::get_cached_wallet_seed().is_some();
 
-    if canonical_identity_ready {
+    if let (true, Some(device_id)) = (canonical_identity_ready, boot_device_id) {
         let app_router = Arc::new(
             AppRouterImpl::new(cfg.clone())
                 .map_err(|e| format!("Failed to create AppRouter: {:?}", e))?,
@@ -494,7 +504,7 @@ pub fn init_dsm_sdk(cfg: &SdkConfig) -> Result<(), String> {
         crate::bridge::install_anchor_enrollment_store(Arc::new(
             crate::sdk::anchor_enrollment_store::SqliteAnchorEnrollmentStore::new(),
         ));
-        crate::bridge::mark_full_app_router_installed();
+        crate::bridge::mark_full_app_router_installed(device_id);
         log::info!("[SDK Init] Full AppRouter installed (device identity ready)");
     } else {
         // Install minimal bootstrap router for pre-genesis queries

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
@@ -4562,78 +4562,28 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_ensureAppRout
 
             log::info!("ensureAppRouterInstalled: START - function called");
 
-            // Check if already installed
-            if crate::bridge::app_router().is_some() {
-                log::info!("ensureAppRouterInstalled: AppRouter is available - SUCCESS");
-                return 1; // true
-            }
-
-            // AppRouter not installed - try to install it only when canonical identity is ready.
-            log::info!(
-                "ensureAppRouterInstalled: AppRouter not available, attempting to install..."
-            );
-
-            let has_device_identity = crate::sdk::app_state::AppState::get_device_id().is_some();
-            // Genesis v2: the full AppRouter needs the device signing key, which re-derives from
-            // the unlocked wallet seed (no persisted C-DBRW key). Gate on wallet-unlocked.
-            let wallet_unlocked =
-                crate::sdk::recovery_sdk::RecoverySDK::get_cached_wallet_seed().is_some();
-
-            if has_device_identity && wallet_unlocked {
-                log::info!(
-                    "ensureAppRouterInstalled: Canonical identity ready, installing AppRouter"
-                );
-
-                // Get storage endpoints: try registry first, fall back to env config
-                let endpoints = match crate::network::list_storage_endpoints() {
-                    Ok(list) if !list.is_empty() => list,
-                    _ => match crate::network::NetworkConfigLoader::load_env_config() {
-                        Ok(env) => env.nodes.into_iter().map(|n| n.endpoint).collect(),
-                        Err(_) => Vec::new(),
-                    },
-                };
-                let cfg = crate::init::SdkConfig {
-                    node_id: "default".to_string(),
-                    storage_endpoints: endpoints,
-                    enable_offline: false,
-                };
-
-                // Install full AppRouter (same logic as init.rs)
-                let app_router = match crate::handlers::AppRouterImpl::new(cfg) {
-                    Ok(router) => std::sync::Arc::new(router),
-                    Err(e) => {
-                        log::error!(
-                            "ensureAppRouterInstalled: Failed to create AppRouter: {:?}",
-                            e
-                        );
-                        return 0; // false
-                    }
-                };
-                if let Err(e) = crate::bridge::install_app_router(app_router) {
-                    log::error!(
-                        "ensureAppRouterInstalled: Failed to install AppRouter: {:?}",
-                        e
-                    );
-                    return 0; // false
+            // Upgrade the MinimalBootstrapRouter to the full AppRouter when the canonical identity is
+            // ready (device_id + unlocked wallet seed). This funnels through the single warm-swap
+            // helper shared with `system.createGenesisV2`; it is idempotent (keyed off
+            // `full_app_router_installed`, NOT `app_router().is_some()` — the latter is true for the
+            // bootstrap router and used to short-circuit the upgrade, leaving post-genesis routes
+            // failing with "requires genesis").
+            match crate::init::install_full_app_router_self_config() {
+                Ok(true) => {
+                    log::info!("ensureAppRouterInstalled: full AppRouter ready - SUCCESS");
+                    1 // true
                 }
-                crate::handlers::install_app_router_adapter(
-                    crate::runtime::get_runtime().handle().clone(),
-                );
-
-                log::info!("ensureAppRouterInstalled: AppRouter installed successfully");
-                return 1; // true
+                Ok(false) => {
+                    log::error!(
+                        "ensureAppRouterInstalled: canonical identity not ready (need device identity + unlocked wallet seed)"
+                    );
+                    0 // false
+                }
+                Err(e) => {
+                    log::error!("ensureAppRouterInstalled: {e}");
+                    0 // false
+                }
             }
-
-            if !has_device_identity {
-                log::error!(
-                    "ensureAppRouterInstalled: Cannot install AppRouter - no device identity available"
-                );
-            } else {
-                log::error!(
-                    "ensureAppRouterInstalled: Cannot install AppRouter - canonical chain-head binding key missing or invalid"
-                );
-            }
-            0 // false
         }),
     )
 }
@@ -4656,8 +4606,9 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_getAppRouterS
 
             log::info!("getAppRouterStatus: START");
 
-            // If AppRouter is installed, report INSTALLED
-            if crate::bridge::app_router().is_some() {
+            // INSTALLED means the FULL AppRouter. `app_router().is_some()` would also be true for
+            // the MinimalBootstrapRouter and mask the locked/needs-genesis states below.
+            if crate::bridge::full_app_router_installed() {
                 log::info!("getAppRouterStatus: INSTALLED");
                 return 2;
             }


### PR DESCRIPTION
Fresh-device wallet creation now works END TO END: the pre-genesis whitelist, the in-session router upgrade, live UI feedback, and the wallet_ready transition — plus fail-closed guards from an adversarial review.

## Commits

1. **b2619995** — whitelist `system.generateMnemonic` + `system.createGenesisV2` in the MinimalBootstrapRouter (a fresh device could never create a wallet: chicken-and-egg).
2. **5e10e304** — the dead-Initialize fix (all native; zero frontend changes):
   - `createGenesisV2` hot-swaps the MinimalBootstrapRouter → full `AppRouterImpl` in-session via a new shared helper (`install_full_app_router_self_config`). Kills `identity.pairingQR ... requires genesis`.
   - `ensureAppRouterInstalled` / `getAppRouterStatus` keyed off a real installed-marker instead of `app_router().is_some()` — which is true for the *minimal* router and made the upgrade path structurally unreachable.
   - The v2 handler emits the legacy-mirrored genesis lifecycle events (securing screen + progress) under a `BOOTSTRAP_SECURING` scope guard.
   - `MainActivity` treats `createGenesisV2` as a long-running genesis request and publishes the post-genesis session snapshot — the actual `wallet_ready` trigger.
3. **3d2c5fb6** — adversarial-review fixes (2 confirmed majors):
   - FAIL CLOSED on re-genesis: a second `createGenesisV2` with an existing identity is rejected (prevents silent identity split-brain on retry-after-lost-response); the installed-marker is identity-keyed (device_id), not a bool.
   - Post-identity failures roll `has_identity` back before returning, so the unconditional session publish reports an honest `needs_genesis` instead of a broken `wallet_ready`.

## Verified on hardware (both bench phones, SM-A165M)

- Fresh install → INITIALIZE → **wallet screen in <1 s** (screen switches; securing rail active) — previously the button did visibly nothing.
- `[SDK] Full AppRouter hot-swapped in (canonical identity ready)` → `COMPUTE_PHASE ... -> phase=wallet_ready` → `publishSessionState: reason=createGenesisV2` in logcat on both devices.
- `identity.pairing_qr` (the exact previously-failing route) renders the pairing QR, served by `APP_ROUTER.query()`.

## Gates

- dsm_sdk **1443/0** (serial), fmt --check clean, clippy (incl. production lints) clean, npm type-check clean, arm64 cross-compile clean.
- Frontend diff EMPTY (pure rendering held — the hook already listened for these events; they were never sent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)