### PR TITLE
fix(offline-bearer): first end-to-end chip-backed transfer (D2)

### DIFF
--- a/crates/dsm-anchor-core/src/appliance.rs
+++ b/crates/dsm-anchor-core/src/appliance.rs
@@ -636,8 +636,16 @@ impl<T: Tropic, S: WitnessSig, P: PartitionSig> Appliance<T, S, P> {
                 }
             }
             Status::Ready => {
+                // The chip's monotonic counter is the source of truth (it can only fall). If it reads
+                // LOWER than the appliance's model (`active < live_u` — more steps consumed than we
+                // tracked, e.g. a fresh birth on a provisioned chip whose counter is already below H0),
+                // ADOPT the live position rather than downgrading. Adopting a HIGHER `u` only shrinks
+                // the remaining budget — it can never mint value or enable a double-spend (the counter
+                // already moved) — and it restores `active.anchor_counter == live_u` so PREPARE's
+                // counter check passes on a Ready device. `active > live_u` is still impossible for a
+                // real down-counter (would require the counter to rise) -> fail closed.
                 if self.active.anchor_counter < live_u {
-                    return RecoverOutcome::DowngradeOnline;
+                    self.active.anchor_counter = live_u;
                 }
                 if self.active.anchor_counter > live_u {
                     return RecoverOutcome::FailClosed;

--- a/crates/dsm-anchor-core/tests/integration.rs
+++ b/crates/dsm-anchor-core/tests/integration.rs
@@ -508,16 +508,24 @@ fn recover_prepared_can_complete() {
 }
 
 #[test]
-fn recover_ready_stale_downgrades_and_ahead_fails_closed() {
+fn recover_ready_stale_adopts_live_and_ahead_fails_closed() {
+    // A Ready device whose model is BEHIND the chip (the normal state after any transfer + reboot,
+    // since the counter is permanently below H0 and the appliance re-births at u=0) must ADOPT the
+    // live counter — the chip is the source of truth. Adopting only shrinks the remaining budget and
+    // cannot enable a double-spend.
     let (mut a, _pk, _b) = app(H0);
     a.boot(1, &FW).unwrap();
     let t = make_transition(ROOT0, ROOT1, 0);
     a.prepare(&t.as_transition(), &RCHAL).unwrap();
     a.commit().unwrap();
     a.finalize().unwrap(); // counter at 99, u=1
-    a.active.anchor_counter = 0; // stale
-    assert_eq!(a.recover(), RecoverOutcome::DowngradeOnline);
+    a.active.anchor_counter = 0; // stale (behind the chip)
+    let root = a.active.root;
+    assert_eq!(a.recover(), RecoverOutcome::Accept(root)); // adopts live_u, ready to serve
+    assert_eq!(a.active.anchor_counter, 1); // reconciled to the live chip counter
 
+    // A device AHEAD of the chip (more spends than the down-counter shows) is impossible for a real
+    // monotonic down-counter (it would have to rise) -> fail closed.
     let (mut a, _pk, _b) = app(H0);
     a.boot(1, &FW).unwrap();
     a.active.anchor_counter = 5; // ahead

--- a/crates/dsm-anchor-hw-verifier/src/reader.rs
+++ b/crates/dsm-anchor-hw-verifier/src/reader.rs
@@ -114,25 +114,45 @@ impl AnchorCounterReader for RelayCounterReader {
             sh_priv: sh_priv.to_bytes(),
             pinned_static_pubkey: stpub,
         };
-        let ephemeral: Option<[u8; 32]> = dsm::crypto::rng::random_bytes(32).try_into().ok();
         let transport = self.transport.clone();
 
         Box::pin(async move {
-            let Some(ephemeral) = ephemeral else {
-                log::warn!("[hw-verifier] counter read refused: CSPRNG ephemeral unavailable");
-                return None;
-            };
-            match read_counter_over_relay(cred, ephemeral, move |mosi| {
-                (transport)(peer_device_id, commitment, mosi)
-            })
-            .await
-            {
-                Ok(h) => Some(h),
-                Err(e) => {
-                    log::warn!("[hw-verifier] Path-B counter read failed (fail-closed): {e}");
-                    None
+            // The counter read is a READ (no chip/relationship state change), so retrying the WHOLE
+            // exchange is idempotent and safe. Each attempt opens a FRESH Noise session (fresh
+            // ephemeral) — a single dropped relay chunk kills one session's round-trip (15s timeout)
+            // but a fresh session recovers. Without this retry a transient BLE drop fails the confirm
+            // AND diverges the cert-chain (per-step-EK passed + anchor pinned, then rejected), so the
+            // retry is load-bearing for correctness, not just latency.
+            const MAX_ATTEMPTS: u32 = 4;
+            for attempt in 1..=MAX_ATTEMPTS {
+                let ephemeral: [u8; 32] = match dsm::crypto::rng::random_bytes(32).try_into() {
+                    Ok(e) => e,
+                    Err(_) => {
+                        log::warn!(
+                            "[hw-verifier] counter read refused: CSPRNG ephemeral unavailable"
+                        );
+                        return None;
+                    }
+                };
+                let t = transport.clone();
+                let cred = cred.clone();
+                match read_counter_over_relay(cred, ephemeral, move |mosi| {
+                    (t)(peer_device_id, commitment, mosi)
+                })
+                .await
+                {
+                    Ok(h) => return Some(h),
+                    Err(e) => {
+                        log::warn!(
+                            "[hw-verifier] Path-B counter read attempt {attempt}/{MAX_ATTEMPTS} failed (fresh session on retry): {e}"
+                        );
+                    }
                 }
             }
+            log::warn!(
+                "[hw-verifier] Path-B counter read failed after {MAX_ATTEMPTS} attempts (fail-closed)"
+            );
+            None
         })
     }
 }

--- a/crates/dsm-anchor-pico/src/main.rs
+++ b/crates/dsm-anchor-pico/src/main.rs
@@ -97,16 +97,70 @@ const ENROLL_H0: u32 = 0xFFFF_FFFE; // tropic01 MCOUNTER_VALUE_MAX (4_294_967_29
 const PART_VARIANT: SphincsVariant = SphincsVariant::SPX128f;
 
 // Enrollment / appliance / test parameters.
-const ANCHOR: [u8; 32] = [0xA0; 32]; // tropic_anchor_id
-const POLICY: [u8; 32] = [0xB0; 32];
-const GENESIS: [u8; 32] = [0x00; 32]; // active root hᵢ at anchor counter 0
+//
+// The device identity (anchor_id, device_id, partition_device_id, partition-key
+// seed, and the birth entropy inputs) is NOT a compile-time constant. It is
+// derived at runtime from the real TROPIC01 — its fused device-cert public key
+// (`stpub`) and `chip_id`, both read once before the secure session — so the
+// SAME chip yields the SAME identity across reboots and a DIFFERENT chip yields a
+// DIFFERENT identity. No per-boot RP2350 randomness enters anything the receiver
+// pins as long-term identity. See `ChipIdentity`. The load-bearing anti-clone
+// root is `stpub` + the live monotonic counter + the receiver pin + the DSM
+// predicate; the partition co-signer key derived here is an HONEST LABEL
+// (deterministic, chip-unique, NOT a silicon secret), attesting firmware
+// authenticity, not chip uniqueness.
+const GENESIS: [u8; 32] = [0x00; 32]; // active root hᵢ at counter 0 (genesis SMT root; host adopts A₀ via STATUS)
 const NEXT_ROOT: [u8; 32] = [0x11; 32]; // self-test successor root hᵢ₊₁
-const ARM0: [u8; 32] = [0xAA; 32]; // initial MAC-and-destroy slot arming seed
-const RCHAL: [u8; 32] = [0x55; 32]; // receiver challenge r_R
-const DEVICE: [u8; 32] = [0xD0; 32]; // DSM device id
-const PART_DEV: [u8; 32] = [0xBD; 32]; // partition device id
-const KEYSEED: [u8; 32] = [0x4E; 32]; // partition key birth seed (bring-up: fixed)
-const FW: [u8; 32] = [0xF0; 32]; // firmware measurement (bring-up: fixed)
+const ARM0: [u8; 32] = [0xAA; 32]; // MAC-and-destroy boot-fence arming input
+const RCHAL: [u8; 32] = [0x55; 32]; // self-test receiver challenge r_R
+const FW: [u8; 32] = [0xF0; 32]; // firmware measurement (boot-fence input; deterministic build label)
+
+/// The well-known offline-bearer policy id, computed identically to the host's
+/// `canonical_offline_bearer_policy().policy_id` =
+/// `domain_hash_bytes("DSM/offline-bearer/policy-id/well-known/v1", &[])` =
+/// `BLAKE3(tag ‖ 0x00)`. Baked into the anchor bundle so `B` commits the real
+/// policy. (On-chip PREPARE is policy-agnostic; the receiver enforces the
+/// canonical value fail-closed. This keeps the bundle honest.)
+const POLICY_ID_DOMAIN: &str = "DSM/offline-bearer/policy-id/well-known/v1";
+
+/// Deterministic, chip-rooted anchor identity. Every field is derived from the
+/// TROPIC01's fused identity (`stpub` from device cert 0 + `chip_id`). Same chip
+/// ⇒ same identity across reboots; different chip ⇒ different identity.
+struct ChipIdentity {
+    anchor_id: [u8; 32],
+    device_id: [u8; 32],
+    partition_device_id: [u8; 32],
+    /// Partition-key birth seed — an HONEST LABEL (deterministic + chip-unique,
+    /// NOT a silicon secret; derivable from the public `stpub`/`chip_id`). The
+    /// partition co-signer attests firmware authenticity, not anti-clone.
+    partition_key_seed: [u8; 32],
+    /// Deterministic stand-in for the birth entropy inputs (`partition_trng`,
+    /// `host_nonce`) so `s_birth` → `B` is stable across reboots. Chip-rooted,
+    /// not per-boot RP2350 RNG.
+    birth_entropy: [u8; 32],
+    birth_host_nonce: [u8; 32],
+    /// Deterministic chip-rooted birth witness. The LIVE per-boot MACANDD witness
+    /// stays in the boot fence (`Appliance::boot`); it must not enter the pinned
+    /// identity, which has to be stable across reboots.
+    birth_witness: [u8; 32],
+}
+impl ChipIdentity {
+    /// Derive from the chip's fused `stpub` (device-cert public key) and a
+    /// 32-byte digest of its `chip_id`.
+    fn derive(stpub: &[u8; 32], chip_id_hash: &[u8; 32]) -> Self {
+        use anchor_core::hash::h;
+        let root = h("DSM/anchor/chip-root/v1", &[stpub, chip_id_hash]);
+        Self {
+            anchor_id: h("DSM/anchor/anchor-id/v1", &[&root]),
+            device_id: h("DSM/anchor/device-id/v1", &[&root]),
+            partition_device_id: h("DSM/anchor/partition-device-id/v1", &[&root]),
+            partition_key_seed: h("DSM/anchor/partition-seed-label/v1", &[&root]),
+            birth_entropy: h("DSM/anchor/birth-entropy/v1", &[&root]),
+            birth_host_nonce: h("DSM/anchor/birth-host-nonce/v1", &[&root]),
+            birth_witness: h("DSM/anchor/birth-witness/v1", &[&root]),
+        }
+    }
+}
 const T_REL: [u8; 32] = [1; 32];
 const T_OBJ: [u8; 32] = [2; 32];
 const T_SND: [u8; 32] = [3; 32];
@@ -326,8 +380,8 @@ fn rt<SPI: SpiDevice, CS: OutputPin>(
 /// birth witness.
 fn enroll<SPI: SpiDevice, CS: OutputPin>(
     sess: &mut Tropic01<SPI, CS, ActiveSession>,
-    partition_trng: &[u8; 32],
-    host_nonce: &[u8; 32],
+    ident: &ChipIdentity,
+    policy_hash: &[u8; 32],
 ) -> Result<(u32, Birth), &'static str> {
     // ADOPT the provisioned counter — do NOT `mcounter_init` (re-init resets the physical counter and
     // would let a rebooted device re-spend already-consumed offline-bearer steps). `H0` is the fixed
@@ -337,21 +391,24 @@ fn enroll<SPI: SpiDevice, CS: OutputPin>(
     if live > ENROLL_H0 {
         return Err("counter above enrollment H0 (unprovisioned/mis-provisioned chip)");
     }
-    // Arm both slots; capture the boot slot's output as the TROPIC birth witness.
-    let birth_witness = *sess
-        .mac_and_destroy(Q_BOOT.into(), &ARM0)
+    // Exercise the boot-fence MACANDD slots (preserves the provisioned arming
+    // interaction). The birth witness is now deterministic + chip-rooted
+    // (`ident.birth_witness`), NOT this per-boot MACANDD output — so the pinned
+    // bundle `B` is stable across reboots. The live per-boot MACANDD witness
+    // still gates the boot fence inside `Appliance::boot`.
+    sess.mac_and_destroy(Q_BOOT.into(), &ARM0)
         .map_err(|_| "arm q_boot")?;
     sess.mac_and_destroy(Q_TX.into(), &ARM0)
         .map_err(|_| "arm q_tx")?;
     let b = birth::<SphincsPart>(&BirthInputs {
-        partition_trng,
-        tropic_birth_witness: &birth_witness,
-        host_nonce,
-        device_id: &DEVICE,
-        policy_hash: &POLICY,
-        partition_device_id: &PART_DEV,
-        tropic_anchor_id: &ANCHOR,
-        partition_key_seed: &KEYSEED,
+        partition_trng: &ident.birth_entropy,
+        tropic_birth_witness: &ident.birth_witness,
+        host_nonce: &ident.birth_host_nonce,
+        device_id: &ident.device_id,
+        policy_hash,
+        partition_device_id: &ident.partition_device_id,
+        tropic_anchor_id: &ident.anchor_id,
+        partition_key_seed: &ident.partition_key_seed,
         enrolled_counter: ENROLL_H0,
         q_boot: Q_BOOT,
         q_tx: Q_TX,
@@ -361,7 +418,7 @@ fn enroll<SPI: SpiDevice, CS: OutputPin>(
     Ok((ENROLL_H0, b))
 }
 
-fn prepare_request() -> pb::ApplianceRequest {
+fn prepare_request(policy_hash: &[u8; 32]) -> pb::ApplianceRequest {
     pb::ApplianceRequest {
         op: pb::Op::Prepare as i32,
         transition: Some(pb::TransitionPackage {
@@ -378,7 +435,7 @@ fn prepare_request() -> pb::ApplianceRequest {
             payload_hash: T_PAY.to_vec(),
             old_leaf_proof: LEAF_OLD.to_vec(),
             new_leaf_proof: LEAF_NEW.to_vec(),
-            authority_policy_hash: POLICY.to_vec(),
+            authority_policy_hash: policy_hash.to_vec(),
         }),
         receiver_challenge: RCHAL.to_vec(),
         ..Default::default()
@@ -401,13 +458,15 @@ struct SelfTest {
 fn self_test<SPI: SpiDevice, CS: OutputPin>(
     core: &mut SecureCore<'_, SPI, CS>,
     part_pk: &[u8],
+    anchor_id: &[u8; 32],
+    policy_hash: &[u8; 32],
 ) -> Result<SelfTest, &'static str> {
     let bundle = core.app.bundle;
     let mut ok_all = true;
     // Boot is device-internal: establish the fence with the device-authoritative
     // measurement directly (the host wire path has no boot op), as serve_forever does.
     ok_all &= core.app.boot(1, &FW).is_ok();
-    ok_all &= rt(core, &prepare_request())?.ok;
+    ok_all &= rt(core, &prepare_request(policy_hash))?.ok;
     ok_all &= rt(
         core,
         &pb::ApplianceRequest {
@@ -456,9 +515,9 @@ fn self_test<SPI: SpiDevice, CS: OutputPin>(
             let ctx = VerifierContext {
                 accepted_prev_root: &GENESIS,
                 pinned_bundle: &bundle,
-                pinned_anchor_id: &ANCHOR,
+                pinned_anchor_id: anchor_id,
                 expected_receiver_challenge: &RCHAL,
-                expected_policy_hash: &POLICY,
+                expected_policy_hash: policy_hash,
                 enrolled_counter: ENROLL_H0 as u64,
                 anchor_uncompromised: true,
             };
@@ -558,9 +617,10 @@ fn main() -> ! {
         }
         b
     };
+    // One TRNG draw: the secure-session handshake ephemeral (randomness is correct
+    // here). The anchor birth entropy is deterministic + chip-rooted (see
+    // `ChipIdentity`) — never per-boot RNG, so the pinned identity is stable.
     let eh = draw();
-    let part_trng = draw();
-    let host_nonce = draw();
 
     let timer = hal::Timer::new_timer0(pac.TIMER0, &mut pac.RESETS, &clocks);
     let sio = hal::Sio::new(pac.SIO);
@@ -616,12 +676,49 @@ fn main() -> ! {
         }
     }
 
-    // ---- Phase 2: L2 chip id ----
+    // ---- Phase 2: read the REAL chip identity (chip_id + device-cert stpub) ----
+    // These L2 getters are only callable BEFORE `session_start` consumes the
+    // NoSession handle. The pinned anchor identity is rooted here, in silicon:
+    // same chip ⇒ same identity across reboots. Fail closed (halt) if the chip
+    // will not disclose a real identity — never fall back to a fake one.
     usb_dev.poll(&mut [&mut serial]);
     let mut tropic = Tropic01::new(spi_dev);
-    let chip_ok = tropic.get_info_chip_id().is_ok();
-    put(&mut serial, b"[T1] chip id: ");
-    put(&mut serial, if chip_ok { b"OK\r\n" } else { b"FAIL\r\n" });
+    let chip_id_hash = match tropic.get_info_chip_id() {
+        Ok(id) => anchor_core::hash::h("DSM/anchor/chip-id/v1", &[id]),
+        Err(_) => {
+            put(&mut serial, b"[T1] chip id: FAIL (no real identity; halting)\r\n");
+            let _ = serial.flush();
+            loop {
+                usb_dev.poll(&mut [&mut serial]);
+            }
+        }
+    };
+    let stpub: [u8; 32] = match tropic.get_info_cert_store() {
+        Ok(cs) => match cs.public_key() {
+            Ok(k) => *k,
+            Err(_) => {
+                put(&mut serial, b"[T1] cert stpub: FAIL (no real identity; halting)\r\n");
+                let _ = serial.flush();
+                loop {
+                    usb_dev.poll(&mut [&mut serial]);
+                }
+            }
+        },
+        Err(_) => {
+            put(&mut serial, b"[T1] cert store: FAIL (no real identity; halting)\r\n");
+            let _ = serial.flush();
+            loop {
+                usb_dev.poll(&mut [&mut serial]);
+            }
+        }
+    };
+    // Deterministic, chip-rooted identity + the well-known canonical policy id.
+    let ident = ChipIdentity::derive(&stpub, &chip_id_hash);
+    let policy_hash = anchor_core::hash::h(POLICY_ID_DOMAIN, &[&[0u8][..]]);
+    put(
+        &mut serial,
+        b"[T1] chip identity: OK (stpub-rooted, deterministic across reboot)\r\n",
+    );
     let _ = serial.flush();
     usb_dev.poll(&mut [&mut serial]);
 
@@ -662,22 +759,22 @@ fn main() -> ! {
     );
     let _ = serial.flush();
     usb_dev.poll(&mut [&mut serial]);
-    let st = match enroll(&mut sess, &part_trng, &host_nonce) {
+    let st = match enroll(&mut sess, &ident, &policy_hash) {
         Ok((h0, b)) => {
             let part_pk = b.partition_pk.clone();
             let mut core = SecureCore {
                 app: Appliance::<_, WotsBlake3, SphincsPart>::new(
                     ChipTropic { sess: &mut sess },
                     h0,
-                    ANCHOR,
+                    ident.anchor_id,
                     Q_BOOT,
                     Q_TX,
-                    PART_DEV,
+                    ident.partition_device_id,
                     GENESIS,
                     b,
                 ),
             };
-            self_test(&mut core, &part_pk)
+            self_test(&mut core, &part_pk, &ident.anchor_id, &policy_hash)
         }
         Err(e) => Err(e),
     };
@@ -734,18 +831,19 @@ fn main() -> ! {
         b"[T6] serving boot-fenced fused appliance over USB-CDC (LE32-len-prefixed protobuf)\r\n",
     );
     let _ = serial.flush();
-    let (h0, b) = enroll(&mut sess, &part_trng, &host_nonce).unwrap_or_else(|_| {
-        // Re-enrollment should not fail after a good session; fall back to a fresh
-        // birth on the genesis seed so the device still serves.
+    let (h0, b) = enroll(&mut sess, &ident, &policy_hash).unwrap_or_else(|_| {
+        // Re-enrollment should not fail after a good session; fall back to a birth
+        // from the SAME deterministic chip-rooted identity so the device still
+        // serves the same anchor (never a fresh/fake one).
         let b = birth::<SphincsPart>(&BirthInputs {
-            partition_trng: &part_trng,
-            tropic_birth_witness: &ARM0,
-            host_nonce: &host_nonce,
-            device_id: &DEVICE,
-            policy_hash: &POLICY,
-            partition_device_id: &PART_DEV,
-            tropic_anchor_id: &ANCHOR,
-            partition_key_seed: &KEYSEED,
+            partition_trng: &ident.birth_entropy,
+            tropic_birth_witness: &ident.birth_witness,
+            host_nonce: &ident.birth_host_nonce,
+            device_id: &ident.device_id,
+            policy_hash: &policy_hash,
+            partition_device_id: &ident.partition_device_id,
+            tropic_anchor_id: &ident.anchor_id,
+            partition_key_seed: &ident.partition_key_seed,
             enrolled_counter: ENROLL_H0,
             q_boot: Q_BOOT,
             q_tx: Q_TX,
@@ -757,10 +855,10 @@ fn main() -> ! {
         app: Appliance::<_, WotsBlake3, SphincsPart>::new(
             ChipTropic { sess: &mut sess },
             h0,
-            ANCHOR,
+            ident.anchor_id,
             Q_BOOT,
             Q_TX,
-            PART_DEV,
+            ident.partition_device_id,
             GENESIS,
             b,
         ),

--- a/crates/dsm-anchor-pico/src/main.rs
+++ b/crates/dsm-anchor-pico/src/main.rs
@@ -38,7 +38,6 @@ extern crate alloc;
 
 use panic_halt as _;
 
-use core::fmt::Write as _;
 
 use rp235x_hal as hal;
 
@@ -225,35 +224,80 @@ impl PartitionSig for SphincsPart {
     }
 }
 
-/// Bridge anchor-core's `Tropic` trait to a libtropic-rs active session. The same
-/// session serves both MACANDD slots (`q_boot`, `q_tx`) and the counter.
+/// Bridge anchor-core's `Tropic` trait to a libtropic-rs active session, WITH SESSION RECOVERY.
+///
+/// The TROPIC01 has exactly ONE L3 secure session. `OP_SPI_PASSTHROUGH` lets a remote receiver
+/// clock its OWN Noise handshake to the chip over raw SPI (the Path-B counter read), which re-keys
+/// the chip and leaves OUR `sess` (nonces/keys) STALE. If the next appliance op then talks over
+/// that dead session, it fails — this was the on-phone `op 2 (PREPARE) error 8` while the Mac (which
+/// never does a relay read) worked. So: mark the session dirty after every passthrough, and
+/// re-establish our own session (local reset + fresh `session_start`) before the NEXT appliance op.
 struct ChipTropic<'a, SPI: SpiDevice, CS: OutputPin> {
-    sess: &'a mut Tropic01<SPI, CS, ActiveSession>,
+    /// `Option` so we can move the session out to transition its typestate during re-handshake.
+    sess: &'a mut Option<Tropic01<SPI, CS, ActiveSession>>,
+    /// Seed (drawn once at boot) for deriving a fresh ephemeral key per re-handshake.
+    reseed: [u8; 32],
+    rehandshakes: u32,
+    dirty: bool,
+}
+impl<SPI: SpiDevice, CS: OutputPin> ChipTropic<'_, SPI, CS> {
+    /// Before an appliance op: if a passthrough may have re-keyed the chip, locally drop our stale
+    /// session typestate and re-handshake with a fresh ephemeral. No-op on the happy path.
+    fn ensure(&mut self) -> Result<&mut Tropic01<SPI, CS, ActiveSession>, TropicError> {
+        if self.dirty {
+            let stale = self.sess.take().ok_or(TropicError::Comm)?;
+            let ns = stale.reset_session_local();
+            self.rehandshakes = self.rehandshakes.wrapping_add(1);
+            let eh = anchor_core::hash::h(
+                "DSM/anchor/rehandshake-eph/v1",
+                &[&self.reseed, &self.rehandshakes.to_le_bytes()],
+            );
+            let ehpriv = StaticSecret::from(eh);
+            let ehpub = PublicKey::from(&ehpriv);
+            let fresh = ns
+                .session_start(
+                    &X25519Dalek,
+                    PublicKey::from(SH0PUB_PROD0),
+                    StaticSecret::from(SH0PRIV_PROD0),
+                    ehpub,
+                    ehpriv,
+                    0,
+                )
+                .map_err(|_| TropicError::Comm)?;
+            *self.sess = Some(fresh);
+            self.dirty = false;
+        }
+        self.sess.as_mut().ok_or(TropicError::Comm)
+    }
 }
 impl<SPI: SpiDevice, CS: OutputPin> Tropic for ChipTropic<'_, SPI, CS> {
     fn mac_and_destroy(&mut self, q: u16, x: &[u8; 32]) -> Result<[u8; 32], TropicError> {
-        self.sess
+        self.ensure()?
             .mac_and_destroy(q.into(), x)
             .map(|w| *w)
             .map_err(|_| TropicError::Comm)
     }
     fn counter_get(&mut self) -> Result<u32, TropicError> {
-        self.sess
+        self.ensure()?
             .mcounter_get(COUNTER)
             .map_err(|_| TropicError::Comm)
     }
     fn counter_update(&mut self) -> Result<(), TropicError> {
-        self.sess
+        self.ensure()?
             .mcounter_update(COUNTER)
             .map_err(|_| TropicError::CounterExhausted)
     }
 }
 impl<SPI: SpiDevice, CS: OutputPin> ChipTropic<'_, SPI, CS> {
     /// Transparent raw-SPI relay bridge (Path-B counter read): clock `buf` to TROPIC01 and read the
-    /// MISO back in place. The bytes are NOT interpreted — a remote receiver drives its own
-    /// libtropic session through these opaque transactions; this device is only the SPI bridge.
+    /// MISO back in place. Do NOT `ensure()` here — the bytes may BE a peer's handshake, and
+    /// re-handshaking mid relay-read would kill the peer's session. Mark dirty so the next appliance
+    /// op re-establishes ours.
     fn passthrough(&mut self, buf: &mut [u8]) -> Result<(), TropicError> {
-        self.sess.l1_passthrough(buf).map_err(|_| TropicError::Comm)
+        let sess = self.sess.as_mut().ok_or(TropicError::Comm)?;
+        let r = sess.l1_passthrough(buf).map_err(|_| TropicError::Comm);
+        self.dirty = true;
+        r
     }
 }
 
@@ -752,78 +796,19 @@ fn main() -> ! {
     put(&mut serial, b"[T2] session=OK\r\n");
     let _ = serial.flush();
 
-    // ---- Phase 4: T5 self-test (own appliance), reported briefly ----
+    // ---- Phase 4: boot self-test REMOVED (it was DESTRUCTIVE to the counter) ----
+    // The former [T5] self-test drove a full PREPARE -> COMMIT -> EMIT on the chip EVERY boot, and
+    // `Appliance::commit` calls `counter_update()` which DECREMENTS the physical monotonic counter.
+    // So every power cycle silently burned one anti-double-spend step, drifting the provisioned
+    // counter below MCOUNTER_MAX and desyncing the serving appliance (a real transfer then failed
+    // `CounterMismatch`). A provisioned/serving device must NEVER consume a counter step at boot. The
+    // appliance is exercised for real by the serve loop below; there is no destructive boot diagnostic.
     put(
         &mut serial,
-        b"[T5] self-test (boot-fenced fused protocol, secure-core seam)...\r\n",
+        b"[T5] boot self-test disabled (non-destructive boot; no counter spend)\r\n",
     );
     let _ = serial.flush();
     usb_dev.poll(&mut [&mut serial]);
-    let st = match enroll(&mut sess, &ident, &policy_hash) {
-        Ok((h0, b)) => {
-            let part_pk = b.partition_pk.clone();
-            let mut core = SecureCore {
-                app: Appliance::<_, WotsBlake3, SphincsPart>::new(
-                    ChipTropic { sess: &mut sess },
-                    h0,
-                    ident.anchor_id,
-                    Q_BOOT,
-                    Q_TX,
-                    ident.partition_device_id,
-                    GENESIS,
-                    b,
-                ),
-            };
-            self_test(&mut core, &part_pk, &ident.anchor_id, &policy_hash)
-        }
-        Err(e) => Err(e),
-    };
-    {
-        let mut w = BufW {
-            buf: [0u8; 256],
-            len: 0,
-        };
-        match &st {
-            Ok(r) => {
-                let pass = r.ops_ok
-                    && r.pk_len == 32
-                    && r.sig_tropic_len == 67 * 32
-                    && r.sig_partition_len == dsm_sphincs::signature_bytes(PART_VARIANT)
-                    && r.st_counter == 1
-                    && r.st_status == 0 // Ready
-                    && r.verify_ok
-                    && r.root_match;
-                let _ = write!(
-                    w,
-                    "[T5] {}  ops_ok={} pk={}B sigT={}B sigP={}B status(u={},st={}) verify={}({})\r\n",
-                    if pass { "PASS" } else { "FAIL" },
-                    r.ops_ok,
-                    r.pk_len,
-                    r.sig_tropic_len,
-                    r.sig_partition_len,
-                    r.st_counter,
-                    r.st_status,
-                    if r.verify_ok { "accepted" } else { "REJECTED" },
-                    if r.root_match { "root ok" } else { "root MISMATCH" },
-                );
-            }
-            Err(e) => {
-                let _ = write!(w, "[T5] FAIL at step: {}\r\n", e);
-            }
-        }
-        let report_until = timer.get_counter().ticks() + 4_000_000;
-        let mut last = timer.get_counter();
-        put(&mut serial, &w.buf[..w.len]);
-        let _ = serial.flush();
-        while timer.get_counter().ticks() < report_until {
-            usb_dev.poll(&mut [&mut serial]);
-            if (timer.get_counter() - last).to_millis() >= 2000 {
-                last = timer.get_counter();
-                put(&mut serial, &w.buf[..w.len]);
-                let _ = serial.flush();
-            }
-        }
-    }
 
     // ---- Phase 5: T6 serve the appliance over USB-CDC for an external host ----
     put(
@@ -851,9 +836,18 @@ fn main() -> ! {
         });
         (ENROLL_H0, b)
     });
+    // Move the live session into an Option so ChipTropic can re-handshake it after a passthrough
+    // re-keys the chip (see ChipTropic). One extra TRNG draw seeds the per-re-handshake ephemeral.
+    let reseed = draw();
+    let mut sess_opt = Some(sess);
     let mut core = SecureCore {
         app: Appliance::<_, WotsBlake3, SphincsPart>::new(
-            ChipTropic { sess: &mut sess },
+            ChipTropic {
+                sess: &mut sess_opt,
+                reseed,
+                rehandshakes: 0,
+                dirty: false,
+            },
             h0,
             ident.anchor_id,
             Q_BOOT,

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
@@ -215,7 +215,7 @@ object LocalPicoUsb {
         val claimed = commIface?.let { conn.claimInterface(it, true) } ?: false
         Log.i(TAG, "comm iface=$commId claim=$claimed (ifaceCount=${device.interfaceCount})")
         var cls = setControlLine(conn, commId)
-        if (cls < 0 && claimed && commIface != null) {
+        if (cls < 0 && commIface != null && claimed) {
             // Some host stacks block class control transfers while the comm interface is claimed by
             // the app; release it and retry (control transfers target endpoint 0, not the interface).
             conn.releaseInterface(commIface)

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/LocalPicoUsb.kt
@@ -45,14 +45,24 @@ object LocalPicoUsb {
     private const val DRAIN_QUIET_POLLS = 4   // ~800ms of silence ends the drain
     private const val DRAIN_MAX_POLLS = 40    // hard cap (~8s worst case) so boot chatter can finish
     // Max idle bulk-IN polls before failing closed (each blocks up to READ_TIMEOUT_MS). Bounds the
-    // total read wait deterministically without a wall-clock deadline (repo invariant).
-    private const val MAX_EMPTY_POLLS = 16
+    // total read wait deterministically without a wall-clock deadline (repo invariant). The appliance
+    // PREPARE runs a BLAKE3-SPHINCS+ (SPX128f) keygen + sign on the RP2350 and takes ~7s on real
+    // silicon, during which the firmware sends nothing; 40 polls x 500ms = ~20s covers it with margin
+    // (16 = ~8s was too tight and intermittently timed out a valid PREPARE -> false online recovery).
+    private const val MAX_EMPTY_POLLS = 40
 
     @Volatile private var appContext: Context? = null
     private var connection: UsbDeviceConnection? = null
     private var iface: UsbInterface? = null
     private var epIn: UsbEndpoint? = null
     private var epOut: UsbEndpoint? = null
+    // Bytes pulled off the bulk-IN endpoint that belong to a LATER read. Android's `bulkTransfer`
+    // hands back one whole USB packet at a time; the firmware coalesces the `LE32 len` and the body
+    // into a single 64-byte packet, so a read for the 4-byte length over-runs into the body. Those
+    // surplus bytes MUST be carried to the next read, not discarded — discarding desyncs the stream,
+    // the following body read then blocks until timeout, and a valid response comes back empty (Rust
+    // decodes it as a default `ok=false, error=0` frame). Per-connection; cleared on reset/reopen.
+    private var residual = ByteArray(0)
 
     /** Cache the application context so the static `Unified.picoUsbTransceive` can reach UsbManager. */
     @JvmStatic
@@ -99,16 +109,26 @@ object LocalPicoUsb {
     private fun resetAndFail(): ByteArray {
         try { iface?.let { connection?.releaseInterface(it) } } catch (_: Exception) {}
         try { connection?.close() } catch (_: Exception) {}
-        connection = null; iface = null; epIn = null; epOut = null
+        connection = null; iface = null; epIn = null; epOut = null; residual = ByteArray(0)
         return ByteArray(0)
     }
 
     /** Read exactly `n` bytes off the bulk-IN endpoint (accumulating across USB packets), or null.
      * Bounded by a poll COUNT (not wall-clock — repo invariant): each `bulkTransfer` already blocks
-     * up to `READ_TIMEOUT_MS`, so at most `MAX_EMPTY_POLLS` idle polls elapse before we fail closed. */
+     * up to `READ_TIMEOUT_MS`, so at most `MAX_EMPTY_POLLS` idle polls elapse before we fail closed.
+     * A `bulkTransfer` returns a whole USB packet, which may run PAST `n` (the firmware coalesces the
+     * length prefix and body into one packet); the surplus is carried in [residual] for the next read
+     * rather than dropped — dropping it desyncs the frame and silently truncates the next response. */
     private fun readExact(conn: UsbDeviceConnection, ep: UsbEndpoint, n: Int): ByteArray? {
         val out = ByteArray(n)
         var got = 0
+        // Serve carried-over bytes from a prior over-read before touching the endpoint.
+        if (residual.isNotEmpty()) {
+            val take = minOf(residual.size, n)
+            System.arraycopy(residual, 0, out, 0, take)
+            got += take
+            residual = residual.copyOfRange(take, residual.size)
+        }
         val buf = ByteArray(ep.maxPacketSize.coerceAtLeast(64))
         var emptyPolls = 0
         while (got < n) {
@@ -125,6 +145,11 @@ object LocalPicoUsb {
             val take = minOf(r, n - got)
             System.arraycopy(buf, 0, out, got, take)
             got += take
+            if (r > take) {
+                // Packet ran past this read's target — stash the tail for the next readExact.
+                val extra = buf.copyOfRange(take, r)
+                residual = if (residual.isEmpty()) extra else residual + extra
+            }
         }
         return out
     }
@@ -172,6 +197,7 @@ object LocalPicoUsb {
         // Discard the firmware boot banner / self-test output before the first transaction so the
         // response read frames on the OP_SPI_PASSTHROUGH reply, not on stale boot chatter.
         drainInput(conn, inEp)
+        residual = ByteArray(0)
         return conn
     }
 

--- a/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/ble/BleCoordinator.kt
+++ b/dsm_client/android/app/src/main/java/com/dsm/wallet/bridge/ble/BleCoordinator.kt
@@ -1171,10 +1171,26 @@ class BleCoordinator private constructor(private val context: Context) : BleScan
             }
         }
 
-        Log.w(
-            "BleCoordinator",
-            "resolveSession: no exact or identity-backed route for $address; refusing ready-peer fallback"
-        )
+        // 4. Single-peer fallback (restored — this existed in the "Harden BLE multi-peer fallback"
+        // version and was later dropped). RPA rotation moves the peer's advertised address faster
+        // than the frontend/SDK cache can follow, so the target address is often stale/unresolvable
+        // even while a LIVE session to the peer exists at the connected address. When there is EXACTLY
+        // ONE peer with a ready session, route to it. Guarded to a single ready peer, so a multi-peer
+        // scenario never routes ambiguously.
+        val readyAddresses = peers.entries.mapNotNull { (addr, peer) ->
+            if (peer.hasActiveClientSession ||
+                (peer.isServerClient && peer.isSubscribedTo(BleConstants.TX_RESPONSE_UUID))
+            ) addr else null
+        }
+        when (readyAddresses.size) {
+            1 -> {
+                val freshAddr = readyAddresses.first()
+                Log.i("BleCoordinator", "resolveSession: single-peer fallback $address → $freshAddr")
+                return peers[freshAddr]!! to freshAddr
+            }
+            0 -> Log.w("BleCoordinator", "resolveSession: no route for $address (no ready peer)")
+            else -> Log.i("BleCoordinator", "resolveSession: refusing ambiguous fallback across ${readyAddresses.size} ready peers")
+        }
         return null
     }
 

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleCoordinatorResolveSessionTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleCoordinatorResolveSessionTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -49,8 +48,21 @@ class BleCoordinatorResolveSessionTest {
         assertEquals(identity, coordinator.addressIndex[staleAddress])
     }
 
+    /**
+     * RPA rotation moves a peer's ADVERTISED address faster than the contact
+     * cache can follow, while the live GATT session sits at the (fixed)
+     * connected address — so the target address is routinely stale even while
+     * a live session to the peer exists. With EXACTLY ONE ready session there
+     * is no ambiguity about where the bilateral traffic belongs, so
+     * `resolveSession` routes to it even without identity hydration (the
+     * restored single-peer fallback from the "Harden BLE multi-peer fallback"
+     * lineage, proven necessary for end-to-end transfer on hardware).
+     * Ambiguity across two or more ready peers is still refused — see
+     * `resolveSession_doesNotFallbackWhenMultipleReadyPeersExist` in
+     * BleCoordinatorTest.
+     */
     @Test
-    fun resolveSession_refusesSingleReadyPeerGuessWithoutIdentity() {
+    fun resolveSession_fallsBackToSoleReadyPeerWithoutIdentity() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val coordinator = BleCoordinator(
             context = context,
@@ -68,6 +80,7 @@ class BleCoordinatorResolveSessionTest {
 
         val resolved = coordinator.resolveSession("6B:CA:44:6D:D9:33")
 
-        assertNull(resolved)
+        assertNotNull(resolved)
+        assertEquals("49:63:1E:15:0A:AA", resolved?.second)
     }
 }

--- a/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleCoordinatorTest.kt
+++ b/dsm_client/android/app/src/test/java/com/dsm/wallet/bridge/ble/BleCoordinatorTest.kt
@@ -79,21 +79,22 @@ class BleCoordinatorTest {
     }
 
     /**
-     * Production `resolveSession` was deliberately hardened to REFUSE the
-     * "fall back to any ready peer when address is unknown" behaviour
-     * (see BleCoordinator.kt:1172-1176, log: "refusing ready-peer fallback").
-     * Routing an unknown peer's traffic to a random ready session is a
-     * privacy/safety hole — the local side would deliver bytes destined
-     * for peer A to peer B without any identity binding.
-     *
-     * This test is the regression guard: an unknown address with no
-     * identity hydration must return null, even when a ready peer exists.
-     * The sibling test below (`_doesNotFallbackWhenMultipleReadyPeersExist`)
-     * covers the multi-peer case; this one covers the single-ready-peer
-     * temptation.
+     * `resolveSession` routes an unknown/stale address to the SOLE ready
+     * session (restored single-peer fallback from the "Harden BLE multi-peer
+     * fallback" lineage). BLE RPA rotation moves a peer's advertised address
+     * faster than the frontend/SDK contact cache can follow, so the send
+     * target is routinely stale even while a live GATT session to that same
+     * peer exists at the (fixed) connected address — without this fallback
+     * every bilateral send eventually dead-ends with "no route". With exactly
+     * one ready session there is no ambiguity about where the traffic
+     * belongs; misdirected bytes are additionally rejected by the
+     * relationship-bound crypto envelope on the far side. The fallback stays
+     * guarded to a single ready peer: the sibling test below
+     * (`_doesNotFallbackWhenMultipleReadyPeersExist`) is the regression guard
+     * for the ambiguous multi-peer case, which is still refused.
      */
     @Test
-    fun resolveSession_refusesFallbackToReadyPeerForUnknownAddress() {
+    fun resolveSession_fallsBackToSoleReadyPeerForUnknownAddress() {
         val fallbackPeer = PeerSession(address = "fallback").apply {
             gattClientSession = activeGattClientSession("fallback")
             isConnected = true
@@ -102,11 +103,13 @@ class BleCoordinatorTest {
 
         val resolved = coordinator.resolveSession("unknown")
 
-        assertNull(
-            "resolveSession must refuse ready-peer fallback for an unknown " +
-                "address with no identity hydration (privacy guard)",
+        assertNotNull(
+            "resolveSession must route an unknown address to the sole ready " +
+                "session (RPA rotation makes cached addresses stale)",
             resolved,
         )
+        assertSame(fallbackPeer, resolved!!.first)
+        assertEquals("fallback", resolved.second)
     }
 
     @Test

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/anchor_accept.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/anchor_accept.rs
@@ -378,21 +378,40 @@ impl CounterVerifier for TrustedTestCounter {
     }
 }
 
+/// The holder's successor appliance-lineage state, returned on acceptance so the
+/// receiver can ADOPT it (persist as the new accepted root) once the canonical
+/// commit succeeds. Def. 25 check 2 then pins the NEXT release's `prev_root` to
+/// this frontier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdoptedAnchorState {
+    /// The release's `next_root` — the appliance root the next transfer consumes.
+    pub next_root: [u8; 32],
+    /// The release's `next_anchor_counter` (`uᵢ + 1`) adopted with it.
+    pub next_anchor_counter: u64,
+}
+
 /// Apply the canonical Boot Fenced Fused Anchor acceptance predicate to an inbound
 /// offline-bearer confirm. Fail-closed: returns `Err(OfflineRecover)` (release no value,
 /// recover online) on a missing/malformed release, an un-enrolled anchor, or ANY failed
-/// predicate check — including the unauthenticated counter. On `Ok(())` the receiver may
-/// proceed to the canonical value-release commit.
+/// predicate check — including the unauthenticated counter. On `Ok(adopted)` the receiver
+/// may proceed to the canonical value-release commit, and after that commit succeeds must
+/// persist `adopted` as the holder's accepted appliance root.
+///
+/// `accepted_prev_root`: the appliance root adopted from the holder's last accepted
+/// release. `None` = relationship genesis (nothing adopted yet) — the release's own
+/// `prev_root` is adopted TOFU; its authenticity still rests on the anchor-state
+/// commitment proofs (checks 3–4) and the live authenticated counter (checks 17–19),
+/// the same trust root as the first-transfer pin admit.
 #[allow(clippy::too_many_arguments)]
 pub fn accept_offline_release(
     offline_release: &[u8],
     pinned: Option<&PinnedAnchor>,
-    accepted_prev_root: &[u8; 32],
+    accepted_prev_root: Option<&[u8; 32]>,
     receiver_device_id: &[u8; 32],
     expected_receiver_challenge: &[u8; 32],
     expected_policy_hash: &[u8; 32],
     binding: &AnchorStateBinding,
-) -> Result<(), OfflineRecover> {
+) -> Result<AdoptedAnchorState, OfflineRecover> {
     // Canonical production path: the Path-B authenticated-counter verifier is fail-closed until the
     // async raw-SPI relay read is wired into the receiver (D2 step 5). With `attested = None` the
     // predicate fails on the counter clause and the transfer recovers online. The live-relay path
@@ -418,13 +437,13 @@ pub fn accept_offline_release(
 pub fn accept_offline_release_with_relay_counter(
     offline_release: &[u8],
     pinned: Option<&PinnedAnchor>,
-    accepted_prev_root: &[u8; 32],
+    accepted_prev_root: Option<&[u8; 32]>,
     receiver_device_id: &[u8; 32],
     expected_receiver_challenge: &[u8; 32],
     expected_policy_hash: &[u8; 32],
     binding: &AnchorStateBinding,
     attested: Option<([u8; 32], u64)>,
-) -> Result<(), OfflineRecover> {
+) -> Result<AdoptedAnchorState, OfflineRecover> {
     accept_offline_release_with_counter(
         offline_release,
         pinned,
@@ -445,13 +464,13 @@ pub fn accept_offline_release_with_relay_counter(
 pub(crate) fn accept_offline_release_with_counter<C: CounterVerifier>(
     offline_release: &[u8],
     pinned: Option<&PinnedAnchor>,
-    accepted_prev_root: &[u8; 32],
+    accepted_prev_root: Option<&[u8; 32]>,
     receiver_device_id: &[u8; 32],
     expected_receiver_challenge: &[u8; 32],
     expected_policy_hash: &[u8; 32],
     binding: &AnchorStateBinding,
     counter: &C,
-) -> Result<(), OfflineRecover> {
+) -> Result<AdoptedAnchorState, OfflineRecover> {
     if offline_release.is_empty() {
         // Absent canonical release (or a legacy IslandAttestation-only confirm).
         return Err(OfflineRecover::MissingRelease);
@@ -462,8 +481,21 @@ pub(crate) fn accept_offline_release_with_counter<C: CounterVerifier>(
         .map_err(|_| OfflineRecover::Malformed)?;
     let pinned = pinned.ok_or(OfflineRecover::AnchorNotEnrolled)?;
 
+    // Def. 25 check 2 root: the adopted lineage frontier when one exists,
+    // else (relationship genesis) the release's own `prev_root` — TOFU,
+    // still bound to the pinned chip by checks 3–4 + the live counter.
+    let t = rel.transition.as_transition();
+    let effective_prev_root: [u8; 32] = match accepted_prev_root {
+        Some(r) => *r,
+        None => *t.prev_root,
+    };
+    let adopted = AdoptedAnchorState {
+        next_root: *t.next_root,
+        next_anchor_counter: t.next_anchor_counter,
+    };
+
     let ctx = VerifierContext {
-        accepted_prev_root,
+        accepted_prev_root: &effective_prev_root,
         pinned_bundle: &pinned.bundle,
         pinned_anchor_id: &pinned.anchor_id,
         expected_receiver_challenge,
@@ -476,7 +508,9 @@ pub(crate) fn accept_offline_release_with_counter<C: CounterVerifier>(
         partition_pk: &pinned.partition_pk,
         binding,
     };
-    accept_offline::<WotsBlake3, _, _>(&rel, &ctx, &dsm, counter).map_err(OfflineRecover::Predicate)
+    accept_offline::<WotsBlake3, _, _>(&rel, &ctx, &dsm, counter)
+        .map_err(OfflineRecover::Predicate)?;
+    Ok(adopted)
 }
 
 #[cfg(test)]
@@ -569,7 +603,7 @@ mod tests {
 
     #[test]
     fn missing_release_routes_online() {
-        let r = accept_offline_release(&[], Some(&pin()), &ZERO, &ZERO, &ZERO, &ZERO, &ZB);
+        let r = accept_offline_release(&[], Some(&pin()), Some(&ZERO), &ZERO, &ZERO, &ZERO, &ZB);
         assert!(matches!(r, Err(OfflineRecover::MissingRelease)));
     }
 
@@ -582,7 +616,7 @@ mod tests {
         }
         .encode_to_vec();
         assert!(!bytes.is_empty());
-        let r = accept_offline_release(&bytes, Some(&pin()), &ZERO, &ZERO, &ZERO, &ZERO, &ZB);
+        let r = accept_offline_release(&bytes, Some(&pin()), Some(&ZERO), &ZERO, &ZERO, &ZERO, &ZB);
         assert!(matches!(r, Err(OfflineRecover::Malformed)));
     }
 
@@ -590,7 +624,7 @@ mod tests {
     fn unenrolled_anchor_routes_online() {
         // A decodable release with NO pinned anchor (the live Phase-4 seam) recovers online.
         let bytes = decodable_release_bytes();
-        let r = accept_offline_release(&bytes, None, &ZERO, &ZERO, &ZERO, &ZERO, &ZB);
+        let r = accept_offline_release(&bytes, None, Some(&ZERO), &ZERO, &ZERO, &ZERO, &ZB);
         assert!(matches!(r, Err(OfflineRecover::AnchorNotEnrolled)));
     }
 
@@ -599,7 +633,7 @@ mod tests {
         // A decodable release WITH a pin reaches accept_offline and is rejected by the predicate
         // (proves the canonical predicate is wired and fail-closed — it can never accept here).
         let bytes = decodable_release_bytes();
-        let r = accept_offline_release(&bytes, Some(&pin()), &ZERO, &ZERO, &ZERO, &ZERO, &ZB);
+        let r = accept_offline_release(&bytes, Some(&pin()), Some(&ZERO), &ZERO, &ZERO, &ZERO, &ZB);
         assert!(matches!(r, Err(OfflineRecover::Predicate(_))));
     }
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -4424,14 +4424,27 @@ impl BilateralBleHandler {
                 } => ap.policy_id,
                 _ => [0u8; 32],
             };
-            // Policy-binding trace (receiver verify): the policy_id this receiver enforces against the
+            // Policy-binding (receiver verify): the policy_id this receiver enforces against the
             // release MUST equal the canonical value the sender bound. A mismatch means the proof does
             // not attest what we think — reject rather than "run and mean nothing".
+            let canonical_policy_id =
+                dsm::types::operations::canonical_offline_bearer_policy().policy_id;
             info!(
                 "[BILATERAL][offline-bearer][receiver] verify policy_id={} (canonical_match={})",
                 bytes_to_base32(&policy_hash),
-                policy_hash == dsm::types::operations::canonical_offline_bearer_policy().policy_id
+                policy_hash == canonical_policy_id
             );
+            // ENFORCE the canonical binding fail-closed (owner directive: logging a mismatch is not
+            // enough). An offline-bearer release whose policy_id is not the well-known canonical value
+            // does not attest the offline-bearer tier — refuse it rather than accept a proof that
+            // means nothing.
+            if policy_hash != canonical_policy_id {
+                return Err(DsmError::invalid_operation(format!(
+                    "offline-bearer policy_id {} is not the canonical well-known value {}; refusing to accept",
+                    bytes_to_base32(&policy_hash),
+                    bytes_to_base32(&canonical_policy_id),
+                )));
+            }
             let expected_receiver_challenge = session.receiver_challenge.unwrap_or([0u8; 32]);
             // Anchor-state binding: the sender's device-SMT roots (before = pinned frontier,
             // after = adopted successor) and the two inclusion proofs, as carried on the confirm.

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -245,29 +245,59 @@ impl BilateralBleHandler {
         };
         let signing_out = crate::sdk::receipts::sign_receipt_with_per_step_ek(&signing_inputs)?;
 
+        let at_rest_key = crate::init::current_chain_head_at_rest_key()?;
         match side {
             BilateralSide::A => {
                 receipt.set_ek_pk_a(signing_out.ek_pk.clone());
                 receipt.set_ek_cert_a(signing_out.ek_cert);
                 receipt.set_kyber_ct_a(signing_out.kyber_ct);
                 receipt.add_sig_a(signing_out.sig);
+
+                // §11.1 sender side: DEFER the Local chain-head advance to
+                // commit-response time (`mark_sender_committed_with_post_state_hash`
+                // promotes it). Advancing here — at confirm BUILD — moved the
+                // Local head past a step the receiver could still reject
+                // (e.g. offline-bearer MissingRelease) or never see; every
+                // subsequent transfer then signed a cert the receiver could
+                // not chain back to its expected prior head, permanently
+                // wedging the relationship. The receiver's own mirror of this
+                // chain (Counterparty side) already advances only at commit;
+                // stashing keeps the two in lockstep.
+                crate::storage::client_db::stash_pending_local_head(
+                    &rel_key,
+                    &commitment_hash,
+                    &signing_out.ek_pk,
+                    &signing_out.ek_sk,
+                    &at_rest_key,
+                    signing_out.used_root_ak,
+                )
+                .map_err(|e| {
+                    DsmError::invalid_operation(format!("stash pending local chain head: {e}"))
+                })?;
+                debug!(
+                    "[BILATERAL] §11.1 stashed pending Local chain-head advance (used_root_ak={}) for commitment {}",
+                    signing_out.used_root_ak,
+                    bytes_to_base32(&commitment_hash[..8]),
+                );
             }
             BilateralSide::B => {
                 receipt.set_ek_pk_b(signing_out.ek_pk.clone());
                 receipt.set_ek_cert_b(signing_out.ek_cert);
                 receipt.set_kyber_ct_b(signing_out.kyber_ct);
                 receipt.add_sig_b(signing_out.sig);
+
+                // §11.1 receiver side: the B-side counter-sign runs AFTER
+                // the canonical commit succeeded in `handle_confirm_request`,
+                // so advancing immediately here is already commit-gated.
+                crate::sdk::receipts::advance_local_chain_head_after_signing(
+                    &rel_key,
+                    &signing_out.ek_pk,
+                    &signing_out.ek_sk,
+                    &at_rest_key,
+                    signing_out.used_root_ak,
+                )?;
             }
         }
-
-        let at_rest_key = crate::init::current_chain_head_at_rest_key()?;
-        crate::sdk::receipts::advance_local_chain_head_after_signing(
-            &rel_key,
-            &signing_out.ek_pk,
-            &signing_out.ek_sk,
-            &at_rest_key,
-            signing_out.used_root_ak,
-        )?;
 
         receipt.to_full_protobuf()
     }
@@ -1120,6 +1150,37 @@ impl BilateralBleHandler {
                     e
                 );
                 continue;
+            }
+
+            // §11.1 — the session is abandoned; drop any pending Local
+            // chain-head advance stashed for it so the EK material does
+            // not linger. The Local head itself never moved (promotion is
+            // commit-gated), so the next transfer signs from the prior
+            // head both sides still agree on.
+            if let Some(counterparty_id) = counterparty_device_id_arr {
+                if record.commitment_hash.len() == 32 {
+                    let mut ch = [0u8; 32];
+                    ch.copy_from_slice(&record.commitment_hash);
+                    let rel_key = dsm::verification::smt_replace_witness::compute_smt_key(
+                        &self.device_id,
+                        &counterparty_id,
+                    );
+                    match crate::storage::client_db::drop_pending_local_head(&rel_key, &ch) {
+                        Ok(true) => {
+                            debug!(
+                                "[BLE_HANDLER] §11.1 dropped pending Local chain-head stash for abandoned session {}",
+                                bytes_to_base32(&ch[..8])
+                            );
+                        }
+                        Ok(false) => {}
+                        Err(e) => {
+                            warn!(
+                                "[BLE_HANDLER] §11.1 failed to drop pending Local chain-head stash during restore: {}",
+                                e
+                            );
+                        }
+                    }
+                }
             }
 
             failed_count += 1;
@@ -3454,7 +3515,13 @@ impl BilateralBleHandler {
                             payload_hash,
                             authority_policy_hash,
                             0,
-                            op_bytes.clone(),
+                            // action_fields: EMPTY. The operation is already bound into the transition
+                            // via `payload_hash = H(op_bytes)` above, so carrying the full `op_bytes`
+                            // here is redundant AND overflows the appliance's `MAX_ACTION_FIELDS` (256)
+                            // once the OfflineBearerRequired policy tail is appended (~266 B) — the chip
+                            // PREPARE then fails `BAD_PROTO`. The receiver recomputes the digest from the
+                            // transition carried in the release, so empty is consistent end-to-end.
+                            Vec::new(),
                             r_r,
                         ) {
                             Ok(art) => Some(art),
@@ -4315,6 +4382,7 @@ impl BilateralBleHandler {
                         )
                         .ok()
                         .flatten();
+                    let had_cp_head = prev_pk_from_chain.is_some();
                     let expected_prev_pk = match prev_pk_from_chain {
                         Some(pk) => pk,
                         None => {
@@ -4324,6 +4392,17 @@ impl BilateralBleHandler {
                             counterparty_pubkey.clone()
                         }
                     };
+
+                    // §11.1 verification provenance: which prior key the
+                    // sender's ek_cert is expected to chain back to (the
+                    // Counterparty head when one exists, else the contact's
+                    // AK root). Key prefixes only.
+                    debug!(
+                        "[BILATERAL] §11.1 A-side verify: counterparty_head_row={} expected_prev_pk={} parent_tip={}",
+                        had_cp_head,
+                        bytes_to_base32(&expected_prev_pk[..8.min(expected_prev_pk.len())]),
+                        bytes_to_base32(&receipt.parent_tip[..8.min(receipt.parent_tip.len())]),
+                    );
 
                     crate::sdk::receipts::verify_per_step_ek_signing_strict_aware(
                         &receipt,
@@ -4408,15 +4487,14 @@ impl BilateralBleHandler {
         // receiver-side admit is still gated: no fused anchor is pinned (`pinned = None`) and the
         // relay counter-verifier slot is unfilled, so this still always recovers online. Ordinary
         // transfers are unaffected (the predicate is false for them).
+        let mut adopted_anchor_state: Option<crate::bluetooth::anchor_accept::AdoptedAnchorState> =
+            None;
         if dsm::core::bilateral_transaction_manager::operation_requires_offline_bearer(
             &session.operation,
         ) {
-            // The receiver supplies no fused-anchor pin yet: `pinned = None` routes every
-            // offline-bearer transfer to online recovery. `h_n` is the receiver's accepted
-            // relationship tip. `expected_receiver_challenge` is the r_R this receiver generated in
+            // `expected_receiver_challenge` is the r_R this receiver generated in
             // its prepare-response and stashed against the session — the release must bind it, so a
-            // release minted for a different receiver session is rejected (defense-in-depth; the
-            // absent pin already short-circuits to recovery before this check).
+            // release minted for a different receiver session is rejected (defense-in-depth).
             let policy_hash = match &session.operation {
                 Operation::Transfer {
                     authority_policy: Some(ap),
@@ -4582,17 +4660,32 @@ impl BilateralBleHandler {
             let pinned = pin
                 .as_ref()
                 .map(crate::bluetooth::anchor_accept::PinnedAnchor::from_fused);
-            crate::bluetooth::anchor_accept::accept_offline_release_with_relay_counter(
-                &confirm_request.offline_release,
-                pinned.as_ref(),
-                &h_n,
-                &self.device_id,
-                &expected_receiver_challenge,
-                &policy_hash,
-                &binding,
-                attested,
-            )
-            .map_err(|r| r.into_dsm_error())?;
+            // Def. 25 check 2: the appliance root adopted from this holder's last
+            // ACCEPTED release. Absent row = relationship genesis — the predicate
+            // adopts the release's own `prev_root` TOFU (authenticated by the
+            // anchor-state proofs + the live counter, same trust root as the pin).
+            let accepted_root =
+                crate::storage::client_db::anchor_enrollments::load_accepted_anchor_root(
+                    &sender_device_id,
+                )
+                .ok()
+                .flatten();
+            let adopted =
+                crate::bluetooth::anchor_accept::accept_offline_release_with_relay_counter(
+                    &confirm_request.offline_release,
+                    pinned.as_ref(),
+                    accepted_root.as_ref().map(|(r, _)| r),
+                    &self.device_id,
+                    &expected_receiver_challenge,
+                    &policy_hash,
+                    &binding,
+                    attested,
+                )
+                .map_err(|r| r.into_dsm_error())?;
+            // Persisted AFTER the canonical commit below succeeds (deferred, like
+            // the §11.1 cert-chain mirrors) — a commit failure must not move the
+            // accepted lineage frontier.
+            adopted_anchor_state = Some(adopted);
             info!(
                 "[BILATERAL] offline-bearer release accepted (canonical Boot Fenced Fused predicate) for commitment {}",
                 bytes_to_base32(&commitment_hash[..8])
@@ -4651,6 +4744,28 @@ impl BilateralBleHandler {
                 DsmError::state_machine(format!("receiver confirm advance failed: {e}"))
             })?;
 
+        // Offline-bearer post-commit: ADOPT the holder's successor appliance
+        // root (Def. 25 "receiver adopts next_root on acceptance"). Deferred
+        // to here so a canonical-commit failure never moves the accepted
+        // lineage frontier past a release that delivered no value.
+        if let Some(adopted) = adopted_anchor_state {
+            match crate::storage::client_db::anchor_enrollments::store_accepted_anchor_root(
+                &session.counterparty_device_id,
+                &adopted.next_root,
+                adopted.next_anchor_counter,
+            ) {
+                Ok(()) => info!(
+                    "[BILATERAL] adopted holder appliance root (next_anchor_counter={}) for commitment {}",
+                    adopted.next_anchor_counter,
+                    bytes_to_base32(&commitment_hash[..8])
+                ),
+                Err(e) => error!(
+                    "[BILATERAL] failed to persist adopted appliance root: {} — the next transfer from this holder will fail check 2 until reconciled",
+                    e
+                ),
+            }
+        }
+
         // §11.1 post-commit: advance the local mirror of the SENDER's
         // cert chain head (Counterparty side from receiver's POV). Done
         // *after* canonical commit succeeds — if the advance call above
@@ -4673,14 +4788,35 @@ impl BilateralBleHandler {
                     );
                 }
                 Ok(None) => {
-                    // No row to update — relationship was never seeded via
-                    // init_cert_chain_for_relationship. Verification still
-                    // succeeded against the contact's AK_pk root above,
-                    // but the mirror row must be initialized before the next
-                    // step can verify against the fresh EK head.
-                    warn!(
-                        "[BILATERAL] §11.1 cert_chain_heads.Counterparty row missing for relationship — verification used AK_pk root; multi-step will degrade until init_cert_chain_for_relationship is called"
-                    );
+                    // First committed transfer on this relationship — no
+                    // Counterparty row exists yet. Verification chained the
+                    // sender's cert to their AK_pk root above; record the
+                    // sender's EK_pk_1 as the step-0 Counterparty head so the
+                    // NEXT step's `expected_prev_pk` resolves to the fresh EK
+                    // head instead of falling back to the AK and rejecting.
+                    match crate::storage::client_db::init_cert_chain_head(
+                        &rel_key,
+                        crate::storage::client_db::CertChainSide::Counterparty,
+                        ek_pk_a,
+                    ) {
+                        Ok(true) => {
+                            info!(
+                                "[BILATERAL] §11.1 initialized Counterparty cert chain head at sender EK_pk_1 for commitment {}",
+                                bytes_to_base32(&commitment_hash[..8])
+                            );
+                        }
+                        Ok(false) => {
+                            warn!(
+                                "[BILATERAL] §11.1 Counterparty cert chain head appeared concurrently — leaving existing row"
+                            );
+                        }
+                        Err(e) => {
+                            error!(
+                                "[BILATERAL] §11.1 failed to initialize Counterparty cert chain head: {} — multi-step verification will degrade until reconciled",
+                                e
+                            );
+                        }
+                    }
                 }
                 Err(e) => {
                     // Advancement is bookkeeping; canonical commit
@@ -5494,6 +5630,40 @@ impl BilateralBleHandler {
             }
         }
 
+        // §11.1 — promote the PENDING Local chain-head advance stashed at
+        // confirm-build time. The receiver's commit-response proves it
+        // verified our A-side cert and advanced its Counterparty mirror,
+        // so our Local head may now move to the EK that signed this step.
+        // Doing this only here (never at build) means a rejected or lost
+        // confirm leaves the Local head untouched and the relationship
+        // convergent.
+        {
+            let rel_key = dsm::verification::smt_replace_witness::compute_smt_key(
+                &self.device_id,
+                &counterparty_device_id,
+            );
+            match crate::storage::client_db::promote_pending_local_head(&rel_key, commitment_hash) {
+                Ok(Some(step)) => {
+                    info!(
+                        "[BILATERAL] §11.1 promoted pending Local chain head to EK_pk_{step} for commitment {}",
+                        bytes_to_base32(&commitment_hash[..8])
+                    );
+                }
+                Ok(None) => {
+                    warn!(
+                        "[BILATERAL] §11.1 no pending Local chain head to promote for commitment {} — head not advanced (already promoted, or stash lost); next step may need reconciliation",
+                        bytes_to_base32(&commitment_hash[..8])
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "[BILATERAL] §11.1 failed to promote pending Local chain head: {} — next outbound step will sign from the stale head",
+                        e
+                    );
+                }
+            }
+        }
+
         // §11.1 Item 8 (B-tight) — advance the local mirror of the
         // RECEIVER's cert chain head (Counterparty side from sender's
         // POV) immediately before deleting the session row. Sourcing
@@ -5526,9 +5696,33 @@ impl BilateralBleHandler {
                             );
                         }
                         Ok(None) => {
-                            warn!(
-                                "[BILATERAL] §11.1 cert_chain_heads.Counterparty row missing for relationship — verification used AK_pk root"
-                            );
+                            // First committed transfer — no Counterparty row
+                            // yet. Record the receiver's EK_pk_1 as the step-0
+                            // head so the next step verifies against it
+                            // instead of falling back to the AK and rejecting.
+                            match crate::storage::client_db::init_cert_chain_head(
+                                &rel_key,
+                                crate::storage::client_db::CertChainSide::Counterparty,
+                                &receipt.ek_pk_b,
+                            ) {
+                                Ok(true) => {
+                                    info!(
+                                        "[BILATERAL] §11.1 (B-tight) initialized Counterparty cert chain head at receiver EK_pk_1 for commitment {}",
+                                        bytes_to_base32(&commitment_hash[..8])
+                                    );
+                                }
+                                Ok(false) => {
+                                    warn!(
+                                        "[BILATERAL] §11.1 (B-tight) Counterparty cert chain head appeared concurrently — leaving existing row"
+                                    );
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "[BILATERAL] §11.1 (B-tight) failed to initialize Counterparty cert chain head: {} — startup reconciliation sweep will retry from session row",
+                                        e
+                                    );
+                                }
+                            }
                         }
                         Err(e) => {
                             error!(

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/ble_frame_coordinator.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/ble_frame_coordinator.rs
@@ -820,7 +820,15 @@ impl BleFrameCoordinator {
         // Transport-level dedup: if the same frame_commitment was already
         // dispatched (e.g. peer retransmitted the entire chunk set), drop it
         // before it reaches the bilateral handler.
-        {
+        //
+        // EXCEPTION — TropicSpiRelay: these are live request/reply round-trips of the Path-B
+        // counter read over a lossy BLE link. A repeated relay request is a legitimate RETRY
+        // (the reader re-runs the idempotent counter read on a fresh Noise session after a
+        // dropped reply), and consecutive requests can be byte-identical -> the same
+        // content-addressed frame_commitment. Content dedup would silently swallow every retry
+        // and wedge the counter read (observed: attempts 2-4 dropped as "duplicate", chip never
+        // sees them). Relay frames must NEVER be deduped.
+        if frame_type != BleFrameType::TropicSpiRelay {
             let mut dedup = self.dedup_table.lock().await;
             if dedup.is_duplicate(&frame_commitment) {
                 warn!(

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
@@ -3120,7 +3120,12 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_processIncomi
                     == crate::generated::BleFrameType::BilateralPrepareReject as i32
                     || frame_type == crate::generated::BleFrameType::BilateralCommit as i32
                     || frame_type == crate::generated::BleFrameType::BilateralCommitResponse as i32
-                    || frame_type == crate::generated::BleFrameType::BilateralConfirm as i32;
+                    || frame_type == crate::generated::BleFrameType::BilateralConfirm as i32
+                    // Path-B relay reply (chip->receiver counter read): the REQUEST is chunked via
+                    // `queue_follow_up_chunks`, so the REPLY must be BleChunk-framed too — otherwise
+                    // the receiver decodes the raw `TropicSpiRelayPacket` as a `BleChunk` and fails
+                    // (`invalid tag value: 0`), dropping the reply and timing out the counter read.
+                    || frame_type == crate::generated::BleFrameType::TropicSpiRelay as i32;
 
                 if needs_chunking {
                     use_reliable_write = true;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -2956,7 +2956,7 @@ mod tests {
         accept_offline_release_with_counter(
             &art1.offline_release,
             Some(&pin1),
-            &art1.appliance_prev_root,
+            Some(&art1.appliance_prev_root),
             &recipient,
             &[0x55u8; 32],
             &policy_hash,
@@ -2974,7 +2974,7 @@ mod tests {
         crate::bluetooth::anchor_accept::accept_offline_release_with_relay_counter(
             &art1.offline_release,
             Some(&pin1),
-            &art1.appliance_prev_root,
+            Some(&art1.appliance_prev_root),
             &recipient,
             &[0x55u8; 32],
             &policy_hash,
@@ -2991,7 +2991,7 @@ mod tests {
             let r = crate::bluetooth::anchor_accept::accept_offline_release_with_relay_counter(
                 &art1.offline_release,
                 Some(&pin1),
-                &art1.appliance_prev_root,
+                Some(&art1.appliance_prev_root),
                 &recipient,
                 &[0x55u8; 32],
                 &policy_hash,
@@ -3009,7 +3009,7 @@ mod tests {
         let replay = accept_offline_release_with_counter(
             &art1.offline_release,
             Some(&pin1),
-            &art1.appliance_next_root, // receiver has adopted the successor root
+            Some(&art1.appliance_next_root), // receiver has adopted the successor root
             &recipient,
             &[0x55u8; 32],
             &policy_hash,
@@ -3044,7 +3044,7 @@ mod tests {
         accept_offline_release_with_counter(
             &art2.offline_release,
             Some(&pin2),
-            &art2.appliance_prev_root,
+            Some(&art2.appliance_prev_root),
             &recipient,
             &[0x66u8; 32],
             &policy_hash,
@@ -3217,7 +3217,7 @@ mod tests {
             accept_offline_release_with_relay_counter(
                 &art.offline_release,
                 Some(&pinned),
-                &art.appliance_prev_root,
+                Some(&art.appliance_prev_root),
                 &recipient,
                 &r_r,
                 &policy_hash,

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/anchor_enrollments.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/anchor_enrollments.rs
@@ -77,6 +77,59 @@ pub fn get_anchor_enrollment_raw(device_id: &[u8; 32]) -> Result<Option<AnchorEn
     }))
 }
 
+/// The appliance root the receiver adopted from the holder's last ACCEPTED
+/// release (Def. 25 check 2), plus the anchor counter adopted with it.
+/// `None` = relationship genesis — the next release's own `prev_root` is
+/// adopted TOFU by the acceptance predicate.
+pub fn load_accepted_anchor_root(device_id: &[u8; 32]) -> Result<Option<([u8; 32], u64)>> {
+    let binding = get_connection()?;
+    let conn = binding
+        .lock()
+        .map_err(|_| anyhow!("anchor_accepted_roots: db lock poisoned"))?;
+    let row = conn
+        .query_row(
+            "SELECT accepted_root, next_anchor_counter FROM anchor_accepted_roots
+             WHERE device_id = ?1",
+            params![device_id.as_slice()],
+            |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()?;
+    match row {
+        Some((root, ctr)) => Ok(Some((
+            fixed32(root, "accepted_root")?,
+            u64::try_from(ctr).unwrap_or(0),
+        ))),
+        None => Ok(None),
+    }
+}
+
+/// Adopt the holder's successor appliance root after an accepted release's
+/// canonical commit. INSERT OR REPLACE: each accepted transfer moves the
+/// lineage frontier forward.
+pub fn store_accepted_anchor_root(
+    device_id: &[u8; 32],
+    accepted_root: &[u8; 32],
+    next_anchor_counter: u64,
+) -> Result<()> {
+    let binding = get_connection()?;
+    let conn = binding
+        .lock()
+        .map_err(|_| anyhow!("anchor_accepted_roots: db lock poisoned"))?;
+    let now = crate::util::deterministic_time::tick() as i64;
+    conn.execute(
+        "INSERT OR REPLACE INTO anchor_accepted_roots
+            (device_id, accepted_root, next_anchor_counter, updated_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            device_id.as_slice(),
+            accepted_root.as_slice(),
+            next_anchor_counter as i64,
+            now
+        ],
+    )?;
+    Ok(())
+}
+
 /// Admit (pin) a fused anchor. INSERT OR REPLACE: re-admission overwrites, matching the
 /// [`AnchorEnrollmentStore`](dsm::crypto::anchor_enrollment::AnchorEnrollmentStore) contract —
 /// the CALLER owns the authority rules (first-transfer TOFU / same-anchor upgrade only; a

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/cert_chain.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/cert_chain.rs
@@ -384,6 +384,134 @@ pub fn advance_cert_chain_for_relationship(
     }
 }
 
+/// Stash a freshly-derived per-step EK as a PENDING Local chain-head
+/// advance for one bilateral commitment (§11.1 sender side). The SK is
+/// AEAD-encrypted under the same chain-head wrap key scheme as
+/// `cert_chain_heads`. Nothing in `cert_chain_heads` changes until
+/// `promote_pending_local_head` runs at commit-response time — a confirm
+/// the receiver rejects or never sees therefore never moves the Local
+/// head, and the next transfer signs from the same prior head the
+/// receiver still expects.
+///
+/// Idempotent per commitment: a rebuild of the same confirm re-derives
+/// the same deterministic EK and simply replaces the row.
+pub fn stash_pending_local_head(
+    relationship_key: &[u8; 32],
+    commitment_hash: &[u8; 32],
+    ek_pubkey: &[u8],
+    ek_secret_key: &[u8],
+    chain_head_wrap_key: &[u8; 32],
+    is_init: bool,
+) -> Result<()> {
+    let encrypted_sk = encrypt_chain_sk(ek_secret_key, chain_head_wrap_key)?;
+    let binding = get_connection()?;
+    let conn = binding.lock().unwrap_or_else(|p| p.into_inner());
+    let now = tick() as i64;
+    conn.execute(
+        "INSERT OR REPLACE INTO pending_local_cert_heads
+            (relationship_key, commitment_hash, ek_pubkey, ek_sk_encrypted, is_init, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            relationship_key.as_slice(),
+            commitment_hash.as_slice(),
+            ek_pubkey,
+            encrypted_sk,
+            is_init as i64,
+            now
+        ],
+    )?;
+    Ok(())
+}
+
+/// Promote a pending Local chain-head advance into `cert_chain_heads`
+/// after the receiver's commit-response proves the step was accepted.
+/// The encrypted SK blob moves verbatim (it is never decrypted here).
+/// Returns the resulting step count, or `None` if no pending row exists
+/// for that (relationship, commitment) pair — e.g. already promoted, or
+/// dropped by a failure path.
+pub fn promote_pending_local_head(
+    relationship_key: &[u8; 32],
+    commitment_hash: &[u8; 32],
+) -> Result<Option<u64>> {
+    let binding = get_connection()?;
+    let mut conn = binding.lock().unwrap_or_else(|p| p.into_inner());
+    let tx = conn.transaction()?;
+    let row: Option<(Vec<u8>, Vec<u8>, i64)> = tx
+        .query_row(
+            "SELECT ek_pubkey, ek_sk_encrypted, is_init FROM pending_local_cert_heads
+             WHERE relationship_key = ?1 AND commitment_hash = ?2",
+            params![relationship_key.as_slice(), commitment_hash.as_slice()],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .optional()?;
+    let Some((ek_pk, sk_ct, is_init)) = row else {
+        return Ok(None);
+    };
+    let now = tick() as i64;
+    if is_init != 0 {
+        // Relationship genesis: the sign fell back to the root AK because
+        // no Local row existed. Record EK_1 as the step-0 head. If a row
+        // appeared in the interim (should not happen — sign-time load and
+        // this promote are serialized per relationship), the INSERT is
+        // ignored and the UPDATE below advances instead.
+        let inserted = tx.execute(
+            "INSERT OR IGNORE INTO cert_chain_heads
+                (relationship_key, side, chain_head_pubkey, chain_head_sk_encrypted, step_count, updated_at)
+             VALUES (?1, 0, ?2, ?3, 0, ?4)",
+            params![relationship_key.as_slice(), ek_pk, sk_ct, now],
+        )?;
+        if inserted == 0 {
+            tx.execute(
+                "UPDATE cert_chain_heads
+                 SET chain_head_pubkey = ?1, chain_head_sk_encrypted = ?2,
+                     step_count = step_count + 1, updated_at = ?3
+                 WHERE relationship_key = ?4 AND side = 0",
+                params![ek_pk, sk_ct, now, relationship_key.as_slice()],
+            )?;
+        }
+    } else {
+        tx.execute(
+            "UPDATE cert_chain_heads
+             SET chain_head_pubkey = ?1, chain_head_sk_encrypted = ?2,
+                 step_count = step_count + 1, updated_at = ?3
+             WHERE relationship_key = ?4 AND side = 0",
+            params![ek_pk, sk_ct, now, relationship_key.as_slice()],
+        )?;
+    }
+    tx.execute(
+        "DELETE FROM pending_local_cert_heads
+         WHERE relationship_key = ?1 AND commitment_hash = ?2",
+        params![relationship_key.as_slice(), commitment_hash.as_slice()],
+    )?;
+    let step: Option<i64> = tx
+        .query_row(
+            "SELECT step_count FROM cert_chain_heads
+             WHERE relationship_key = ?1 AND side = 0",
+            params![relationship_key.as_slice()],
+            |r| r.get(0),
+        )
+        .optional()?;
+    tx.commit()?;
+    Ok(step.map(|s| s as u64))
+}
+
+/// Drop a pending Local chain-head advance whose confirm terminally
+/// failed (receiver rejected, or the session was abandoned on restore).
+/// Returns `true` if a row was deleted.
+pub fn drop_pending_local_head(
+    relationship_key: &[u8; 32],
+    commitment_hash: &[u8; 32],
+) -> Result<bool> {
+    let binding = get_connection()?;
+    let conn = binding.lock().unwrap_or_else(|p| p.into_inner());
+    let deleted = conn.execute(
+        "DELETE FROM pending_local_cert_heads
+         WHERE relationship_key = ?1 AND commitment_hash = ?2",
+        params![relationship_key.as_slice(), commitment_hash.as_slice()],
+    )?;
+    Ok(deleted > 0)
+}
+
 /// Load the full chain head record (pubkey + step_count + timestamp).
 pub fn load_cert_chain_head(
     relationship_key: &[u8; 32],
@@ -757,6 +885,120 @@ mod tests {
             advance_local_cert_chain_head_with_sk(&r, &[0x77; 64], &[0x88; 96], &[0x99; 32])
                 .unwrap();
         assert!(result.is_none());
+    }
+
+    // ── Pending (deferred) Local chain-head advance (§11.1 sender side) ──
+
+    /// Genesis flow: stash (is_init) leaves cert_chain_heads untouched;
+    /// promote creates the step-0 Local row with the EK and its SK; the
+    /// pending row is consumed.
+    #[test]
+    #[serial_test::serial]
+    fn pending_local_head_stash_promote_genesis() {
+        reset_database_for_tests();
+        let r = rel(0xC1);
+        let commitment = [0xD1; 32];
+        let ek_pk = vec![0x10; 64];
+        let ek_sk = vec![0x11; 96];
+        let wrap = [0x12; 32];
+
+        stash_pending_local_head(&r, &commitment, &ek_pk, &ek_sk, &wrap, true).unwrap();
+        // Nothing promoted yet — the Local head must be unchanged (absent).
+        assert!(load_cert_chain_head_pubkey(&r, CertChainSide::Local)
+            .unwrap()
+            .is_none());
+
+        let step = promote_pending_local_head(&r, &commitment).unwrap();
+        assert_eq!(step, Some(0), "genesis promote records EK_1 at step 0");
+        assert_eq!(
+            load_cert_chain_head_pubkey(&r, CertChainSide::Local)
+                .unwrap()
+                .unwrap(),
+            ek_pk
+        );
+        // The SK ciphertext moved verbatim and still decrypts.
+        assert_eq!(
+            load_local_chain_head_sk(&r, &wrap).unwrap(),
+            Some(ek_sk.clone())
+        );
+        // Pending row consumed — second promote is a no-op.
+        assert_eq!(promote_pending_local_head(&r, &commitment).unwrap(), None);
+    }
+
+    /// Steady-state flow: with an existing Local row, promote advances it
+    /// (step + 1, new pubkey + SK).
+    #[test]
+    #[serial_test::serial]
+    fn pending_local_head_promote_advances_existing_row() {
+        reset_database_for_tests();
+        let r = rel(0xC2);
+        let wrap = [0x21; 32];
+        init_local_cert_chain_head_with_sk(&r, &[0xA0; 64], &[0xA1; 96], &wrap).unwrap();
+
+        let commitment = [0xD2; 32];
+        let ek_pk = vec![0xB0; 64];
+        let ek_sk = vec![0xB1; 96];
+        stash_pending_local_head(&r, &commitment, &ek_pk, &ek_sk, &wrap, false).unwrap();
+
+        let step = promote_pending_local_head(&r, &commitment).unwrap();
+        assert_eq!(step, Some(1));
+        assert_eq!(
+            load_cert_chain_head_pubkey(&r, CertChainSide::Local)
+                .unwrap()
+                .unwrap(),
+            ek_pk
+        );
+        assert_eq!(load_local_chain_head_sk(&r, &wrap).unwrap(), Some(ek_sk));
+    }
+
+    /// Rejected confirm: drop removes the pending row and the Local head
+    /// never moves — the divergence-on-failure hazard this table exists
+    /// to prevent.
+    #[test]
+    #[serial_test::serial]
+    fn pending_local_head_drop_on_failure_leaves_head_untouched() {
+        reset_database_for_tests();
+        let r = rel(0xC3);
+        let wrap = [0x31; 32];
+        let ak_pk = vec![0xA0; 64];
+        init_local_cert_chain_head_with_sk(&r, &ak_pk, &[0xA1; 96], &wrap).unwrap();
+
+        let commitment = [0xD3; 32];
+        stash_pending_local_head(&r, &commitment, &[0xB0; 64], &[0xB1; 96], &wrap, false).unwrap();
+        assert!(drop_pending_local_head(&r, &commitment).unwrap());
+
+        // Head unchanged; promote after drop is a no-op.
+        assert_eq!(
+            load_cert_chain_head_pubkey(&r, CertChainSide::Local)
+                .unwrap()
+                .unwrap(),
+            ak_pk
+        );
+        assert_eq!(promote_pending_local_head(&r, &commitment).unwrap(), None);
+        // Dropping again reports nothing deleted.
+        assert!(!drop_pending_local_head(&r, &commitment).unwrap());
+    }
+
+    /// Re-stash for the same commitment replaces the row (idempotent
+    /// rebuild of the same confirm).
+    #[test]
+    #[serial_test::serial]
+    fn pending_local_head_restash_replaces() {
+        reset_database_for_tests();
+        let r = rel(0xC4);
+        let wrap = [0x41; 32];
+        let commitment = [0xD4; 32];
+        stash_pending_local_head(&r, &commitment, &[0x50; 64], &[0x51; 96], &wrap, true).unwrap();
+        let ek_pk2 = vec![0x60; 64];
+        stash_pending_local_head(&r, &commitment, &ek_pk2, &[0x61; 96], &wrap, true).unwrap();
+
+        promote_pending_local_head(&r, &commitment).unwrap();
+        assert_eq!(
+            load_cert_chain_head_pubkey(&r, CertChainSide::Local)
+                .unwrap()
+                .unwrap(),
+            ek_pk2
+        );
     }
 
     #[test]

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/storage/client_db/mod.rs
@@ -702,6 +702,46 @@ fn create_schema(conn: &Connection) -> Result<()> {
             PRIMARY KEY (relationship_key, side)
         );
 
+        -- §11.1 sender-side DEFERRED Local chain-head advance. The new
+        -- per-step EK (pubkey + AEAD-encrypted SK, same wrap scheme as
+        -- cert_chain_heads) signed into an outbound bilateral confirm is
+        -- held here, keyed by the bilateral commitment, until the
+        -- receiver's commit-response proves the step was accepted — then
+        -- it is promoted into cert_chain_heads.Local. Advancing at
+        -- confirm-BUILD time (the previous behavior) moved the Local head
+        -- past a step the receiver could still reject (e.g. MissingRelease)
+        -- or never see, after which every subsequent transfer signed a
+        -- cert the receiver could not chain back to its expected prior
+        -- head — permanently wedging the relationship. is_init records
+        -- whether the sign fell back to the root AK (relationship genesis,
+        -- no Local row yet) so promotion knows to INSERT (step 0) rather
+        -- than UPDATE.
+        CREATE TABLE IF NOT EXISTS pending_local_cert_heads(
+            relationship_key        BLOB NOT NULL,
+            commitment_hash         BLOB NOT NULL,
+            ek_pubkey               BLOB NOT NULL,
+            ek_sk_encrypted         BLOB NOT NULL,
+            is_init                 INTEGER NOT NULL CHECK(is_init IN (0, 1)),
+            created_at              INTEGER NOT NULL,
+            PRIMARY KEY (relationship_key, commitment_hash)
+        );
+
+        -- Offline-bearer receiver-side appliance-root lineage (Def. 25 check 2:
+        -- "previous root is the receiver's accepted root"). One row per HOLDER
+        -- (sender) device: the appliance root the receiver adopted from the last
+        -- ACCEPTED release's `next_root`, plus the anchor counter adopted with it.
+        -- Written only after the canonical commit succeeds (deferred, like the
+        -- §11.1 cert-chain mirrors). Absent row = relationship genesis: the first
+        -- release's own `prev_root` is adopted TOFU — its authenticity rests on
+        -- the anchor-state commitment proofs + the LIVE authenticated counter
+        -- (`H == H0 − (uᵢ+1)`), the same trust root as the first-transfer pin.
+        CREATE TABLE IF NOT EXISTS anchor_accepted_roots(
+            device_id            BLOB NOT NULL PRIMARY KEY,
+            accepted_root        BLOB NOT NULL,
+            next_anchor_counter  INTEGER NOT NULL,
+            updated_at           INTEGER NOT NULL
+        );
+
         -- Offline-bearer anti-clone (Boot Fenced Fused Anchor): the RECEIVER's pinned admission of
         -- a counterparty's fused anchor, keyed by the counterparty device id — the persistent
         -- backing for `dsm::crypto::anchor_enrollment::AnchorEnrollmentStore` (FusedAnchorPin


### PR DESCRIPTION
## Summary

This branch takes the chip-backed offline-bearer transfer from fail-closed to **complete on real hardware**: 42 ERA moved between two phones over BLE with the sender's TROPIC01 producing the release and the receiver authenticating the live counter through the Path-B relay — the D2 milestone.

Four commits, in discovery order (each layer's fix exposed the next):

1. **`fix(anchor)` — deterministic, chip-rooted anchor identity** (stable across reboot).
2. **`fix(anchor)` — firmware session recovery + live-counter adoption.** The TROPIC01 has one L3 session; the receiver's relay read re-keys the chip, so the firmware re-handshakes before the next appliance op. `recover()` on a Ready device behind the chip now adopts the live counter (the monotonic down-counter is the source of truth; adopting can only shrink the budget).
3. **`fix(ble)` — four stacked Path-B transport bugs**: USB packet-boundary framing desync (residual buffer), relay reply not BleChunk-framed (reply now mirrors request framing), RPA-rotation routing dead-end (single-peer-guarded live-session fallback, recovered from `655f9e64`), and an idempotent 4× counter-read retry paired with exempting `TropicSpiRelay` from the content-addressed dedup that was silently swallowing the retries.
4. **`fix(bilateral)` — the two receiver-blocking protocol bugs** (both proven by pulling and diffing each phone's SQLite):
   - **§11.1 divergence**: the sender advanced its Local cert-chain head at confirm-*build* while the receiver only advances at commit — one rejected confirm permanently wedged the relationship. The A-side advance is now deferred via a `pending_local_cert_heads` stash promoted at commit-response; both `Ok(None)` Counterparty arms now initialize the mirror row at `EK_pk_1` (the warn-only arm killed every *second* transfer).
   - **Def. 25 check 2**: the receiver compared the release's appliance lineage root against the bilateral relationship tip (different domains — fail-closed placeholder). New `anchor_accepted_roots` frontier: TOFU-adopt the first release's own `prev_root` (still bound by the anchor-state proofs + the live authenticated counter), persist `next_root` post-commit, strict lineage equality from transfer 2 on.

**Known residual (documented):** the chip advances even on a rejected confirm, so a failed bearer attempt leaves the chip lineage ahead of the receiver's adopted root; a later transfer to the same receiver fails check 2 until a re-admission flow exists (Phase H). First transfers always work.

## Test plan

- `cargo test -p dsm-anchor-core` — 25 passed (incl. the updated recover-adopts-live test)
- `cargo test -p dsm_sdk --lib cert_chain` — 22 passed (4 new pending-stash tests)
- `cargo test -p dsm_sdk --lib anchor_accept` — 12 passed
- `cargo test -p dsm_sdk --lib core_sdk offline_bearer` — 9 passed (full accept → adopt → transfer-2 activation test)
- **Hardware E2E (2× SM-A165M + Pico 2 W/TROPIC01):** chip release u=12→13 → §11.1 per-step EK PASS → authenticated relay counter read → all 22 Boot Fenced Fused Anchor predicate checks → canonical commit both sides → **balances 100→58 / 0→42**

🤖 Generated with [Claude Code](https://claude.com/claude-code)