### PR TITLE
feat(anchor): phone-side USB client for the physical fused-anchor appliance (sender-mock replacement)

### DIFF
--- a/crates/dsm-anchor-core/proto/dsm_anchor.proto
+++ b/crates/dsm-anchor-core/proto/dsm_anchor.proto
@@ -134,4 +134,7 @@ message ApplianceResponse {
   uint32 status                = 10; // OP_STATUS: 0=Ready 1=Prepared 2=Committed
   bool boot_valid              = 11; // OP_STATUS: offline mode enabled this cycle
   bytes spi_response           = 12; // OP_SPI_PASSTHROUGH: raw MISO bytes read back from the chip
+  bytes active_committed_boot_head = 13; // OP_STATUS: committed boot head J_b (== active_boot_head at
+                                         // rest; the PREV fused-anchor-state leaf commits THIS). The
+                                         // USB appliance client needs it to build the next transition.
 }

--- a/crates/dsm-anchor-core/src/proto.rs
+++ b/crates/dsm-anchor-core/src/proto.rs
@@ -298,6 +298,12 @@ pub fn encode_request(req: &pb::ApplianceRequest) -> Vec<u8> {
     req.encode_to_vec()
 }
 
+/// Encode an `OfflineRelease` sub-message to its canonical bytes — what a USB appliance client puts
+/// into `BilateralConfirmRequest.offline_release` after reading it from an `EMIT` response.
+pub fn encode_release(rel: &pb::OfflineRelease) -> Vec<u8> {
+    rel.encode_to_vec()
+}
+
 /// Decode an `ApplianceResponse` frame (host/transport side).
 pub fn decode_response(bytes: &[u8]) -> Result<pb::ApplianceResponse, ProtoError> {
     pb::ApplianceResponse::decode(bytes).map_err(|_| ProtoError::Decode)

--- a/crates/dsm-anchor-core/src/service.rs
+++ b/crates/dsm-anchor-core/src/service.rs
@@ -82,6 +82,7 @@ fn base(op: i32) -> pb::ApplianceResponse {
         status: 0,
         boot_valid: false,
         spi_response: Vec::new(),
+        active_committed_boot_head: Vec::new(),
     }
 }
 
@@ -154,6 +155,7 @@ pub fn dispatch<T: Tropic, S: WitnessSig, P: PartitionSig>(
             anchor_bundle: app.bundle.to_vec(),
             active_anchor_head: app.active.anchor_head.to_vec(),
             active_boot_head: app.active.boot_head.to_vec(),
+            active_committed_boot_head: app.active.committed_boot_head.to_vec(),
             active_anchor_counter: app.active.anchor_counter,
             status: status_code(app.active.status),
             boot_valid: app.active.boot_valid,

--- a/crates/dsm-android-anchor/src/lib.rs
+++ b/crates/dsm-android-anchor/src/lib.rs
@@ -30,6 +30,7 @@ use dsm_sdk::bridge::{
 pub mod install;
 pub mod se_slot;
 pub mod self_test;
+pub mod usb_appliance;
 pub mod usb_pico;
 pub use usb_pico::{UsbPicoTransport, UsbTransceive};
 

--- a/crates/dsm-android-anchor/src/usb_appliance.rs
+++ b/crates/dsm-android-anchor/src/usb_appliance.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Phone-side USB client for the PHYSICAL RP2350 + TROPIC01 fused-anchor appliance.
+//!
+//! The Pico firmware runs the full `anchor_core::Appliance` on real silicon and serves the
+//! `ApplianceRequest`/`ApplianceResponse` protocol over USB-CDC (`LE32` length ++ prost body). This
+//! is the concrete `AnchorAppliance` the SDK flagged as "a real RP2350 USB-CDC/BLE client ...
+//! hardware follow-on" (`dsm_sdk::anchor::appliance_client`): each trait op is exactly one framed
+//! round-trip to the chip, reusing the SAME opaque USB transport proven end-to-end in H2/H3.
+//!
+//! Installing this in place of `InProcessAnchorAppliance` makes the SENDER's `OfflineRelease` come
+//! from the physical secure element and consume a real TROPIC01 monotonic-counter step — the
+//! receiver then reads the decremented counter over the relay and the predicate `H == H0 − (u+1)`
+//! holds against actual silicon. Every op fails CLOSED into `DsmError` (transport error, on-chip
+//! error, or malformed response) so a missing/wedged chip can never fabricate a release.
+
+use anchor_core::proto::{decode_response, encode_release, encode_request, pb};
+use anchor_core::root_advance::{OwnedTransition, Transition};
+use dsm::types::error::DsmError;
+use dsm_sdk::anchor::{AnchorAppliance, AnchorPin, ApplianceStatus};
+
+use crate::usb_pico::UsbTransceive;
+
+/// A physical-chip appliance driven over USB. `pin` is the chip's enrolled identity
+/// (`B`, `anchor_id`, `H0`, `partition_pk`), captured at admission because the appliance wire
+/// protocol has no host op that returns it (STATUS returns `B` but not the rest).
+pub struct UsbAnchorAppliance {
+    usb: UsbTransceive,
+    pin: AnchorPin,
+}
+
+fn arr32(b: &[u8]) -> Result<[u8; 32], DsmError> {
+    b.try_into()
+        .map_err(|_| DsmError::invalid_operation("anchor appliance: expected 32-byte field"))
+}
+
+impl UsbAnchorAppliance {
+    pub fn new(usb: UsbTransceive, pin: AnchorPin) -> Self {
+        Self { usb, pin }
+    }
+
+    /// One appliance op: frame `LE32(len) ++ ApplianceRequest`, run the opaque USB round-trip,
+    /// decode `ApplianceResponse`, and fail closed unless the chip reported `ok`.
+    fn roundtrip(&self, req: pb::ApplianceRequest) -> Result<pb::ApplianceResponse, DsmError> {
+        let body = encode_request(&req);
+        let mut frame = (body.len() as u32).to_le_bytes().to_vec();
+        frame.extend_from_slice(&body);
+        let resp_body = (self.usb)(frame)?;
+        let resp = decode_response(&resp_body).map_err(|e| {
+            DsmError::invalid_operation(format!("anchor appliance: decode response: {e:?}"))
+        })?;
+        if !resp.ok {
+            return Err(DsmError::invalid_operation(format!(
+                "anchor appliance: op {} failed on-chip (error code {})",
+                resp.op, resp.error
+            )));
+        }
+        Ok(resp)
+    }
+
+    fn bare(op: pb::Op) -> pb::ApplianceRequest {
+        pb::ApplianceRequest {
+            op: op as i32,
+            ..Default::default()
+        }
+    }
+}
+
+impl AnchorAppliance for UsbAnchorAppliance {
+    fn status(&mut self) -> Result<ApplianceStatus, DsmError> {
+        let r = self.roundtrip(Self::bare(pb::Op::Status))?;
+        Ok(ApplianceStatus {
+            root: arr32(&r.active_root)?,
+            anchor_head: arr32(&r.active_anchor_head)?,
+            boot_head: arr32(&r.active_boot_head)?,
+            committed_boot_head: arr32(&r.active_committed_boot_head)?,
+            anchor_counter: r.active_anchor_counter,
+        })
+    }
+
+    fn prepare(&mut self, t: &Transition, receiver_challenge: &[u8; 32]) -> Result<(), DsmError> {
+        let req = pb::ApplianceRequest {
+            op: pb::Op::Prepare as i32,
+            transition: Some(OwnedTransition::from(t).to_pb()),
+            receiver_challenge: receiver_challenge.to_vec(),
+            ..Default::default()
+        };
+        self.roundtrip(req).map(|_| ())
+    }
+
+    fn commit(&mut self) -> Result<(), DsmError> {
+        self.roundtrip(Self::bare(pb::Op::Commit)).map(|_| ())
+    }
+
+    fn emit(&mut self) -> Result<Vec<u8>, DsmError> {
+        let r = self.roundtrip(Self::bare(pb::Op::Emit))?;
+        let release = r.release.ok_or_else(|| {
+            DsmError::invalid_operation("anchor appliance: EMIT returned no release")
+        })?;
+        // Re-encode the OfflineRelease sub-message to the exact bytes the mock's emit() produces,
+        // ready to drop into BilateralConfirmRequest.offline_release.
+        Ok(encode_release(&release))
+    }
+
+    fn finalize(&mut self) -> Result<[u8; 32], DsmError> {
+        let r = self.roundtrip(Self::bare(pb::Op::Finalize))?;
+        arr32(&r.active_root)
+    }
+
+    fn cancel(&mut self) -> Result<(), DsmError> {
+        self.roundtrip(Self::bare(pb::Op::Cancel)).map(|_| ())
+    }
+
+    fn pin(&self) -> AnchorPin {
+        self.pin.clone()
+    }
+}


### PR DESCRIPTION
## Why

The sender-side offline-bearer release was produced by `InProcessAnchorAppliance` — **mock silicon** (`core_sdk.rs`: *"in-process mock silicon; real chip material is hardware follow-on"*). So even with the chips plugged in, a sender's `OfflineRelease` never touched the physical TROPIC01. This is the hardware follow-on client the SDK trait comment explicitly flagged.

## What

`UsbAnchorAppliance` (dsm-android-anchor) implements the `AnchorAppliance` trait by driving the **physical** RP2350/TROPIC01 over the opaque USB transport already proven end-to-end in H2/H3 — one framed `ApplianceRequest`/`ApplianceResponse` round-trip per op. The Pico firmware already runs the full `anchor_core::Appliance` on real silicon and dispatches STATUS/PREPARE/COMMIT/EMIT/FINALIZE/CANCEL, so **no firmware op work** was needed — this is purely the phone-side client. With it installed, the sender's release comes from the secure element and consumes a real counter step.

- `usb_appliance.rs` — the client; fail-closed on transport / on-chip / malformed-response. Pin material (`anchor_id`/`H0`/`partition_pk`) is injected at construction because the wire protocol has no host op that returns it (STATUS returns `B` only).
- proto: `ApplianceResponse.active_committed_boot_head` (STATUS) — the client needs `J_b` to build the next transition (`== active_boot_head` at rest). `service::dispatch` returns it; shared by firmware + host verifier.
- `anchor_core::proto::encode_release` — canonical `OfflineRelease` bytes for `emit()`, keeping the crate prost-free.

## Verification

anchor-core **25 tests green**; `dsm_sdk` + `dsm-anchor-hw-verifier` build clean.

## Not in this PR (the remaining hardware bring-up)

1. Injection seam — make `build_offline_bearer_release` use the installed hardware appliance instead of the mock, sourcing the pin from the chip's enrolled identity.
2. Operation wiring — the Offline toggle must build a Transfer with `AuthorityMode::OfflineBearerRequired` (today nothing sets it, so the anchor gate never fires).
3. Firmware reflash (the proto `committed_boot_head` add) + **on-hardware D2 validation** — the counter/identity reconciliation that can only be confirmed by running it on the boards. **No live claim until D2 passes on hardware.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)