### PR TITLE
feat(offline-bearer): drive the physical TROPIC01 anchor from the Offline send path

### DIFF
--- a/crates/dsm-anchor-core/proto/dsm_anchor.proto
+++ b/crates/dsm-anchor-core/proto/dsm_anchor.proto
@@ -137,4 +137,10 @@ message ApplianceResponse {
   bytes active_committed_boot_head = 13; // OP_STATUS: committed boot head J_b (== active_boot_head at
                                          // rest; the PREV fused-anchor-state leaf commits THIS). The
                                          // USB appliance client needs it to build the next transition.
+  // OP_STATUS pin material — the chip self-describing the identity a receiver pins. `anchor_bundle`
+  // (field 6) is B; these three complete the AnchorPin so a USB client sources it from one STATUS
+  // round-trip (no host-side enrollment DB) and the sender's disclosure carries the REAL pin.
+  bytes  pin_anchor_id         = 14; // OP_STATUS: 32-byte anchor id
+  uint64 pin_enrolled_counter  = 15; // OP_STATUS: H0 (the live provisioned enrollment counter)
+  bytes  pin_partition_pk      = 16; // OP_STATUS: partition public key
 }

--- a/crates/dsm-anchor-core/src/appliance.rs
+++ b/crates/dsm-anchor-core/src/appliance.rs
@@ -128,6 +128,9 @@ pub struct Appliance<T: Tropic, S: WitnessSig, P: PartitionSig> {
     pub q_boot: u16,
     pub q_tx: u16,
     pub partition_device_id: [u8; 32],
+    /// PUBLIC partition verification key (safe to disclose). Part of the receiver pin material; the
+    /// STATUS op returns it so a host client / disclosure can carry the full `AnchorPin`.
+    pub partition_pk: Vec<u8>,
     pub active: Active,
     /// Set when recovery sees a firmware-boundary / R-memory-map event.
     pub firmware_boundary_invalid: bool,
@@ -164,6 +167,7 @@ impl<T: Tropic, S: WitnessSig, P: PartitionSig> Appliance<T, S, P> {
             q_boot,
             q_tx,
             partition_device_id,
+            partition_pk: birth.partition_pk.clone(),
             active: Active {
                 root: genesis_root,
                 anchor_head: birth.anchor_head,

--- a/crates/dsm-anchor-core/src/service.rs
+++ b/crates/dsm-anchor-core/src/service.rs
@@ -83,6 +83,9 @@ fn base(op: i32) -> pb::ApplianceResponse {
         boot_valid: false,
         spi_response: Vec::new(),
         active_committed_boot_head: Vec::new(),
+        pin_anchor_id: Vec::new(),
+        pin_enrolled_counter: 0,
+        pin_partition_pk: Vec::new(),
     }
 }
 
@@ -159,6 +162,9 @@ pub fn dispatch<T: Tropic, S: WitnessSig, P: PartitionSig>(
             active_anchor_counter: app.active.anchor_counter,
             status: status_code(app.active.status),
             boot_valid: app.active.boot_valid,
+            pin_anchor_id: app.anchor_id.to_vec(),
+            pin_enrolled_counter: u64::from(app.h0),
+            pin_partition_pk: app.partition_pk.clone(),
             ..base(op)
         },
         Ok(pb::Op::Cancel) => match app.cancel() {

--- a/crates/dsm-anchor-pico/src/main.rs
+++ b/crates/dsm-anchor-pico/src/main.rs
@@ -83,7 +83,14 @@ const XTAL_HZ: u32 = 12_000_000;
 const Q_BOOT: u16 = 5; // MACANDD boot-fence slot
 const Q_TX: u16 = 6; // MACANDD transfer-witness slot
 const COUNTER: MCounterIndex = MCounterIndex::Index0;
-const ENROLL_H0: u32 = 1000;
+// Enrollment counter H0 = the value the monotonic counter was PROVISIONED to (bench CLI:
+// `MCOUNTER_MAX`), NOT a bring-up placeholder. It is a FIXED constant so the birth ceremony is
+// deterministic across reboots (stable bundle/identity); the LIVE counter (`mcounter_get`) gives the
+// current H and the appliance derives u = H0 − H. The firmware ADOPTS the provisioned counter — it
+// must NOT re-init it (that would reset the counter and defeat the anti-double-spend guarantee).
+// NOTE (D2 reconciliation): `COUNTER` must be the SAME physical MCOUNTER index the CLI initialized AND
+// the caged verifier slot the receiver reads over the relay — confirm on hardware.
+const ENROLL_H0: u32 = 0xFFFF_FFFE; // tropic01 MCOUNTER_VALUE_MAX (4_294_967_294)
 
 /// The partition certificate scheme: BLAKE3-SPHINCS+ SPX128f (fast sign, 17,088 B
 /// signature, 64 B pk). The receiver verifies with the same scheme.
@@ -322,9 +329,14 @@ fn enroll<SPI: SpiDevice, CS: OutputPin>(
     partition_trng: &[u8; 32],
     host_nonce: &[u8; 32],
 ) -> Result<(u32, Birth), &'static str> {
-    sess.mcounter_init(COUNTER, ENROLL_H0)
-        .map_err(|_| "mcounter_init")?;
-    let h0 = sess.mcounter_get(COUNTER).map_err(|_| "mcounter_get")?;
+    // ADOPT the provisioned counter — do NOT `mcounter_init` (re-init resets the physical counter and
+    // would let a rebooted device re-spend already-consumed offline-bearer steps). `H0` is the fixed
+    // provisioning constant `ENROLL_H0`; the live read is only a sanity floor (a healthy provisioned
+    // chip reads at or below H0). Birth is deterministic over `ENROLL_H0`, so identity is stable.
+    let live = sess.mcounter_get(COUNTER).map_err(|_| "mcounter_get")?;
+    if live > ENROLL_H0 {
+        return Err("counter above enrollment H0 (unprovisioned/mis-provisioned chip)");
+    }
     // Arm both slots; capture the boot slot's output as the TROPIC birth witness.
     let birth_witness = *sess
         .mac_and_destroy(Q_BOOT.into(), &ARM0)
@@ -345,7 +357,8 @@ fn enroll<SPI: SpiDevice, CS: OutputPin>(
         q_tx: Q_TX,
         genesis_root: &GENESIS,
     });
-    Ok((h0, b))
+    // Return the FIXED enrollment H0 (not the live read): the appliance derives u = H0 − live.
+    Ok((ENROLL_H0, b))
 }
 
 fn prepare_request() -> pb::ApplianceRequest {

--- a/crates/dsm-android-anchor/src/install.rs
+++ b/crates/dsm-android-anchor/src/install.rs
@@ -90,6 +90,19 @@ pub fn install_path_b_transports() -> bool {
     log::info!(
         "[anchor-install] read-only SeSlotWriter installed (disclosure fail-closed until setup)"
     );
+
+    // Sender side: the ACCEPT-PRODUCING appliance factory. Each offline-bearer release is built by a
+    // fresh `UsbAnchorAppliance` that drives A's own physical RP2350/TROPIC01 over the same opaque USB
+    // up-call, self-sourcing its pin from a STATUS round-trip. Installing this replaces the in-process
+    // mock so a real send consumes a real counter step. Absent -> offline-bearer fails closed in the
+    // SDK ("offline = chips").
+    dsm_sdk::bridge::install_anchor_appliance_factory(std::sync::Arc::new(|| {
+        let usb: crate::usb_pico::UsbTransceive =
+            std::sync::Arc::new(crate::usb_pico::jni_usb_transceive);
+        crate::usb_appliance::UsbAnchorAppliance::connect(usb)
+            .map(|a| Box::new(a) as Box<dyn dsm_sdk::anchor::AnchorAppliance + Send>)
+    }));
+    log::info!("[anchor-install] UsbAnchorAppliance factory installed (offline-bearer = physical chip)");
     true
 }
 

--- a/crates/dsm-android-anchor/src/usb_appliance.rs
+++ b/crates/dsm-android-anchor/src/usb_appliance.rs
@@ -20,9 +20,9 @@ use dsm_sdk::anchor::{AnchorAppliance, AnchorPin, ApplianceStatus};
 
 use crate::usb_pico::UsbTransceive;
 
-/// A physical-chip appliance driven over USB. `pin` is the chip's enrolled identity
-/// (`B`, `anchor_id`, `H0`, `partition_pk`), captured at admission because the appliance wire
-/// protocol has no host op that returns it (STATUS returns `B` but not the rest).
+/// A physical-chip appliance driven over USB. The `pin` is self-sourced from a STATUS round-trip
+/// at construction — the chip self-describes its enrolled identity (`B`, `anchor_id`, `H0`,
+/// `partition_pk`), so there is no host-side enrollment DB and the pin is always the REAL silicon's.
 pub struct UsbAnchorAppliance {
     usb: UsbTransceive,
     pin: AnchorPin,
@@ -33,41 +33,62 @@ fn arr32(b: &[u8]) -> Result<[u8; 32], DsmError> {
         .map_err(|_| DsmError::invalid_operation("anchor appliance: expected 32-byte field"))
 }
 
+/// One appliance op over the transport: frame `LE32(len) ++ ApplianceRequest`, run the opaque USB
+/// round-trip, decode `ApplianceResponse`, and fail closed unless the chip reported `ok`. Free
+/// function so it is usable from `new()` before `self` exists.
+fn roundtrip(usb: &UsbTransceive, req: pb::ApplianceRequest) -> Result<pb::ApplianceResponse, DsmError> {
+    let body = encode_request(&req);
+    let mut frame = (body.len() as u32).to_le_bytes().to_vec();
+    frame.extend_from_slice(&body);
+    let resp_body = usb(frame)?;
+    let resp = decode_response(&resp_body).map_err(|e| {
+        DsmError::invalid_operation(format!("anchor appliance: decode response: {e:?}"))
+    })?;
+    if !resp.ok {
+        return Err(DsmError::invalid_operation(format!(
+            "anchor appliance: op {} failed on-chip (error code {})",
+            resp.op, resp.error
+        )));
+    }
+    Ok(resp)
+}
+
+fn bare(op: pb::Op) -> pb::ApplianceRequest {
+    pb::ApplianceRequest {
+        op: op as i32,
+        ..Default::default()
+    }
+}
+
 impl UsbAnchorAppliance {
-    pub fn new(usb: UsbTransceive, pin: AnchorPin) -> Self {
-        Self { usb, pin }
+    /// Connect to the physical appliance and self-source its pin from one STATUS round-trip.
+    /// Fails closed if the chip is unreachable or STATUS omits the pin material (pre-STATUS-pin
+    /// firmware) — an appliance whose identity cannot be read must never produce releases.
+    pub fn connect(usb: UsbTransceive) -> Result<Self, DsmError> {
+        let s = roundtrip(&usb, bare(pb::Op::Status))?;
+        let pin = AnchorPin {
+            bundle: arr32(&s.anchor_bundle)?,
+            anchor_id: arr32(&s.pin_anchor_id)?,
+            enrolled_counter: s.pin_enrolled_counter,
+            partition_pk: s.pin_partition_pk,
+        };
+        if pin.partition_pk.is_empty() {
+            return Err(DsmError::invalid_operation(
+                "anchor appliance: STATUS returned no partition_pk — firmware lacks STATUS pin \
+                 material; cannot produce verifiable releases (fail closed)",
+            ));
+        }
+        Ok(Self { usb, pin })
     }
 
-    /// One appliance op: frame `LE32(len) ++ ApplianceRequest`, run the opaque USB round-trip,
-    /// decode `ApplianceResponse`, and fail closed unless the chip reported `ok`.
     fn roundtrip(&self, req: pb::ApplianceRequest) -> Result<pb::ApplianceResponse, DsmError> {
-        let body = encode_request(&req);
-        let mut frame = (body.len() as u32).to_le_bytes().to_vec();
-        frame.extend_from_slice(&body);
-        let resp_body = (self.usb)(frame)?;
-        let resp = decode_response(&resp_body).map_err(|e| {
-            DsmError::invalid_operation(format!("anchor appliance: decode response: {e:?}"))
-        })?;
-        if !resp.ok {
-            return Err(DsmError::invalid_operation(format!(
-                "anchor appliance: op {} failed on-chip (error code {})",
-                resp.op, resp.error
-            )));
-        }
-        Ok(resp)
-    }
-
-    fn bare(op: pb::Op) -> pb::ApplianceRequest {
-        pb::ApplianceRequest {
-            op: op as i32,
-            ..Default::default()
-        }
+        roundtrip(&self.usb, req)
     }
 }
 
 impl AnchorAppliance for UsbAnchorAppliance {
     fn status(&mut self) -> Result<ApplianceStatus, DsmError> {
-        let r = self.roundtrip(Self::bare(pb::Op::Status))?;
+        let r = self.roundtrip(bare(pb::Op::Status))?;
         Ok(ApplianceStatus {
             root: arr32(&r.active_root)?,
             anchor_head: arr32(&r.active_anchor_head)?,
@@ -88,11 +109,11 @@ impl AnchorAppliance for UsbAnchorAppliance {
     }
 
     fn commit(&mut self) -> Result<(), DsmError> {
-        self.roundtrip(Self::bare(pb::Op::Commit)).map(|_| ())
+        self.roundtrip(bare(pb::Op::Commit)).map(|_| ())
     }
 
     fn emit(&mut self) -> Result<Vec<u8>, DsmError> {
-        let r = self.roundtrip(Self::bare(pb::Op::Emit))?;
+        let r = self.roundtrip(bare(pb::Op::Emit))?;
         let release = r.release.ok_or_else(|| {
             DsmError::invalid_operation("anchor appliance: EMIT returned no release")
         })?;
@@ -102,12 +123,12 @@ impl AnchorAppliance for UsbAnchorAppliance {
     }
 
     fn finalize(&mut self) -> Result<[u8; 32], DsmError> {
-        let r = self.roundtrip(Self::bare(pb::Op::Finalize))?;
+        let r = self.roundtrip(bare(pb::Op::Finalize))?;
         arr32(&r.active_root)
     }
 
     fn cancel(&mut self) -> Result<(), DsmError> {
-        self.roundtrip(Self::bare(pb::Op::Cancel)).map(|_| ())
+        self.roundtrip(bare(pb::Op::Cancel)).map(|_| ())
     }
 
     fn pin(&self) -> AnchorPin {

--- a/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/types/operations.rs
@@ -188,6 +188,26 @@ impl AuthorityPolicy {
     }
 }
 
+/// The canonical DSM offline-bearer authority policy (v1). ONE agreed value referenced by BOTH the
+/// sender (building the offline-bearer transfer operation) and the receiver (verifying the release
+/// commits to the same policy) — so the `policy_id` bound into the operation, the chip's PREPARE
+/// `authority_policy_hash`, and the receiver's accept check are provably identical bytes.
+/// `policy_id`/`anchor_set_id` are domain-separated constants; per-tenant policy-registry management
+/// is a later refinement layered on this default.
+pub fn canonical_offline_bearer_policy() -> AuthorityPolicy {
+    AuthorityPolicy {
+        mode: AuthorityMode::OfflineBearerRequired,
+        policy_id: crate::crypto::blake3::domain_hash_bytes(
+            "DSM/offline-bearer/policy-id/well-known/v1",
+            &[],
+        ),
+        anchor_set_id: crate::crypto::blake3::domain_hash_bytes(
+            "DSM/offline-bearer/anchor-set-id/well-known/v1",
+            &[],
+        ),
+    }
+}
+
 /// Primary state transition operation enum (no Serde in canonical path).
 ///
 /// Each variant represents a distinct kind of state transition in the DSM

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -3390,6 +3390,15 @@ impl BilateralBleHandler {
                             .as_ref()
                             .map(|ap| ap.policy_id)
                             .unwrap_or([0u8; 32]);
+                        // Policy-binding trace (sender → chip PREPARE): the value the chip commits as
+                        // `authority_policy_hash` MUST equal the receiver's canonical policy_id, or the
+                        // proof is meaningless. Compared against the canonical value here.
+                        info!(
+                            "[BILATERAL][offline-bearer][sender] chip PREPARE authority_policy_hash={} (canonical_match={})",
+                            bytes_to_base32(&authority_policy_hash),
+                            authority_policy_hash
+                                == dsm::types::operations::canonical_offline_bearer_policy().policy_id
+                        );
                         match router.build_offline_bearer_release(
                             rel_key,
                             session.counterparty_device_id,
@@ -4367,6 +4376,14 @@ impl BilateralBleHandler {
                 } => ap.policy_id,
                 _ => [0u8; 32],
             };
+            // Policy-binding trace (receiver verify): the policy_id this receiver enforces against the
+            // release MUST equal the canonical value the sender bound. A mismatch means the proof does
+            // not attest what we think — reject rather than "run and mean nothing".
+            info!(
+                "[BILATERAL][offline-bearer][receiver] verify policy_id={} (canonical_match={})",
+                bytes_to_base32(&policy_hash),
+                policy_hash == dsm::types::operations::canonical_offline_bearer_policy().policy_id
+            );
             let expected_receiver_challenge = session.receiver_challenge.unwrap_or([0u8; 32]);
             // Anchor-state binding: the sender's device-SMT roots (before = pinned frontier,
             // after = adopted successor) and the two inclusion proofs, as carried on the confirm.

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bridge/mod.rs
@@ -301,6 +301,38 @@ pub fn anchor_enrollment_store(
     ANCHOR_ENROLLMENT_STORE.read().ok()?.clone()
 }
 
+/// SENDER-side fused-anchor appliance factory. Produces the fresh `AnchorAppliance` the offline-bearer
+/// release is built on. The device layer installs a factory that returns a `UsbAnchorAppliance`
+/// driving the physical RP2350/TROPIC01; `build_offline_bearer_release` calls it ONCE and caches the
+/// result (the appliance is stateful — its counter advances and its witness key erases on COMMIT).
+///
+/// `None` until installed. On device, an absent factory means offline-bearer is unavailable and the
+/// send FAILS CLOSED (no mock fallback) — "offline = chips". The in-process mock is used only by the
+/// SDK's own `#[cfg(test)]` release-path tests. The factory returns `Result` so a failed chip connect
+/// (e.g. STATUS unreadable) propagates as a fail-closed error rather than a silent mock.
+type AnchorApplianceFactory = Arc<
+    dyn Fn() -> Result<Box<dyn crate::anchor::AnchorAppliance + Send>, dsm::types::error::DsmError>
+        + Send
+        + Sync,
+>;
+static ANCHOR_APPLIANCE_FACTORY: Lazy<RwLock<Option<AnchorApplianceFactory>>> =
+    Lazy::new(|| RwLock::new(None));
+
+/// Install (or replace) the sender-side anchor-appliance factory (the physical-chip producer).
+pub fn install_anchor_appliance_factory(factory: AnchorApplianceFactory) {
+    if let Ok(mut g) = ANCHOR_APPLIANCE_FACTORY.write() {
+        *g = Some(factory);
+        log::info!(
+            "[SDK] AnchorApplianceFactory installed (offline-bearer release = physical chip)"
+        );
+    }
+}
+
+#[must_use]
+pub fn anchor_appliance_factory() -> Option<AnchorApplianceFactory> {
+    ANCHOR_APPLIANCE_FACTORY.read().ok()?.clone()
+}
+
 /// RECEIVER-side X25519 verifier pairing key deriver (Boot Fenced Fused Anchor receiver-admit).
 /// Produces the pairing PUBLIC key B offers in the first-transfer `AnchorEnrollRequest`, derived
 /// per-counterparty from B's identity seed (the private half is re-derived at read time by the

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/wallet_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/wallet_routes.rs
@@ -248,6 +248,17 @@ fn encode_offline_transfer_operation_canonical(
     push_str(&mut out, memo);
     push_bytes(&mut out, &[]);
 
+    // Offline mode is HARD-REQUIRED to be chip-attested ("offline = chips"): append the canonical
+    // offline-bearer authority-policy tail so `operation_requires_offline_bearer` fires and the send
+    // drives the physical anchor (fail-closed if no chip). Uses the real `append_canonical` codec, so
+    // the bytes are exactly what `Operation::from_bytes` decodes on the receiver.
+    let policy = dsm::types::operations::canonical_offline_bearer_policy();
+    policy.append_canonical(&mut out);
+    log::info!(
+        "[wallet.sendOffline] offline-bearer authority policy bound: policy_id={}",
+        crate::util::text_id::encode_base32_crockford(&policy.policy_id)
+    );
+
     out
 }
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -70,7 +70,7 @@ pub struct CoreSDK {
     /// its down-counter + fused-anchor lineage advance. Its `commit_0` is bootstrapped into the
     /// DeviceState anchor-state leaf on birth; each bearer transfer drives PREPARE→COMMIT→EMIT→
     /// FINALIZE and advances the leaf in the same `DeviceState::advance`.
-    anchor_appliance: Mutex<Option<crate::anchor::InProcessAnchorAppliance>>,
+    anchor_appliance: Mutex<Option<Box<dyn crate::anchor::AnchorAppliance + Send>>>,
 }
 
 /* ------------------------------- Helpers -------------------------------- */
@@ -1602,7 +1602,6 @@ impl CoreSDK {
         action_fields: Vec<u8>,
         receiver_challenge: [u8; 32],
     ) -> Result<OfflineBearerArtifacts, DsmError> {
-        use crate::anchor::{AnchorAppliance, BirthConfig, InProcessAnchorAppliance};
         use dsm::core::bilateral_transaction_manager::{anchor_state_commit, anchor_state_leaf_key};
 
         let dev = self.device_info.device_id;
@@ -1610,34 +1609,40 @@ impl CoreSDK {
 
         let mut guard = self.anchor_appliance.lock();
         if guard.is_none() {
-            // Birth the device appliance from deterministic device-derived material (in-process
-            // mock silicon; real chip material is hardware follow-on).
-            let app = InProcessAnchorAppliance::birth_and_boot(&BirthConfig {
-                partition_trng: seed("DSM/anchor/partition-trng/v1"),
-                host_nonce: seed("DSM/anchor/host-nonce/v1"),
-                device_id: dev,
-                policy_hash: seed("DSM/anchor/policy-hash/v1"),
-                partition_device_id: seed("DSM/anchor/partition-device-id/v1"),
-                anchor_id: seed("DSM/anchor/anchor-id/v1"),
-                partition_key_seed: seed("DSM/anchor/partition-key-seed/v1"),
-                enrolled_counter: 1_000_000,
-                q_boot: 5,
-                q_tx: 6,
-                genesis_root: seed("DSM/anchor/genesis-root/v1"),
-                firmware_measurement: seed("DSM/anchor/firmware-measurement/v1"),
-                se_secret: seed("DSM/anchor/se-secret/v1"),
-            })?;
-            // Bootstrap commit_0 = (B, A_0, J_0, 0) into the DeviceState anchor-state leaf.
-            let st = {
-                // status() needs &mut; take it, read, put back below.
-                let mut a = app;
+            // Sender-side appliance: the physical RP2350/TROPIC01 via the installed factory. On device
+            // an absent factory FAILS CLOSED ("offline = chips"); the in-process mock is the test-only
+            // producer. The factory is called once and cached (stateful appliance).
+            let mut a: Box<dyn crate::anchor::AnchorAppliance + Send> =
+                match crate::bridge::anchor_appliance_factory() {
+                    Some(factory) => factory()?,
+                    None => hardware_appliance_or_fail(&seed, dev)?,
+                };
+            // Reconcile the DeviceState anchor-state leaf to the appliance's CURRENT committed fused
+            // state, sourced from the chip's own status()/pin() (chip identity for hardware; seeds for
+            // the test mock). The CHIP is the source of truth for the counter, so this uses its live
+            // `anchor_counter` (u), NOT a hardcoded 0:
+            //   * fresh provisioned chip -> u == 0 (H == H0), the genesis commit;
+            //   * process restart with k prior offline-bearer transfers (possibly with ONLINE transfers
+            //     in between — those advance the device SMT but never touch the chip counter) -> u == k,
+            //     so the leaf adopts the true post-k state instead of resetting to genesis;
+            //   * device-state/chip divergence -> the hardware wins (a monotonic counter cannot lie).
+            // Writing the current committed state is idempotent when the leaf already matches.
+            {
                 let s = a.status()?;
                 let pin = a.pin();
-                // commit_0 must commit the COMMITTED boot head (what the first transfer's cert reports
-                // as `prev_boot_head`), NOT the live `boot_head` — `birth_and_boot` advances the live
-                // head past the committed one, so they differ at genesis until the first finalize.
-                let commit0 =
-                    anchor_state_commit(&pin.bundle, &s.anchor_head, &s.committed_boot_head, 0);
+                // Commit the COMMITTED boot head (what the next transfer's cert reports as
+                // `prev_boot_head`), NOT the live `boot_head` — a boot advance moves the live head past
+                // the committed one until the next finalize.
+                let committed = anchor_state_commit(
+                    &pin.bundle,
+                    &s.anchor_head,
+                    &s.committed_boot_head,
+                    s.anchor_counter,
+                );
+                log::info!(
+                    "[offline-bearer] anchor-state leaf reconciled to chip state: u(anchor_counter)={} (online-transfer-safe; chip is source of truth)",
+                    s.anchor_counter
+                );
                 let key = anchor_state_leaf_key(&pin.bundle);
                 {
                     let mut sm = self.state_machine.lock();
@@ -1646,13 +1651,11 @@ impl CoreSDK {
                             "offline-bearer: DeviceState not initialized (genesis first)",
                         )
                     })?;
-                    let bootstrapped = ds.with_anchor_state_leaf(&key, &commit0)?;
+                    let bootstrapped = ds.with_anchor_state_leaf(&key, &committed)?;
                     sm.set_device_head(bootstrapped);
                 }
                 *guard = Some(a);
-                s
-            };
-            let _ = st;
+            }
         }
 
         let app = guard.as_mut().ok_or_else(|| {
@@ -1716,6 +1719,44 @@ impl CoreSDK {
 }
 
 /* ------------------------------ Private helpers ------------------------- */
+
+/// The sender-side appliance when NO hardware factory is installed. Test builds get the in-process
+/// mock so the release-path unit tests keep exercising `build_offline_bearer_release`; real device
+/// builds FAIL CLOSED — offline-bearer strictly requires the physical chip ("offline = chips").
+#[cfg(test)]
+fn hardware_appliance_or_fail(
+    seed: &impl Fn(&str) -> [u8; 32],
+    dev: [u8; 32],
+) -> Result<Box<dyn crate::anchor::AnchorAppliance + Send>, DsmError> {
+    use crate::anchor::{BirthConfig, InProcessAnchorAppliance};
+    Ok(Box::new(InProcessAnchorAppliance::birth_and_boot(
+        &BirthConfig {
+            partition_trng: seed("DSM/anchor/partition-trng/v1"),
+            host_nonce: seed("DSM/anchor/host-nonce/v1"),
+            device_id: dev,
+            policy_hash: seed("DSM/anchor/policy-hash/v1"),
+            partition_device_id: seed("DSM/anchor/partition-device-id/v1"),
+            anchor_id: seed("DSM/anchor/anchor-id/v1"),
+            partition_key_seed: seed("DSM/anchor/partition-key-seed/v1"),
+            enrolled_counter: 1_000_000,
+            q_boot: 5,
+            q_tx: 6,
+            genesis_root: seed("DSM/anchor/genesis-root/v1"),
+            firmware_measurement: seed("DSM/anchor/firmware-measurement/v1"),
+            se_secret: seed("DSM/anchor/se-secret/v1"),
+        },
+    )?))
+}
+
+#[cfg(not(test))]
+fn hardware_appliance_or_fail(
+    _seed: &impl Fn(&str) -> [u8; 32],
+    _dev: [u8; 32],
+) -> Result<Box<dyn crate::anchor::AnchorAppliance + Send>, DsmError> {
+    Err(DsmError::invalid_operation(
+        "offline-bearer requires the hardware anchor; connect the Pico and install Path-B (fail closed)",
+    ))
+}
 
 impl CoreSDK {
     fn validate_transfer_request(


### PR DESCRIPTION
Stacked on #557 (base = `feat/hw-anchor-appliance-usb-client`). GitHub will auto-retarget this PR to `main` once #557 merges. Review/merge #557 first.

## What this does
Makes the **Offline** send toggle actually engage the TROPIC01 secure element instead of running a plain bilateral BLE transfer. This is the Rust half of the chip-backed offline-bearer activation; the Pico firmware already runs the full `anchor_core::Appliance` on real silicon, so no firmware *logic* was needed — only the phone-side wiring (plus a counter-model fix in the firmware constants).

## Two source-verified reasons the chips never ran (both fixed)

**1. Nothing set `OfflineBearerRequired`.** The anchor path is gated on `operation_requires_offline_bearer` (`bilateral_transaction_manager.rs:336`), which only fires for a `Transfer` whose `AuthorityPolicy.mode == OfflineBearerRequired`. The sole setter was a `#[cfg(test)]` test, so the gate was always false.
- The offline encoder (`wallet_routes.rs`) now always appends the canonical `OfflineBearerRequired` authority-policy tail via the new `canonical_offline_bearer_policy()` (`operations.rs`).
- Policy-match trace logs added at sender-build, chip `PREPARE`, and receiver verify so the same policy bytes are provably bound end-to-end.

**2. The sender release was mock silicon.** `build_offline_bearer_release` built the release with `InProcessAnchorAppliance`.
- `CoreSDK.anchor_appliance` is now `Box<dyn AnchorAppliance + Send>`, sourced from a bridge factory (`install_anchor_appliance_factory`) that `install_path_b_transports` fills with the real `UsbAnchorAppliance`.
- **Hard-require the chip:** on device with no factory installed, `build_offline_bearer_release` **fails closed** (the mock is `#[cfg(test)]`-only). Offline mode strictly means chip-attested — no signature-only fallback.

## Chip self-describes its identity
`anchor-core` STATUS now returns the full pin — `pin_anchor_id`, `pin_enrolled_counter` (H0), `pin_partition_pk` — and `Appliance` stores `partition_pk` at birth. So `UsbAnchorAppliance::connect` self-sources its `AnchorPin` from **one STATUS round-trip** (fail-closed if `partition_pk` is empty). No sender-side enrollment DB.

## Online-transfer interleaving (owner requirement)
Online transfers happen between offline-bearer transfers and must never touch the chip counter. Verified: `DeviceState::advance` with `anchor_leaf: None` replaces only the relationship leaf (preserving the anchor-state leaf); the receiver verifies against the sender's *current* SMT root; `H == H0 − (u+1)` is inherently online-safe (`u` counts chip steps only).

**Bug found + fixed:** the anchor-state leaf bootstrap in `build_offline_bearer_release` hardcoded `counter = 0`, so a process restart after prior offline transfers reset the leaf to genesis. It now reconciles to the chip's **live** `anchor_counter`. The mock (re-birthed at genesis each process, `u=0`) hid this; the real chip (state of record, survives restart) exposes it.

## Firmware counter model
`ENROLL_H0` → `MCOUNTER_MAX` (`0xFFFF_FFFE`) and `mcounter_init` **removed** — the firmware *adopts* the provisioned counter and never re-inits it at boot (a boot init would reset the counter and re-enable replay of consumed steps). `u = H0 − live`, with a sanity floor rejecting a chip that reads above `H0`.

## Verification
`dsm_sdk` 1443/0 · `dsm` 1555/0 · `anchor-core` 25/0 · android ndk check · firmware `thumbv8m` release build · proto-guard · fmt — all green.

## Not done here (fail-closed until proven)
- Firmware container reflash of both Picos + chip-unique birth identity (`anchor_id` from `stpub`) — production hardening; anti-clone is already carried by the pin's `chip_static_pubkey`.
- On-hardware **D2**: `PREPARE`/`COMMIT`/`EMIT` to the chip, relay counter read, accept iff `H == H0 − (u+1)`, the offline→online→offline interleave, and process-restart recovery.

**No live claim until D2 passes on the actual boards.**