### PR TITLE
fix(offline-bearer): recognize bearer frames end-to-end (canonical validator + JNI routing/chunking)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/envelope.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/envelope.rs
@@ -48,6 +48,10 @@ const ALLOWED_PAYLOAD_TAGS: &[u32] = &[
     39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
     63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
     87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106,
+    // Counter-Positioned Commit first-transfer round-trip (§21) envelope payloads:
+    // bilateral_bearer_prepared (110) + bilateral_bearer_proceed (111). Without these the
+    // canonical validator rejects every bearer envelope as an unknown field before routing.
+    110, 111,
 ];
 
 fn parsing_error(message: impl Into<String>) -> DsmError {
@@ -730,6 +734,65 @@ mod tests {
 
         let err = from_canonical_bytes(&bytes).expect_err("unknown fields must reject");
         assert!(err.to_string().contains("unknown Envelope field 107"));
+    }
+
+    #[test]
+    fn strict_decode_accepts_bearer_round_trip_payloads() {
+        // §21 first-transfer round-trip payloads (bilateral_bearer_prepared = 110,
+        // bilateral_bearer_proceed = 111) must pass the canonical validator, else the
+        // receiver rejects every bearer envelope as an unknown field before it can route.
+        let prepared = Envelope {
+            version: 3,
+            headers: Some(crate::types::proto::Headers {
+                device_id: vec![1; 32],
+                chain_tip: vec![2; 32],
+                genesis_hash: vec![3; 32],
+                seq: 7,
+            }),
+            message_id: vec![4; 16],
+            payload: Some(
+                crate::types::proto::envelope::Payload::BilateralBearerPrepared(
+                    crate::types::proto::BilateralBearerPrepared {
+                        commitment_hash: Some(crate::types::proto::Hash32 { v: vec![5; 32] }),
+                        anchor_disclosure: Some(crate::types::proto::AnchorDisclosure {
+                            bundle: vec![6; 32],
+                            anchor_id: vec![7; 32],
+                            enrolled_counter: 42,
+                            partition_pk: vec![8; 64],
+                            policy_hash: vec![9; 32],
+                            verifier_slot: 1,
+                            verifier_slot_present: true,
+                            chip_static_pubkey: vec![10; 32],
+                        }),
+                    },
+                ),
+            ),
+        };
+        let decoded = from_canonical_bytes(&to_canonical_bytes(&prepared))
+            .expect("bilateral_bearer_prepared (tag 110) must be accepted");
+        assert_eq!(decoded, prepared);
+
+        let proceed = Envelope {
+            version: 3,
+            headers: Some(crate::types::proto::Headers {
+                device_id: vec![1; 32],
+                chain_tip: vec![2; 32],
+                genesis_hash: vec![3; 32],
+                seq: 8,
+            }),
+            message_id: vec![4; 16],
+            payload: Some(
+                crate::types::proto::envelope::Payload::BilateralBearerProceed(
+                    crate::types::proto::BilateralBearerProceed {
+                        commitment_hash: Some(crate::types::proto::Hash32 { v: vec![5; 32] }),
+                        receiver_signature: vec![11; 64],
+                    },
+                ),
+            ),
+        };
+        let decoded = from_canonical_bytes(&to_canonical_bytes(&proceed))
+            .expect("bilateral_bearer_proceed (tag 111) must be accepted");
+        assert_eq!(decoded, proceed);
     }
 
     #[test]

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/frame_classify.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/frame_classify.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! BLE frame-type classification and chunking eligibility.
 //!
 //! These helpers decide, for a canonical DSM envelope or a frame type, which

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/frame_classify.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/frame_classify.rs
@@ -1,0 +1,302 @@
+//! BLE frame-type classification and chunking eligibility.
+//!
+//! These helpers decide, for a canonical DSM envelope or a frame type, which
+//! `BleFrameType` a payload carries and whether the outbound reply must be
+//! `BleChunk`-framed rather than pushed raw. They are consumed by the Android JNI
+//! bridge (`crate::jni::unified_protobuf_bridge`, compiled only for
+//! `target_os = "android"`), so they live here in the host-compiled transport layer
+//! to keep the routing/classification logic under host CI unit tests.
+//!
+//! The functions are `dead_code`-allowed on non-Android hosts because their only
+//! non-test caller is the Android-only JNI shim; on Android they are live.
+
+use crate::generated as pb;
+use prost::Message;
+
+/// Strip the single `0x03` envelope-v3 frame tag if present, returning the raw
+/// canonical envelope bytes.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub(crate) fn strip_envelope_v3_framing(bytes: &[u8]) -> &[u8] {
+    if bytes.first() == Some(&0x03) {
+        &bytes[1..]
+    } else {
+        bytes
+    }
+}
+
+/// Classify a (possibly v3-framed) canonical envelope into its `BleFrameType`
+/// discriminant, returning `Unspecified` when the payload is not a routed BLE frame.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub(crate) fn detect_ble_frame_type_from_bytes(bytes: &[u8]) -> i32 {
+    let raw = strip_envelope_v3_framing(bytes);
+
+    if let Ok(env) = crate::envelope::from_canonical_bytes(raw) {
+        return match env.payload {
+            Some(pb::envelope::Payload::BilateralPrepareResponse(_)) => {
+                pb::BleFrameType::BilateralPrepareResponse as i32
+            }
+            Some(pb::envelope::Payload::BilateralPrepareReject(_)) => {
+                pb::BleFrameType::BilateralPrepareReject as i32
+            }
+            Some(pb::envelope::Payload::BilateralCommitResponse(_)) => {
+                pb::BleFrameType::BilateralCommitResponse as i32
+            }
+            Some(pb::envelope::Payload::BilateralBearerPrepared(_)) => {
+                pb::BleFrameType::BilateralBearerPrepared as i32
+            }
+            Some(pb::envelope::Payload::BilateralBearerProceed(_)) => {
+                pb::BleFrameType::BilateralBearerProceed as i32
+            }
+            Some(pb::envelope::Payload::UniversalTx(tx)) => {
+                if let Some(op) = tx.ops.first() {
+                    if let Some(pb::universal_op::Kind::Invoke(inv)) = op.kind.as_ref() {
+                        if inv.method == "bilateral.prepare" {
+                            return pb::BleFrameType::BilateralPrepare as i32;
+                        }
+                        if inv.method == "bilateral.confirm" {
+                            return pb::BleFrameType::BilateralConfirm as i32;
+                        }
+                        if inv.method == "bilateral.commit" {
+                            return pb::BleFrameType::BilateralCommit as i32;
+                        }
+                    }
+                }
+                pb::BleFrameType::Unspecified as i32
+            }
+            _ => pb::BleFrameType::Unspecified as i32,
+        };
+    }
+
+    if let Ok(env) = pb::BilateralMessageEnvelope::decode(raw) {
+        if let Some(msg) = env.msg {
+            return match msg {
+                pb::bilateral_message_envelope::Msg::ChainHistoryRequest(_) => {
+                    pb::BleFrameType::ChainHistoryRequest as i32
+                }
+                pb::bilateral_message_envelope::Msg::ChainHistoryResponse(_) => {
+                    pb::BleFrameType::ChainHistoryResponse as i32
+                }
+                pb::bilateral_message_envelope::Msg::ReconciliationRequest(_) => {
+                    pb::BleFrameType::ReconciliationRequest as i32
+                }
+                pb::bilateral_message_envelope::Msg::ReconciliationResponse(_) => {
+                    pb::BleFrameType::ReconciliationResponse as i32
+                }
+                _ => pb::BleFrameType::Unspecified as i32,
+            };
+        }
+    }
+
+    pb::BleFrameType::Unspecified as i32
+}
+
+/// Frame types whose outbound reply must be `BleChunk`-framed rather than pushed raw.
+///
+/// A frame needs chunking when its payload can exceed a single BLE notification, or
+/// when the peer recovers the frame type from the `BleChunk` header (so a raw frame
+/// would be misdecoded). `BilateralBearerPrepared` carries the full `AnchorDisclosure`
+/// (anchor bundle, partition pubkey up to 4 KiB, verifier slot + chip static pubkey)
+/// and readily exceeds the unframed budget — sent raw it truncates and the first-transfer
+/// round-trip fails before the protocol runs. `BilateralBearerProceed` is small but is
+/// chunk-framed for symmetry so the sender recovers its frame type from the header.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub(crate) fn ble_frame_needs_chunking(frame_type: i32) -> bool {
+    frame_type == pb::BleFrameType::BilateralPrepareReject as i32
+        || frame_type == pb::BleFrameType::BilateralCommit as i32
+        || frame_type == pb::BleFrameType::BilateralCommitResponse as i32
+        || frame_type == pb::BleFrameType::BilateralConfirm as i32
+        || frame_type == pb::BleFrameType::BilateralBearerPrepared as i32
+        || frame_type == pb::BleFrameType::BilateralBearerProceed as i32
+        // Path-B relay reply (chip->receiver counter read): the REQUEST is chunked via
+        // `queue_follow_up_chunks`, so the REPLY must be BleChunk-framed too — otherwise
+        // the receiver decodes the raw `TropicSpiRelayPacket` as a `BleChunk` and fails
+        // (`invalid tag value: 0`), dropping the reply and timing out the counter read.
+        || frame_type == pb::BleFrameType::TropicSpiRelay as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_envelope() -> pb::Envelope {
+        pb::Envelope {
+            version: 3,
+            headers: Some(pb::Headers {
+                device_id: vec![1; 32],
+                chain_tip: vec![2; 32],
+                genesis_hash: vec![3; 32],
+                seq: 0,
+            }),
+            message_id: vec![4; 16],
+            payload: None,
+        }
+    }
+
+    fn encode(env: pb::Envelope) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        env.encode(&mut bytes).expect("encode envelope");
+        bytes
+    }
+
+    fn build_bilateral_confirm_envelope() -> Vec<u8> {
+        let mut env = base_envelope();
+        env.payload = Some(pb::envelope::Payload::UniversalTx(pb::UniversalTx {
+            ops: vec![pb::UniversalOp {
+                op_id: Some(pb::Hash32 { v: vec![5; 32] }),
+                actor: vec![1; 32],
+                genesis_hash: vec![3; 32],
+                kind: Some(pb::universal_op::Kind::Invoke(pb::Invoke {
+                    method: "bilateral.confirm".to_string(),
+                    args: Some(pb::ArgPack {
+                        body: vec![9, 9, 9],
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })),
+            }],
+            atomic: true,
+        }));
+        encode(env)
+    }
+
+    fn build_bilateral_bearer_prepared_envelope(partition_pk_len: usize) -> Vec<u8> {
+        let mut env = base_envelope();
+        env.payload = Some(pb::envelope::Payload::BilateralBearerPrepared(
+            pb::BilateralBearerPrepared {
+                commitment_hash: Some(pb::Hash32 { v: vec![5; 32] }),
+                anchor_disclosure: Some(pb::AnchorDisclosure {
+                    bundle: vec![6; 32],
+                    anchor_id: vec![7; 32],
+                    enrolled_counter: 42,
+                    partition_pk: vec![8; partition_pk_len],
+                    policy_hash: vec![9; 32],
+                    verifier_slot: 1,
+                    verifier_slot_present: true,
+                    chip_static_pubkey: vec![10; 32],
+                }),
+            },
+        ));
+        encode(env)
+    }
+
+    fn build_bilateral_bearer_proceed_envelope() -> Vec<u8> {
+        let mut env = base_envelope();
+        env.payload = Some(pb::envelope::Payload::BilateralBearerProceed(
+            pb::BilateralBearerProceed {
+                commitment_hash: Some(pb::Hash32 { v: vec![5; 32] }),
+                receiver_signature: vec![11; 64],
+            },
+        ));
+        encode(env)
+    }
+
+    #[test]
+    fn strips_envelope_v3_framing_only_when_present() {
+        let raw = build_bilateral_confirm_envelope();
+        let mut framed = vec![0x03];
+        framed.extend_from_slice(&raw);
+        assert_eq!(strip_envelope_v3_framing(&raw), raw.as_slice());
+        assert_eq!(strip_envelope_v3_framing(&framed), raw.as_slice());
+    }
+
+    #[test]
+    fn detects_bilateral_confirm_for_raw_and_framed_envelopes() {
+        let raw = build_bilateral_confirm_envelope();
+        let mut framed = vec![0x03];
+        framed.extend_from_slice(&raw);
+        assert_eq!(
+            detect_ble_frame_type_from_bytes(&raw),
+            pb::BleFrameType::BilateralConfirm as i32
+        );
+        assert_eq!(
+            detect_ble_frame_type_from_bytes(&framed),
+            pb::BleFrameType::BilateralConfirm as i32
+        );
+    }
+
+    #[test]
+    fn detects_bilateral_bearer_frames_for_raw_and_framed_envelopes() {
+        let prepared = build_bilateral_bearer_prepared_envelope(64);
+        let mut prepared_framed = vec![0x03];
+        prepared_framed.extend_from_slice(&prepared);
+        assert_eq!(
+            detect_ble_frame_type_from_bytes(&prepared),
+            pb::BleFrameType::BilateralBearerPrepared as i32
+        );
+        assert_eq!(
+            detect_ble_frame_type_from_bytes(&prepared_framed),
+            pb::BleFrameType::BilateralBearerPrepared as i32
+        );
+
+        let proceed = build_bilateral_bearer_proceed_envelope();
+        let mut proceed_framed = vec![0x03];
+        proceed_framed.extend_from_slice(&proceed);
+        assert_eq!(
+            detect_ble_frame_type_from_bytes(&proceed),
+            pb::BleFrameType::BilateralBearerProceed as i32
+        );
+        assert_eq!(
+            detect_ble_frame_type_from_bytes(&proceed_framed),
+            pb::BleFrameType::BilateralBearerProceed as i32
+        );
+    }
+
+    #[test]
+    fn bearer_frames_are_chunking_eligible() {
+        // Both bearer frames must be BleChunk-framed on the outbound reply path.
+        assert!(ble_frame_needs_chunking(
+            pb::BleFrameType::BilateralBearerPrepared as i32
+        ));
+        assert!(ble_frame_needs_chunking(
+            pb::BleFrameType::BilateralBearerProceed as i32
+        ));
+        // Pre-existing large frames stay eligible; a small unframed frame stays ineligible.
+        assert!(ble_frame_needs_chunking(
+            pb::BleFrameType::BilateralConfirm as i32
+        ));
+        assert!(ble_frame_needs_chunking(
+            pb::BleFrameType::TropicSpiRelay as i32
+        ));
+        assert!(!ble_frame_needs_chunking(
+            pb::BleFrameType::BilateralPrepareResponse as i32
+        ));
+        assert!(!ble_frame_needs_chunking(
+            pb::BleFrameType::Unspecified as i32
+        ));
+    }
+
+    #[test]
+    fn large_bearer_prepared_disclosure_is_chunked_not_truncated() {
+        // A realistic first-transfer disclosure (partition_pk up to 4 KiB) exceeds a single
+        // BLE notification. Prove it is (a) chunk-eligible and (b) actually split by the frame
+        // coordinator into >1 chunk, each stamped with the bearer frame type — so the receiver
+        // reassembles the full disclosure instead of a truncated one.
+        let prepared = build_bilateral_bearer_prepared_envelope(1024);
+        assert!(
+            prepared.len() > 512,
+            "test disclosure should exceed one notification, got {}",
+            prepared.len()
+        );
+        assert!(ble_frame_needs_chunking(
+            pb::BleFrameType::BilateralBearerPrepared as i32
+        ));
+
+        let coord = crate::bluetooth::BleFrameCoordinator::new([7u8; 32]);
+        let chunks = coord
+            .encode_message(pb::BleFrameType::BilateralBearerPrepared, &prepared)
+            .expect("encode_message chunks bearer-prepared");
+        assert!(
+            chunks.len() > 1,
+            "large disclosure must span multiple chunks, got {}",
+            chunks.len()
+        );
+        for chunk_bytes in &chunks {
+            let chunk = pb::BleChunk::decode(chunk_bytes.as_slice()).expect("decode BleChunk");
+            let header = chunk.header.expect("chunk header present");
+            assert_eq!(
+                header.frame_type,
+                pb::BleFrameType::BilateralBearerPrepared as i32
+            );
+        }
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/mod.rs
@@ -13,6 +13,7 @@ pub mod bilateral_envelope;
 pub mod bilateral_session;
 pub mod bilateral_transport_adapter;
 pub mod ble_frame_coordinator;
+pub mod frame_classify;
 pub mod pairing_orchestrator;
 pub mod tropic_relay;
 

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/jni/unified_protobuf_bridge.rs
@@ -64,6 +64,9 @@ use crate::jni::bilateral_poll::{
 // these `use`s restore the android+bluetooth build, which had not been recompiled since).
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use crate::bluetooth::bilateral_transport_adapter::BleTransportDelegate;
+use crate::bluetooth::frame_classify::{
+    ble_frame_needs_chunking, detect_ble_frame_type_from_bytes, strip_envelope_v3_framing,
+};
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use crate::jni::state::{parse_hex_32, DEVICE_ID_TO_ADDR};
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
@@ -1283,6 +1286,16 @@ fn process_envelope_v3_impl(
                 }
                 Some(pb::envelope::Payload::BilateralCommitResponse(_)) => {
                     Some(pb::BleFrameType::BilateralCommitResponse)
+                }
+                // §21 first-transfer round-trip: a complete-envelope (unchunked)
+                // BilateralBearerPrepared / BilateralBearerProceed must route to the
+                // BLE adapter (admit-disclosure+FROM-read / commit) instead of the core
+                // bridge, exactly like the other bilateral frames above.
+                Some(pb::envelope::Payload::BilateralBearerPrepared(_)) => {
+                    Some(pb::BleFrameType::BilateralBearerPrepared)
+                }
+                Some(pb::envelope::Payload::BilateralBearerProceed(_)) => {
+                    Some(pb::BleFrameType::BilateralBearerProceed)
                 }
                 Some(pb::envelope::Payload::UniversalTx(tx)) => {
                     // Detect bilateral.confirm invoke for 3-step protocol
@@ -2723,70 +2736,11 @@ pub(crate) fn send_ble_chunks_via_unified<'a>(
     Ok(result.z().unwrap_or(false))
 }
 
-fn strip_envelope_v3_framing(bytes: &[u8]) -> &[u8] {
-    if bytes.first() == Some(&0x03) {
-        &bytes[1..]
-    } else {
-        bytes
-    }
-}
-
-fn detect_ble_frame_type_from_bytes(bytes: &[u8]) -> i32 {
-    let raw = strip_envelope_v3_framing(bytes);
-
-    if let Ok(env) = crate::envelope::from_canonical_bytes(raw) {
-        return match env.payload {
-            Some(pb::envelope::Payload::BilateralPrepareResponse(_)) => {
-                pb::BleFrameType::BilateralPrepareResponse as i32
-            }
-            Some(pb::envelope::Payload::BilateralPrepareReject(_)) => {
-                pb::BleFrameType::BilateralPrepareReject as i32
-            }
-            Some(pb::envelope::Payload::BilateralCommitResponse(_)) => {
-                pb::BleFrameType::BilateralCommitResponse as i32
-            }
-            Some(pb::envelope::Payload::UniversalTx(tx)) => {
-                if let Some(op) = tx.ops.first() {
-                    if let Some(pb::universal_op::Kind::Invoke(inv)) = op.kind.as_ref() {
-                        if inv.method == "bilateral.prepare" {
-                            return pb::BleFrameType::BilateralPrepare as i32;
-                        }
-                        if inv.method == "bilateral.confirm" {
-                            return pb::BleFrameType::BilateralConfirm as i32;
-                        }
-                        if inv.method == "bilateral.commit" {
-                            return pb::BleFrameType::BilateralCommit as i32;
-                        }
-                    }
-                }
-                pb::BleFrameType::Unspecified as i32
-            }
-            _ => pb::BleFrameType::Unspecified as i32,
-        };
-    }
-
-    if let Ok(env) = pb::BilateralMessageEnvelope::decode(raw) {
-        if let Some(msg) = env.msg {
-            return match msg {
-                pb::bilateral_message_envelope::Msg::ChainHistoryRequest(_) => {
-                    pb::BleFrameType::ChainHistoryRequest as i32
-                }
-                pb::bilateral_message_envelope::Msg::ChainHistoryResponse(_) => {
-                    pb::BleFrameType::ChainHistoryResponse as i32
-                }
-                pb::bilateral_message_envelope::Msg::ReconciliationRequest(_) => {
-                    pb::BleFrameType::ReconciliationRequest as i32
-                }
-                pb::bilateral_message_envelope::Msg::ReconciliationResponse(_) => {
-                    pb::BleFrameType::ReconciliationResponse as i32
-                }
-                _ => pb::BleFrameType::Unspecified as i32,
-            };
-        }
-    }
-
-    pb::BleFrameType::Unspecified as i32
-}
+// BLE frame-type classification (`detect_ble_frame_type_from_bytes`,
+// `strip_envelope_v3_framing`) and chunking eligibility (`ble_frame_needs_chunking`)
+// live in the host-compiled `crate::bluetooth::frame_classify` module so they are unit
+// tested in host CI (this JNI shim only compiles for `target_os = "android"`). They are
+// imported at the top of this module; this shim only routes and frames.
 
 #[no_mangle]
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
@@ -3116,16 +3070,7 @@ pub extern "system" fn Java_com_dsm_wallet_bridge_UnifiedNativeApi_processIncomi
                     continue;
                 }
                 let frame_type = outbound.frame_type as i32;
-                let needs_chunking = frame_type
-                    == crate::generated::BleFrameType::BilateralPrepareReject as i32
-                    || frame_type == crate::generated::BleFrameType::BilateralCommit as i32
-                    || frame_type == crate::generated::BleFrameType::BilateralCommitResponse as i32
-                    || frame_type == crate::generated::BleFrameType::BilateralConfirm as i32
-                    // Path-B relay reply (chip->receiver counter read): the REQUEST is chunked via
-                    // `queue_follow_up_chunks`, so the REPLY must be BleChunk-framed too — otherwise
-                    // the receiver decodes the raw `TropicSpiRelayPacket` as a `BleChunk` and fails
-                    // (`invalid tag value: 0`), dropping the reply and timing out the counter read.
-                    || frame_type == crate::generated::BleFrameType::TropicSpiRelay as i32;
+                let needs_chunking = ble_frame_needs_chunking(frame_type);
 
                 if needs_chunking {
                     use_reliable_write = true;


### PR DESCRIPTION
First of the hardware-activation-readiness fixes: make the §21 first-transfer bearer round-trip actually survive a real two-phone run. Pure code, no hardware, no owner-gated flips.

## The defects (both from #567, both silent)

`BilateralBearerPrepared` (tag **110**) and `BilateralBearerProceed` (tag **111**) were unrecognized at two decision points:

1. **dsm-core canonical validator** — `ALLOWED_PAYLOAD_TAGS` stopped at 106, so `validate_canonical_envelope_v3_bytes` rejected **every** bearer envelope as an "unknown Envelope field". The receiver dropped bearer frames before routing — the round-trip could never complete. (107/108/109 stay excluded by design; a test pins 107 rejection.)
2. **dsm_sdk JNI bridge** — bearer payloads were missing from the inbound classifier, the frame-type detector, and the outbound `needs_chunking` allowlist. A full-disclosure `BilateralBearerPrepared` (~454 B+, `partition_pk` up to 4 KiB) would be sent **unframed and truncated**.

## Change
- Add 110/111 to `ALLOWED_PAYLOAD_TAGS` + regression test `strict_decode_accepts_bearer_round_trip_payloads`.
- Add both bearer frames to the JNI inbound classifier, `detect_ble_frame_type_from_bytes`, and `needs_chunking`.
- Relocate the pure classifier/chunking helpers into a new **host-compiled** `bluetooth::frame_classify` module so the routing + anti-truncation invariants get host CI coverage (the JNI shim only compiles for `target_os = "android"`, so its tests never ran).

## Verification
- dsm-core envelope tests **18/18** (incl. bearer-accept + preserved 107-reject).
- `frame_classify` host tests **5/5** under both default and `jni,bluetooth` features: classifies confirm + both bearer frames (raw and v3-framed), chunking eligibility, and a large disclosure splitting into multiple `BleChunk` frames instead of truncating.
- android arm64 `--lib` cross-compile clean; clippy clean on both crates.

Note: `Cargo.lock` churn intentionally excluded (see the separate stale-nested-lock follow-up).
