### PR TITLE
feat(offline-bearer): step 4 — recover() observation seam + host cancel policy (§28-strict)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/anchor/appliance_client.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/anchor/appliance_client.rs
@@ -11,7 +11,7 @@
 
 use prost::Message;
 
-use anchor_core::appliance::{Appliance, ApplianceError};
+use anchor_core::appliance::{Appliance, ApplianceError, RecoverOutcome};
 use anchor_core::enrollment::{birth, BirthInputs};
 use anchor_core::root_advance::Transition;
 use anchor_core::sig::WotsBlake3;
@@ -69,6 +69,65 @@ pub trait AnchorAppliance {
     fn cancel(&mut self) -> Result<(), DsmError>;
     /// The receiver pin material for this anchor (pinned at admission).
     fn pin(&self) -> AnchorPin;
+
+    /// `OP_RECOVER` (§27) — OBSERVATION ONLY. Report the appliance's recovery state after a power
+    /// loss / host re-attach. This NEVER cancels, commits, moves the counter, or erases a release:
+    /// the host decides what to do from the returned [`RecoverOutcome`] (see [`recovery_action`]).
+    /// The default is the fail-safe `DowngradeOnline` for appliances that have not yet implemented
+    /// on-device recovery — never auto-cancel an appliance whose true state is unknown.
+    fn recover(&mut self) -> Result<RecoverOutcome, DsmError> {
+        Ok(RecoverOutcome::DowngradeOnline)
+    }
+}
+
+/// The host's policy decision after OBSERVING a [`RecoverOutcome`]. `recover()` observes; this
+/// decides; the caller executes. The only state that is auto-cancelled is an orphaned uncommitted
+/// `Prepared` (no owning session, counter not moved). A committed release is re-emitted, never
+/// erased (§28); anything ambiguous downgrades online.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RecoveryAction {
+    /// Appliance is `Ready` at its active root — nothing to do.
+    Ready,
+    /// Orphaned uncommitted `Prepared` with no owning session — cancel it back to `Ready`. The
+    /// counter has not moved, so nothing is lost.
+    CancelOrphanedPrepared,
+    /// A `Prepared` record an in-flight/durable session still owns — leave it for that owner to
+    /// complete or cancel; do NOT touch it.
+    LeavePreparedForOwner,
+    /// A committed successor is pending — re-emit + finalize the SAME release; never cancel/erase.
+    ReemitCommitted,
+    /// Ambiguous, mismatched, exhausted, or an appliance without on-device recovery — resolve via
+    /// online reconciliation. Never guess.
+    DowngradeOnline,
+}
+
+/// Host recovery policy (§27/§28): a PURE decision from an observed [`RecoverOutcome`] plus whether
+/// an in-flight/durable session still owns the prepared bearer.
+///
+/// Guardrails (owner-mandated): auto-cancel happens ONLY for an orphaned uncommitted `Prepared`;
+/// `Committed`/`ReemitCommitted` is NEVER cancelled or erased (it is re-emitted or resolved online);
+/// a possibly-counter-moved or mismatched state downgrades online rather than guessing.
+#[must_use]
+pub fn recovery_action(outcome: RecoverOutcome, prepared_owned_by_session: bool) -> RecoveryAction {
+    match outcome {
+        RecoverOutcome::Accept(_) => RecoveryAction::Ready,
+        // A committed successor carrying hᵢ₊₁: re-emit + finalize the SAME release. NEVER cancel or
+        // erase — the counter may have moved.
+        RecoverOutcome::ReemitCommitted(_) => RecoveryAction::ReemitCommitted,
+        // `Prepared`, uncommitted, counter NOT moved (recover only returns these two for a prepared
+        // record whose counter still sits at uᵢ). Cancel ONLY when no session owns it.
+        RecoverOutcome::AcceptPreparedCanComplete | RecoverOutcome::OnlineCancelOrResolve => {
+            if prepared_owned_by_session {
+                RecoveryAction::LeavePreparedForOwner
+            } else {
+                RecoveryAction::CancelOrphanedPrepared
+            }
+        }
+        // Counter mismatch, exhausted, or any ambiguity: online reconciliation, never a guess.
+        RecoverOutcome::DowngradeOnline
+        | RecoverOutcome::FailClosed
+        | RecoverOutcome::ExhaustedOnlineOnly => RecoveryAction::DowngradeOnline,
+    }
 }
 
 // --- in-process secure-element mock (silicon only; crypto is real) ---
@@ -241,6 +300,12 @@ impl AnchorAppliance for InProcessAnchorAppliance {
         self.app.cancel().map_err(map_err)
     }
 
+    fn recover(&mut self) -> Result<RecoverOutcome, DsmError> {
+        // Pure observation — delegates to the anchor-core §27 recovery classifier, which never
+        // cancels or signs a new release. The host applies `recovery_action` to decide.
+        Ok(self.app.recover())
+    }
+
     fn pin(&self) -> AnchorPin {
         AnchorPin {
             bundle: self.app.bundle,
@@ -268,6 +333,68 @@ mod tests {
     const H0: u32 = 100;
     const GENESIS: [u8; 32] = [0x11; 32];
     const NEXT_ROOT: [u8; 32] = [0x22; 32];
+
+    /// The host recovery policy (§27/§28): `recover()` OBSERVES, `recovery_action` DECIDES. Auto-cancel
+    /// is reserved for an orphaned uncommitted `Prepared`; `Committed` is never cancelled/erased;
+    /// anything ambiguous downgrades online. Ownership only matters for the `Prepared` states.
+    #[test]
+    fn recovery_action_cancels_only_orphaned_uncommitted_prepared() {
+        let root = [7u8; 32];
+
+        // Ready — nothing to do, regardless of ownership.
+        assert_eq!(
+            recovery_action(RecoverOutcome::Accept(root), false),
+            RecoveryAction::Ready
+        );
+        assert_eq!(
+            recovery_action(RecoverOutcome::Accept(root), true),
+            RecoveryAction::Ready
+        );
+
+        // Committed — re-emit, NEVER cancel/erase, regardless of ownership (§28).
+        assert_eq!(
+            recovery_action(RecoverOutcome::ReemitCommitted(root), false),
+            RecoveryAction::ReemitCommitted
+        );
+        assert_eq!(
+            recovery_action(RecoverOutcome::ReemitCommitted(root), true),
+            RecoveryAction::ReemitCommitted
+        );
+
+        // Prepared (uncommitted, counter not moved) with NO owning session — cancel to Ready.
+        assert_eq!(
+            recovery_action(RecoverOutcome::AcceptPreparedCanComplete, false),
+            RecoveryAction::CancelOrphanedPrepared
+        );
+        assert_eq!(
+            recovery_action(RecoverOutcome::OnlineCancelOrResolve, false),
+            RecoveryAction::CancelOrphanedPrepared
+        );
+
+        // Prepared with an OWNING in-flight/durable session — leave it, do NOT cancel.
+        assert_eq!(
+            recovery_action(RecoverOutcome::AcceptPreparedCanComplete, true),
+            RecoveryAction::LeavePreparedForOwner
+        );
+        assert_eq!(
+            recovery_action(RecoverOutcome::OnlineCancelOrResolve, true),
+            RecoveryAction::LeavePreparedForOwner
+        );
+
+        // Counter mismatch / exhausted / ambiguous — online reconciliation, never a guess.
+        assert_eq!(
+            recovery_action(RecoverOutcome::DowngradeOnline, false),
+            RecoveryAction::DowngradeOnline
+        );
+        assert_eq!(
+            recovery_action(RecoverOutcome::FailClosed, false),
+            RecoveryAction::DowngradeOnline
+        );
+        assert_eq!(
+            recovery_action(RecoverOutcome::ExhaustedOnlineOnly, false),
+            RecoveryAction::DowngradeOnline
+        );
+    }
     const POLICY: [u8; 32] = [0x33; 32];
     const RECIP: [u8; 32] = [0x44; 32];
     const RCHAL: [u8; 32] = [0x55; 32];

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/anchor/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/anchor/mod.rs
@@ -15,6 +15,8 @@
 
 pub mod appliance_client;
 
+pub use anchor_core::appliance::RecoverOutcome;
 pub use appliance_client::{
-    AnchorAppliance, AnchorPin, ApplianceStatus, BirthConfig, InProcessAnchorAppliance,
+    recovery_action, AnchorAppliance, AnchorPin, ApplianceStatus, BirthConfig,
+    InProcessAnchorAppliance, RecoveryAction,
 };

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -1798,6 +1798,39 @@ impl CoreSDK {
         Ok(())
     }
 
+    /// §27/§28 host recovery seam. OBSERVE the sender appliance's recovery state at a re-attach
+    /// (process restart / power loss) via [`AnchorAppliance::recover`], then apply the host cancel
+    /// policy ([`crate::anchor::recovery_action`]): cancel ONLY an orphaned uncommitted `Prepared` —
+    /// one with no in-flight/durable session owning it and whose counter has not moved. A committed
+    /// release is NEVER cancelled or erased here (it is re-emitted or resolved online); a mismatch
+    /// downgrades online. `recover()` observes; this method decides and executes ONLY the
+    /// orphaned-`Prepared` cancel.
+    ///
+    /// `prepared_owned_by_session` is supplied by the caller — the bilateral handler knows whether an
+    /// in-flight session still holds the matching prepared bearer. Pass `false` at a cold re-attach
+    /// where the in-memory sessions are gone. Returns the decided [`crate::anchor::RecoveryAction`].
+    pub fn resolve_prepared_on_reattach(
+        &self,
+        prepared_owned_by_session: bool,
+    ) -> Result<crate::anchor::RecoveryAction, DsmError> {
+        let mut guard = self.anchor_appliance.lock();
+        let Some(app) = guard.as_mut() else {
+            // No appliance attached yet -> nothing is prepared -> Ready.
+            return Ok(crate::anchor::RecoveryAction::Ready);
+        };
+        let outcome = app.recover()?;
+        let action = crate::anchor::recovery_action(outcome, prepared_owned_by_session);
+        if action == crate::anchor::RecoveryAction::CancelOrphanedPrepared {
+            // Host policy executes the cancel — `recover()` did not. Only an orphaned uncommitted
+            // Prepared reaches here (no owning session, counter not moved), so nothing is lost.
+            app.cancel()?;
+            log::info!(
+                "[offline-bearer] re-attach cancelled an orphaned prepared bearer (appliance → Ready)"
+            );
+        }
+        Ok(action)
+    }
+
     /// Single-shot producer: PREPARE then immediately COMMIT (the non-interactive path, used where
     /// the receiver's FROM read is not interleaved — e.g. the current single-confirm seam, which
     /// stays fail-closed on the missing FROM read). The interactive Counter-Positioned Commit flow
@@ -3070,6 +3103,75 @@ mod tests {
         assert_eq!(
             prepared2.anchor_counter, 1,
             "the next transfer starts from the advanced FROM coordinate uᵢ+1"
+        );
+    }
+
+    /// §27/§28 host recovery seam (Step 4). At a re-attach the host cancels ONLY an orphaned
+    /// uncommitted `Prepared` (no owning session) and moves no counter doing so; a `Prepared` an
+    /// in-flight session still owns is left untouched. `recover()` observes; the host decides.
+    #[test]
+    #[serial]
+    fn reattach_cancels_orphaned_prepared_not_owned_and_moves_no_counter() {
+        use crate::anchor::RecoveryAction;
+        use dsm::types::device_state::DeviceState;
+
+        let sdk = test_sdk();
+        {
+            let ds = DeviceState::new([9u8; 32], sdk.device_info.device_id, vec![0u8; 64], 256);
+            sdk.state_machine.lock().set_device_head(ds);
+        }
+        let recipient = [4u8; 32];
+
+        // No appliance attached yet -> nothing prepared -> Ready.
+        assert_eq!(
+            sdk.resolve_prepared_on_reattach(false).expect("reattach"),
+            RecoveryAction::Ready
+        );
+
+        // Drive the appliance to PREPARED (the FROM coordinate uᵢ is exposed; NO counter move).
+        let prepared = sdk
+            .prepare_offline_bearer_release(
+                [1u8; 32],
+                recipient,
+                [2u8; 32],
+                [9u8; 32],
+                [3u8; 32],
+                0,
+                vec![0xAB],
+                [0x55u8; 32],
+            )
+            .expect("prepare");
+        assert_eq!(prepared.anchor_counter, 0, "PREPARE moved no counter");
+
+        // An in-flight session OWNS this prepared bearer -> the host must NOT cancel it.
+        assert_eq!(
+            sdk.resolve_prepared_on_reattach(true).expect("owned"),
+            RecoveryAction::LeavePreparedForOwner
+        );
+
+        // Orphaned (the owning session was lost on restart) -> cancel it back to Ready.
+        assert_eq!(
+            sdk.resolve_prepared_on_reattach(false).expect("orphan"),
+            RecoveryAction::CancelOrphanedPrepared
+        );
+
+        // The appliance is Ready again and NO counter moved: a fresh transfer still starts at uᵢ=0,
+        // so a lost/abandoned prepare does not strand future sends (and burned no counter).
+        let prepared2 = sdk
+            .prepare_offline_bearer_release(
+                [1u8; 32],
+                recipient,
+                [2u8; 32],
+                [9u8; 32],
+                [3u8; 32],
+                0,
+                vec![0xCD],
+                [0x66u8; 32],
+            )
+            .expect("prepare after cancel");
+        assert_eq!(
+            prepared2.anchor_counter, 0,
+            "cancel moved no counter — the FROM coordinate uᵢ is unchanged, future sends not stranded"
         );
     }
 


### PR DESCRIPTION
Step 4 (final): the host recovery seam for abandoned prepared state. **Stacked on #572** (→ #571). GitHub retargets down the stack as each merges.

Honors the tightening: **`recover()` observes and reports only — it never cancels.** The host decides; the caller cancels *only* an orphaned uncommitted `Prepared`. Nothing here cancels or erases a committed / possibly-counter-moved release.

## Change
- `AnchorAppliance::recover() -> RecoverOutcome` — observation only (never cancels/commits/moves the counter). Fail-safe **default `DowngradeOnline`** so appliances without on-device recovery (incl. the excluded-crate `UsbAnchorAppliance`) keep compiling and never auto-cancel an unknown state. `InProcessAnchorAppliance` delegates to anchor-core's §27 classifier.
- `recovery_action(outcome, prepared_owned_by_session) -> RecoveryAction` — **pure** host policy:
  - orphaned uncommitted `Prepared` (counter not moved, no owning session) → `CancelOrphanedPrepared`
  - `Prepared` an in-flight/durable session owns → `LeavePreparedForOwner`
  - `Committed` → `ReemitCommitted` (never cancel/erase, §28)
  - mismatch / exhausted / ambiguous / unknown → `DowngradeOnline` (never guess)
- `CoreSDK::resolve_prepared_on_reattach(prepared_owned_by_session)` — observe via `recover()`, decide via `recovery_action`, execute **only** the orphaned-`Prepared` cancel.

## Tests (your Step-4 list)
- `recovery_action` across **every** `RecoverOutcome` × owned/not-owned — the full policy table (orphaned→cancel; owned→leave; committed→re-emit not cancel; mismatch/exhausted→online).
- re-attach on a real in-process appliance: **owned `Prepared` untouched**, **orphaned `Prepared` cancelled** to Ready, **no counter moved**, and a fresh transfer still starts at uᵢ=0 (a lost/abandoned prepare doesn't strand future sends or burn the counter).

Committed-release-survives-restart / `ReemitCommitted` behavior is proven at the policy layer here (never cancel/erase) and at the appliance layer by anchor-core's own recover tests.

## Verification
appliance_client 3/3, core_sdk offline-bearer 11/11; clippy + android arm64 `--lib` cross-compile clean.
