### PR TITLE
fix(bilateral): carry Kyber keys on the prepare exchange (first BLE transfer moved no value)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/bridge.rs
@@ -1572,6 +1572,7 @@ pub fn handle_bilateral_offline_send(env_bytes: &[u8], ble_address: &str) -> Vec
                         responder_signing_public_key: vec![], // Populated by BLE handler with local signing key
                         receiver_challenge: vec![], // r_R: set by the BLE receiver path for bearer transfers
                         anchor_enroll_request: None, // set by the BLE receiver path (first-transfer bearer enroll)
+                        responder_kyber_public_key: vec![], // Populated by BLE handler with local Kyber key
                     };
                     let body = response.encode_to_vec();
                     results.push(op_success(op_id, body, None, None, gp::Codec::Proto));

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -1691,6 +1691,9 @@ impl BilateralBleHandler {
             token_id_hint: String::new(),
             memo_hint: String::new(),
             transfer_amount_display: String::new(),
+            // Randomized-per-init Kyber key: the receiver refreshes its contact copy from this
+            // (empty when no wallet key is installed — legacy behavior, receipt fail-closes).
+            sender_kyber_public_key: crate::bridge::local_kyber_pubkey().unwrap_or_default(),
         };
 
         let tip_override = {
@@ -2260,6 +2263,27 @@ impl BilateralBleHandler {
                 );
             }
 
+            // Refresh the sender's Kyber (ML-KEM-768) key alongside the signing key: it is
+            // randomized per wallet init on the peer, and the per-step EK receipt this transfer
+            // builds fail-closes without a current copy on the contact record.
+            if !prepare_request.sender_kyber_public_key.is_empty() {
+                match crate::storage::client_db::update_contact_kyber_key(
+                    &counterparty_device_id,
+                    &prepare_request.sender_kyber_public_key,
+                ) {
+                    Ok(()) => log::info!(
+                        "[BilateralBleHandler] ✅ Refreshed contact kyber_public_key from prepare request"
+                    ),
+                    Err(e) => log::warn!(
+                        "[BilateralBleHandler] ⚠️ Failed to persist contact kyber_public_key: {e}"
+                    ),
+                }
+            } else {
+                log::warn!(
+                    "[BilateralBleHandler] ⚠️ No sender_kyber_public_key in prepare request (legacy peer?)"
+                );
+            }
+
             // =====================================================================
             // CRITICAL: Update our view of sender's chain tip from prepare request
             // This enables proper state synchronization in multi-relationship scenarios
@@ -2702,6 +2726,9 @@ impl BilateralBleHandler {
             responder_signing_public_key: local_signing_key,
             receiver_challenge: receiver_challenge.to_vec(),
             anchor_enroll_request,
+            // Randomized-per-init Kyber key: the sender refreshes its contact copy from this
+            // before building the per-step EK receipt in the immediately following confirm.
+            responder_kyber_public_key: crate::bridge::local_kyber_pubkey().unwrap_or_default(),
         };
 
         // Wrap in envelope
@@ -3040,6 +3067,27 @@ impl BilateralBleHandler {
                 } else {
                     log::info!(
                         "[BilateralBleHandler] ✅ Persisted responder public_key to SQLite (handle_prepare_response)"
+                    );
+                }
+
+                // Refresh the responder's Kyber (ML-KEM-768) key alongside the signing key: the
+                // per-step EK receipt built in send_bilateral_confirm (immediately after this)
+                // encapsulates to it and fail-closes when the contact record has no current copy.
+                if !prepare_response.responder_kyber_public_key.is_empty() {
+                    match crate::storage::client_db::update_contact_kyber_key(
+                        &counterparty_device_id,
+                        &prepare_response.responder_kyber_public_key,
+                    ) {
+                        Ok(()) => log::info!(
+                            "[BilateralBleHandler] ✅ Refreshed contact kyber_public_key from prepare response"
+                        ),
+                        Err(e) => log::warn!(
+                            "[BilateralBleHandler] ⚠️ Failed to persist responder kyber_public_key: {e}"
+                        ),
+                    }
+                } else {
+                    log::warn!(
+                        "[BilateralBleHandler] ⚠️ No responder_kyber_public_key in prepare response (legacy peer?)"
                     );
                 }
             } else {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_envelope.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_envelope.rs
@@ -331,6 +331,7 @@ mod tests {
             token_id_hint: String::new(),
             memo_hint: String::new(),
             transfer_amount_display: String::new(),
+            sender_kyber_public_key: vec![],
         };
         let body = req.encode_to_vec();
         let env = make_invoke_envelope("bilateral.prepare", &body);
@@ -389,6 +390,7 @@ mod tests {
             token_id_hint: String::new(),
             memo_hint: String::new(),
             transfer_amount_display: String::new(),
+            sender_kyber_public_key: vec![],
         };
         let body = req.encode_to_vec();
         let mut env = make_invoke_envelope("bilateral.prepare", &body);

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
@@ -254,6 +254,29 @@ pub fn app_router() -> Option<Arc<dyn AppRouter>> {
     APP_ROUTER.read().ok()?.clone()
 }
 
+/// The local device's CURRENT ML-KEM-768 (Kyber) encapsulation key. Installed by
+/// `AppRouterImpl::new` right after `WalletSDK` initializes device keys — the keypair is
+/// deliberately RANDOMIZED per wallet init (no persisted device secret), so this snapshot is
+/// valid for the life of the wallet instance and is re-installed on every router (re)build.
+/// The bilateral BLE prepare exchange attaches it so counterparties can refresh their contact
+/// record (per-step EK receipts encapsulate to it). `None` -> prepare messages carry an empty
+/// key and the counterparty's receipt build fail-closes exactly as before.
+static LOCAL_KYBER_PUBKEY: Lazy<RwLock<Option<Vec<u8>>>> = Lazy::new(|| RwLock::new(None));
+
+/// Install (or replace) the local wallet's Kyber public key snapshot.
+pub fn install_local_kyber_pubkey(pk: Vec<u8>) {
+    if let Ok(mut g) = LOCAL_KYBER_PUBKEY.write() {
+        *g = Some(pk);
+        log::info!("[SDK] Local Kyber public key installed (bilateral prepare exchange)");
+    }
+}
+
+/// The local wallet's Kyber public key, if a wallet is initialized this session.
+#[must_use]
+pub fn local_kyber_pubkey() -> Option<Vec<u8>> {
+    LOCAL_KYBER_PUBKEY.read().ok()?.clone()
+}
+
 /// Receiver-side Path-B counter reader (D2 activation). Installed by the device layer with an
 /// implementation backed by the BLE relay + the excluded hardware verifier crate. `None` until
 /// installed, which keeps offline-bearer acceptance fail-closed (online recovery).

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/envelope_tests.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/envelope_tests.rs
@@ -101,6 +101,7 @@ fn anchor_enroll_and_disclosure_roundtrip_on_bilateral_messages() {
         anchor_enroll_request: Some(AnchorEnrollRequest {
             verifier_pairing_pubkey: vec![0xB0; 32],
         }),
+        responder_kyber_public_key: vec![],
     };
     let prep2 = BilateralPrepareResponse::decode(prep.encode_to_vec().as_slice()).unwrap();
     assert_eq!(

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
@@ -538,6 +538,19 @@ impl AppRouterImpl {
             }
         };
 
+        // Publish the wallet's Kyber public key to the bridge slot so the bilateral BLE prepare
+        // exchange can attach it (the keypair is randomized per wallet init; counterparties must
+        // refresh their contact's copy every exchange or the per-step EK receipt fail-closes with
+        // "counterparty contact missing Kyber public key"). Warn-and-continue: an absent key just
+        // leaves prepare messages with an empty field, which is the legacy behavior.
+        match wallet.get_kyber_public_key() {
+            Ok(pk) => crate::bridge::install_local_kyber_pubkey(pk),
+            Err(e) => log::warn!(
+                "[DSM_SDK] local Kyber public key unavailable at router build (bilateral prepare \
+                 will omit it): {e}"
+            ),
+        }
+
         let bilateral_storage = if config.enable_offline {
             let cfg = BilateralStorageConfig {
                 offline_mode: true,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/bilateral_impl.rs
@@ -289,6 +289,8 @@ impl BilateralHandler for BiImpl {
                                         .unwrap_or_default(),
                                 receiver_challenge: vec![], // r_R: set by the BLE receiver path for bearer transfers
                                 anchor_enroll_request: None, // set by the BLE receiver path (first-transfer bearer enroll)
+                                responder_kyber_public_key: crate::bridge::local_kyber_pubkey()
+                                    .unwrap_or_default(),
                             };
 
                             return BiResult {
@@ -329,6 +331,8 @@ impl BilateralHandler for BiImpl {
                             crate::sdk::app_state::AppState::get_public_key().unwrap_or_default(),
                         receiver_challenge: vec![], // r_R: set by the BLE receiver path for bearer transfers
                         anchor_enroll_request: None, // set by the BLE receiver path (first-transfer bearer enroll)
+                        responder_kyber_public_key: crate::bridge::local_kyber_pubkey()
+                            .unwrap_or_default(),
                     };
 
                     BiResult {

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/contacts.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/contacts.rs
@@ -1332,6 +1332,49 @@ pub fn update_contact_public_key(device_id: &[u8], public_key: &[u8]) -> Result<
     Ok(())
 }
 
+/// Update a contact's ML-KEM-768 (Kyber) encapsulation key from a live bilateral prepare
+/// exchange. The peer's Kyber keypair is randomized per wallet init, so this is refreshed on
+/// every exchange (mirrors [`update_contact_public_key`]); per-step EK receipts encapsulate
+/// to this key and fail-close when it is absent.
+pub fn update_contact_kyber_key(device_id: &[u8], kyber_public_key: &[u8]) -> Result<()> {
+    if device_id.len() != 32 {
+        return Err(anyhow!("Invalid device_id length"));
+    }
+    // ML-KEM-768 encapsulation key is exactly 1184 bytes; never persist anything else.
+    if kyber_public_key.len() != 1184 {
+        return Err(anyhow!(
+            "Invalid Kyber public key length {} (expected 1184)",
+            kyber_public_key.len()
+        ));
+    }
+
+    let binding = get_connection()?;
+    let conn = binding.lock().unwrap_or_else(|poisoned| {
+        log::warn!("DB lock poisoned, recovering");
+        poisoned.into_inner()
+    });
+
+    let rows_changed = conn.execute(
+        "UPDATE contacts SET kyber_public_key = ?1 WHERE device_id = ?2",
+        params![kyber_public_key, device_id],
+    )?;
+
+    if rows_changed == 0 {
+        info!(
+            "No contact found with device_id={:?} to update kyber_public_key",
+            &device_id[..8]
+        );
+    } else {
+        info!(
+            "Updated contact kyber_public_key: device_id={:?} key_len={}",
+            &device_id[..8],
+            kyber_public_key.len()
+        );
+    }
+
+    Ok(())
+}
+
 /// Remove a contact by its contact_id. Returns Ok(true) if a row was deleted, Ok(false) if not found.
 pub fn remove_contact(contact_id: &str) -> Result<bool> {
     let binding = get_connection()?;

--- a/proto/dsm_app.proto
+++ b/proto/dsm_app.proto
@@ -1735,6 +1735,12 @@ message BilateralPrepareRequest {
   string memo_hint               = 13; // optional transfer memo
   string transfer_amount_display = 14; // decimal display amount; backend scales via token decimals
   reserved 15; // removed: legacy Safe-7 sender_anchor_identity (fused anchor is pinned out-of-band)
+  // Sender's CURRENT ML-KEM-768 encapsulation key (1184 bytes; empty = legacy peer).
+  // The device Kyber keypair is deliberately RANDOMIZED per wallet init (no persisted device
+  // secret), so the peer's copy must be refreshed on every prepare exchange — exactly like
+  // sender_signing_public_key above. The receiver persists it on the contact record; the
+  // §11.1 per-step EK receipt (kyber_ct encapsulation) fail-closes without it.
+  bytes  sender_kyber_public_key = 16 [(dsm_max_len)=1184];
 }
 // B -> A, rides BilateralPrepareResponse (Boot Fenced Fused Anchor, receiver-admit fold).
 // On the FIRST offline-bearer transfer with an already-verified contact, the value receiver B
@@ -1779,6 +1785,10 @@ message BilateralPrepareResponse {
   // Receiver-admit fold: present iff this is an offline-bearer transfer with an already-verified
   // contact for which B holds no pin yet (first-transfer enrollment request). See AnchorEnrollRequest.
   AnchorEnrollRequest anchor_enroll_request = 8;
+  // Responder's CURRENT ML-KEM-768 encapsulation key (1184 bytes; empty = legacy peer).
+  // Mirrors responder_signing_public_key: the sender persists it on the contact record so the
+  // §11.1 per-step EK receipt built in the immediately following confirm can encapsulate to it.
+  bytes  responder_kyber_public_key = 9 [(dsm_max_len)=1184];
 }
 
 enum RelationshipSendCheckState {


### PR DESCRIPTION
## The live failure

First real 2-phone BLE transfer: prepare sent, receiver popup accepted, then the sender fail-closed one step later building the confirm receipt —

```
bilateral receipt: counterparty contact missing Kyber public key — re-establish contact to upgrade
```

— and both sides hung silently (receiver stuck Accepted, sender polling `pending_list` forever; the silent-death UX is filed separately).

## Root cause: consumer without producer

`contacts.kyber_public_key` had storage (schema + COALESCE upsert), **two consumers** (the §11.1 per-step EK receipt encapsulates `kyber_ct` to it; `wallet.send` requires it too), and an error message referencing an upgrade path — but **zero producers anywhere in the codebase**. The QR carries no Kyber key; the prepare exchange refreshed only the SPHINCS+ signing key. Every first transfer between QR-added contacts died here. It survives compile and the full test suites because tests stub the key.

## Fix — the prepare exchange is the contact-upgrade seam

Device Kyber keypairs are deliberately **randomized per wallet init** (in-memory keystore, no persisted device secret), so the peer's copy must refresh per exchange — the same rail the signing key already rides:

- **proto** (additive): `BilateralPrepareRequest.sender_kyber_public_key = 16`, `BilateralPrepareResponse.responder_kyber_public_key = 9` (`max_len 1184`; empty = legacy peer → receipt fail-closes exactly as before)
- **bridge**: `install_local_kyber_pubkey` slot, installed by `AppRouterImpl::new` (wallet verified unlocked + device keys initialized at that point, incl. the genesis hot-swap path)
- **BLE handler**: attaches the local key at both build sites; persists the peer key on both receive legs via new `update_contact_kyber_key` (ML-KEM-768 length 1184 enforced)
- skeleton / local-ack / test construction sites filled to conventions

## Scope note (honest status)

This feeds the **BLE bilateral leg**. The **online** `wallet.send` path has the identical *pre-existing* consumer fail-close and still has no refresh channel of its own (works after one BLE exchange with the peer; goes stale if the peer re-inits its wallet). The online refresh channel is filed as follow-up — confirmed by adversarial review as pre-existing, not a regression of this diff.

## Verification

- `dsm_sdk` **1443/0**, `dsm` **1555/0** (serial, CI-style), proto-guard green, fmt clean, all feature combos compile
- Multi-agent adversarial review (MITM-substitution / stale-key / lifecycle lenses): no new attack surface — the Kyber pk rides the same trust rail as the existing `sender_signing_public_key`, and `kyber_ct` is bound inside the signed receipt; the one confirmed finding is the online-leg scope note above

🤖 Generated with [Claude Code](https://claude.com/claude-code)