### PR TITLE
chore: gitignore Pico firmware build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,8 @@ rules/caveman-*.md
 skills/
 desktop-extensions/
 WEBSITE_ROADMAP.md
+
+# Firmware build outputs (flash artifacts) — never committed; curated bench evidence lives in
+# docs/bench-proofs/ only when explicitly added (owner rule 2026-07-09).
+crates/dsm-anchor-pico/*.uf2
+crates/dsm-anchor-pico/*.elf


### PR DESCRIPTION
Owner rule (2026-07-09): build outputs are never committed. Ignores `crates/dsm-anchor-pico/*.uf2` / `*.elf` so a root-level `git add -A` can never sweep flash artifacts in. Curated bench evidence (docs/bench-proofs/) is unaffected — added explicitly when intended.
