### PR TITLE
feat(offline-bearer): surface anchor UX signals — connect-device error + TOFU pin events

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -3833,6 +3833,7 @@ impl BilateralBleHandler {
     async fn admit_anchor_disclosure(
         &self,
         sender_device_id: [u8; 32],
+        commitment_hash: [u8; 32],
         d: &generated::AnchorDisclosure,
     ) {
         let contact_verified = {
@@ -3872,20 +3873,62 @@ impl BilateralBleHandler {
                     &disclosed,
                     existing.as_ref(),
                 ) {
-                    crate::bluetooth::anchor_accept::PinAdmitDecision::Admit(e) => match store.admit(e) {
-                        Ok(()) => info!(
-                            "[BILATERAL] fused anchor PINNED for {} (first-transfer TOFU admit)",
-                            bytes_to_base32(&sender_device_id[..8])
-                        ),
-                        Err(err) => warn!(
-                            "[BILATERAL] fused anchor admit failed (continuing fail-closed): {err}"
-                        ),
-                    },
+                    crate::bluetooth::anchor_accept::PinAdmitDecision::Admit(e) => {
+                        let anchor_id = e.pin.anchor_id;
+                        match store.admit(e) {
+                            Ok(()) => {
+                                info!(
+                                    "[BILATERAL] fused anchor PINNED for {} (first-transfer TOFU admit)",
+                                    bytes_to_base32(&sender_device_id[..8])
+                                );
+                                // Stage 4 Slice 3 (signal b): surface the first-transfer trust so the
+                                // receiver UI can say "trusted anchor for <contact>". The message
+                                // carries the Base32 anchor id.
+                                self.emit_event(&generated::BilateralEventNotification {
+                                    event_type:
+                                        generated::BilateralEventType::BilateralEventAnchorPinned
+                                            .into(),
+                                    counterparty_device_id: sender_device_id.to_vec(),
+                                    commitment_hash: commitment_hash.to_vec(),
+                                    transaction_hash: None,
+                                    amount: None,
+                                    token_id: None,
+                                    status: "anchor_pinned_first_transfer".to_string(),
+                                    message: bytes_to_base32(&anchor_id),
+                                    sender_ble_address: None,
+                                    failure_reason: None,
+                                });
+                            }
+                            Err(err) => warn!(
+                                "[BILATERAL] fused anchor admit failed (continuing fail-closed): {err}"
+                            ),
+                        }
+                    }
                     crate::bluetooth::anchor_accept::PinAdmitDecision::NoChange => {}
-                    crate::bluetooth::anchor_accept::PinAdmitDecision::Reject(reason) => warn!(
-                        "[BILATERAL] fused anchor disclosure REJECTED for {} ({reason}); keeping the pinned anchor",
-                        bytes_to_base32(&sender_device_id[..8])
-                    ),
+                    crate::bluetooth::anchor_accept::PinAdmitDecision::Reject(reason) => {
+                        // A pinned anchor's identity changed on a later transfer — a security event,
+                        // not a routine failure. The transfer is ALREADY rejected fail-closed by the
+                        // acceptance predicate (it verifies against the PINNED anchor) and the pinned
+                        // anchor is kept; here we only SURFACE it (owner directive). The log line is
+                        // the audit record; the event drives a prominent security warning in the UI.
+                        warn!(
+                            "[BILATERAL] fused anchor disclosure REJECTED for {} ({reason}); keeping the pinned anchor",
+                            bytes_to_base32(&sender_device_id[..8])
+                        );
+                        self.emit_event(&generated::BilateralEventNotification {
+                            event_type: generated::BilateralEventType::BilateralEventAnchorChanged
+                                .into(),
+                            counterparty_device_id: sender_device_id.to_vec(),
+                            commitment_hash: commitment_hash.to_vec(),
+                            transaction_hash: None,
+                            amount: None,
+                            token_id: None,
+                            status: "anchor_identity_changed".to_string(),
+                            message: reason.to_string(),
+                            sender_ble_address: None,
+                            failure_reason: None,
+                        });
+                    }
                 }
             }
             (false, _, _) => warn!(
@@ -4579,7 +4622,8 @@ impl BilateralBleHandler {
             // Admission is a memory of what to verify — acceptance is the predicate below.
             let sender_device_id = session.counterparty_device_id;
             if let Some(d) = confirm_request.anchor_disclosure.as_ref() {
-                self.admit_anchor_disclosure(sender_device_id, d).await;
+                self.admit_anchor_disclosure(sender_device_id, commitment_hash, d)
+                    .await;
             }
             let pin = crate::bridge::anchor_enrollment_store()
                 .and_then(|s| s.get(&sender_device_id))
@@ -7118,4 +7162,109 @@ mod tests {
     }
 
     // Removed background maintenance test (interval-based) to comply with deterministic, clockless spec.
+
+    /// Stage 4 Slice 3 (signal b): the receiver-admit path emits the right UX events.
+    /// First disclosure from a verified contact -> ANCHOR_PINNED + pin stored; an identical repeat
+    /// -> NO event (NoChange); a DIFFERING anchor -> ANCHOR_CHANGED + the ORIGINAL pin retained
+    /// (never overwritten). Uses a stub event callback + a fresh in-memory enrollment store.
+    #[tokio::test]
+    #[serial]
+    async fn admit_anchor_disclosure_emits_pin_and_change_events() {
+        use dsm::crypto::anchor_enrollment::InMemoryAnchorEnrollmentStore;
+        use std::sync::Mutex as StdMutex;
+
+        init_test_db();
+        let device_id = [0x51u8; 32]; // receiver
+        let genesis_hash = [0x52u8; 32];
+        let sender = [0x53u8; 32];
+        let sender_genesis = [0x54u8; 32];
+
+        let (bilateral_manager, mut handler) =
+            make_test_handler(device_id, genesis_hash, b"anchor-events");
+
+        // Verified contact for the sender (admit requires it).
+        let contact = dsm::types::contact_types::DsmVerifiedContact {
+            alias: "sender".to_string(),
+            device_id: sender,
+            genesis_hash: sender_genesis,
+            public_key: vec![7u8; 32],
+            genesis_material: vec![5u8; 32],
+            chain_tip: Some([6u8; 32]),
+            chain_tip_smt_proof: None,
+            genesis_verified_online: true,
+            verified_at_commit_height: 1000,
+            added_at_commit_height: 1000,
+            last_updated_commit_height: 1000,
+            verifying_storage_nodes: vec![],
+            ble_address: Some(String::new()),
+        };
+        {
+            let mut m = bilateral_manager.write().await;
+            m.add_verified_contact(contact).expect("contact");
+        }
+
+        // Fresh receiver-side enrollment store (the admit target).
+        crate::bridge::install_anchor_enrollment_store(Arc::new(
+            InMemoryAnchorEnrollmentStore::new(),
+        ));
+
+        // Capture emitted events by decoding them off the callback.
+        let events: Arc<StdMutex<Vec<generated::BilateralEventNotification>>> =
+            Arc::new(StdMutex::new(Vec::new()));
+        {
+            let sink = events.clone();
+            handler.set_event_callback(Arc::new(move |bytes: &[u8]| {
+                if let Ok(ev) = generated::BilateralEventNotification::decode(bytes) {
+                    sink.lock().expect("sink").push(ev);
+                }
+            }));
+        }
+
+        let disclosure = |anchor_tag: u8| generated::AnchorDisclosure {
+            bundle: vec![0xB1; 32],
+            anchor_id: vec![anchor_tag; 32],
+            enrolled_counter: 1_000,
+            partition_pk: vec![0x07; 64],
+            policy_hash: vec![0x9A; 32],
+            pk_chip: vec![0x0C; 32],
+        };
+        let last_type = |events: &Arc<StdMutex<Vec<generated::BilateralEventNotification>>>| {
+            events.lock().expect("evs").last().map(|e| e.event_type)
+        };
+        let anchor_pinned = generated::BilateralEventType::BilateralEventAnchorPinned as i32;
+        let anchor_changed = generated::BilateralEventType::BilateralEventAnchorChanged as i32;
+
+        // 1) First disclosure -> ANCHOR_PINNED + pin stored.
+        handler
+            .admit_anchor_disclosure(sender, [0x01; 32], &disclosure(0xA1))
+            .await;
+        assert_eq!(events.lock().expect("evs").len(), 1);
+        assert_eq!(last_type(&events), Some(anchor_pinned));
+        let pinned = crate::bridge::anchor_enrollment_store()
+            .and_then(|s| s.get(&sender))
+            .expect("pin stored");
+        assert_eq!(pinned.pin.anchor_id, [0xA1; 32]);
+
+        // 2) Identical repeat -> NoChange -> NO new event.
+        handler
+            .admit_anchor_disclosure(sender, [0x02; 32], &disclosure(0xA1))
+            .await;
+        assert_eq!(events.lock().expect("evs").len(), 1, "NoChange must be silent");
+
+        // 3) Differing anchor -> ANCHOR_CHANGED + ORIGINAL pin retained (never overwritten).
+        handler
+            .admit_anchor_disclosure(sender, [0x03; 32], &disclosure(0xEE))
+            .await;
+        assert_eq!(events.lock().expect("evs").len(), 2);
+        assert_eq!(last_type(&events), Some(anchor_changed));
+        let still = crate::bridge::anchor_enrollment_store()
+            .and_then(|s| s.get(&sender))
+            .expect("pin still present");
+        assert_eq!(
+            still.pin.anchor_id, [0xA1; 32],
+            "a differing disclosure must never overwrite the pinned anchor"
+        );
+
+        crate::bridge::uninstall_anchor_enrollment_store();
+    }
 }

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/bluetooth/bilateral_ble_handler.rs
@@ -7249,7 +7249,11 @@ mod tests {
         handler
             .admit_anchor_disclosure(sender, [0x02; 32], &disclosure(0xA1))
             .await;
-        assert_eq!(events.lock().expect("evs").len(), 1, "NoChange must be silent");
+        assert_eq!(
+            events.lock().expect("evs").len(),
+            1,
+            "NoChange must be silent"
+        );
 
         // 3) Differing anchor -> ANCHOR_CHANGED + ORIGINAL pin retained (never overwritten).
         handler

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -1863,14 +1863,19 @@ fn hardware_appliance_or_fail(
     })?))
 }
 
+/// User-facing error when an offline-bearer send finds no anchor appliance connected. It rides the
+/// `DsmError` up through the confirm-build failure into the `BilateralEventFailed` event's message,
+/// where the frontend maps it to a "connect your anchor device" toast (Stage 4 Slice 3 signal a).
+/// A const so the not(test) producer and the wording test share one source of truth.
+pub(crate) const OFFLINE_BEARER_NO_APPLIANCE_MSG: &str =
+    "offline-bearer requires the anchor appliance; connect the anchor device (Pico) and retry (fail closed)";
+
 #[cfg(not(test))]
 fn hardware_appliance_or_fail(
     _seed: &impl Fn(&str) -> [u8; 32],
     _dev: [u8; 32],
 ) -> Result<Box<dyn crate::anchor::AnchorAppliance + Send>, DsmError> {
-    Err(DsmError::invalid_operation(
-        "offline-bearer requires the hardware anchor; connect the Pico and install Path-B (fail closed)",
-    ))
+    Err(DsmError::invalid_operation(OFFLINE_BEARER_NO_APPLIANCE_MSG))
 }
 
 impl CoreSDK {
@@ -2847,6 +2852,21 @@ mod tests {
             Ok(sdk) => sdk,
             Err(e) => panic!("Failed to init SDK: {:?}", e),
         }
+    }
+
+    /// Stage 4 Slice 3 (signal a): the offline-bearer "no appliance" error must speak v2 — name the
+    /// anchor device the user connects — and never the deleted v1 "Path-B" concept. This message
+    /// rides into the failed-transfer event the frontend friendly-maps.
+    #[test]
+    fn offline_bearer_no_appliance_message_is_v2_worded() {
+        assert!(
+            OFFLINE_BEARER_NO_APPLIANCE_MSG.contains("anchor device"),
+            "the send-failure message must tell the user to connect the anchor device"
+        );
+        assert!(
+            !OFFLINE_BEARER_NO_APPLIANCE_MSG.contains("Path-B"),
+            "the message must not reference the deleted v1 Path-B concept"
+        );
     }
 
     /// v2 producer phases: STAGE determines the transition + successor leaf with NO appliance

--- a/dsm_client/frontend/src/components/BilateralTransferDialog.tsx
+++ b/dsm_client/frontend/src/components/BilateralTransferDialog.tsx
@@ -5,6 +5,7 @@ import { on as eventBridgeOn } from '../dsm/EventBridge';
 import { acceptIncomingTransfer, BilateralEventType, BilateralTransferEvent, decodeBilateralEvent, rejectIncomingTransfer } from '../services/bilateral/bilateralEventService';
 import { useWallet } from '../contexts/WalletContext';
 import { useUX } from '../contexts/UXContext';
+import { useContacts } from '../contexts/ContactsContext';
 import '../styles/BilateralTransfer.css';
 import { emitWalletRefresh } from '../dsm/events';
 import { bridgeEvents } from '../bridge/bridgeEvents';
@@ -20,8 +21,20 @@ export const BilateralTransferDialog: React.FC<BilateralTransferDialogProps> = (
   const [outgoingTransfer, setOutgoingTransfer] = useState<BilateralTransferEvent | null>(null);
   const [processing, setProcessing] = useState(false);
   const { refreshAll } = useWallet();
-  const { hideComplexity } = useUX();
+  const { hideComplexity, notifyToast } = useUX();
+  const { contacts } = useContacts();
   const [inboxOpen, setInboxOpen] = useState(false);
+
+  // Resolve a friendly name for a counterparty device id (base32) from the contacts store,
+  // falling back to a short id prefix. Rendering-only.
+  const aliasFor = useCallback(
+    (deviceIdB32: string): string => {
+      const c = contacts.find((c) => c.deviceId === deviceIdB32);
+      if (c?.alias) return c.alias;
+      return deviceIdB32 ? `${deviceIdB32.slice(0, 8)}…` : 'a contact';
+    },
+    [contacts]
+  );
 
   // Hide bilateral overlay when inbox is open
   useEffect(() => {
@@ -65,7 +78,33 @@ export const BilateralTransferDialog: React.FC<BilateralTransferDialogProps> = (
 
           case BilateralEventType.REJECTED:
           case BilateralEventType.FAILED:
-            // Transfer failed
+            // Transfer failed. Stage 4 Slice 3 (signal a): if the failure is the sender's
+            // absent anchor appliance, show a clear "connect your anchor device" toast instead
+            // of leaving the user with a silent failure. Substring-matched on the Rust message.
+            if (/anchor appliance|anchor device/i.test(event.message || '')) {
+              notifyToast(
+                'error',
+                'Connect your anchor device to send offline, then try again.',
+                { persistent: true }
+              );
+            }
+            setIncomingTransfer(null);
+            setOutgoingTransfer(null);
+            break;
+
+          case BilateralEventType.ANCHOR_PINNED:
+            // Stage 4 Slice 3 (signal b): first-transfer TOFU trust established.
+            notifyToast('success', `Trusted the offline anchor for ${aliasFor(event.counterpartyDeviceId)}.`);
+            break;
+
+          case BilateralEventType.ANCHOR_CHANGED:
+            // Stage 4 Slice 3 (signal b): a pinned anchor's identity changed — a security event.
+            // The transfer is already refused fail-closed; surface it prominently (persistent).
+            notifyToast(
+              'error',
+              `Security: the trusted offline identity for ${aliasFor(event.counterpartyDeviceId)} changed — transfer refused.`,
+              { persistent: true }
+            );
             setIncomingTransfer(null);
             setOutgoingTransfer(null);
             break;
@@ -79,7 +118,7 @@ export const BilateralTransferDialog: React.FC<BilateralTransferDialogProps> = (
     });
 
     return () => unsubscribe();
-  }, [refreshAll]);
+  }, [refreshAll, notifyToast, aliasFor]);
 
   const handleAccept = useCallback(async () => {
     if (!incomingTransfer) return;

--- a/dsm_client/frontend/src/components/BilateralTransferDialog.tsx
+++ b/dsm_client/frontend/src/components/BilateralTransferDialog.tsx
@@ -5,7 +5,7 @@ import { on as eventBridgeOn } from '../dsm/EventBridge';
 import { acceptIncomingTransfer, BilateralEventType, BilateralTransferEvent, decodeBilateralEvent, rejectIncomingTransfer } from '../services/bilateral/bilateralEventService';
 import { useWallet } from '../contexts/WalletContext';
 import { useUX } from '../contexts/UXContext';
-import { useContacts } from '../contexts/ContactsContext';
+import { contactsStore } from '../stores/contactsStore';
 import '../styles/BilateralTransfer.css';
 import { emitWalletRefresh } from '../dsm/events';
 import { bridgeEvents } from '../bridge/bridgeEvents';
@@ -22,19 +22,16 @@ export const BilateralTransferDialog: React.FC<BilateralTransferDialogProps> = (
   const [processing, setProcessing] = useState(false);
   const { refreshAll } = useWallet();
   const { hideComplexity, notifyToast } = useUX();
-  const { contacts } = useContacts();
   const [inboxOpen, setInboxOpen] = useState(false);
 
   // Resolve a friendly name for a counterparty device id (base32) from the contacts store,
-  // falling back to a short id prefix. Rendering-only.
-  const aliasFor = useCallback(
-    (deviceIdB32: string): string => {
-      const c = contacts.find((c) => c.deviceId === deviceIdB32);
-      if (c?.alias) return c.alias;
-      return deviceIdB32 ? `${deviceIdB32.slice(0, 8)}…` : 'a contact';
-    },
-    [contacts]
-  );
+  // falling back to a short id prefix. Read imperatively at event time (a one-shot toast needs no
+  // reactive subscription), so this component takes no new context dependency. Rendering-only.
+  const aliasFor = useCallback((deviceIdB32: string): string => {
+    const c = contactsStore.getSnapshot().contacts.find((c) => c.deviceId === deviceIdB32);
+    if (c?.alias) return c.alias;
+    return deviceIdB32 ? `${deviceIdB32.slice(0, 8)}…` : 'a contact';
+  }, []);
 
   // Hide bilateral overlay when inbox is open
   useEffect(() => {

--- a/dsm_client/frontend/src/proto/dsm_app_pb.ts
+++ b/dsm_client/frontend/src/proto/dsm_app_pb.ts
@@ -424,6 +424,20 @@ export enum BilateralEventType {
    * @generated from enum value: BILATERAL_EVENT_FAILED = 6;
    */
   BILATERAL_EVENT_FAILED = 6,
+
+  /**
+   * Receiver: first-transfer TOFU anchor pin admitted (trust established)
+   *
+   * @generated from enum value: BILATERAL_EVENT_ANCHOR_PINNED = 7;
+   */
+  BILATERAL_EVENT_ANCHOR_PINNED = 7,
+
+  /**
+   * Receiver: a pinned anchor's identity changed on a later transfer (SECURITY warning; transfer refused, pinned anchor kept)
+   *
+   * @generated from enum value: BILATERAL_EVENT_ANCHOR_CHANGED = 8;
+   */
+  BILATERAL_EVENT_ANCHOR_CHANGED = 8,
 }
 // Retrieve enum metadata with: proto3.getEnumType(BilateralEventType)
 proto3.util.setEnumType(BilateralEventType, "dsm.BilateralEventType", [
@@ -434,6 +448,8 @@ proto3.util.setEnumType(BilateralEventType, "dsm.BilateralEventType", [
   { no: 4, name: "BILATERAL_EVENT_TRANSFER_COMPLETE" },
   { no: 5, name: "BILATERAL_EVENT_REJECTED" },
   { no: 6, name: "BILATERAL_EVENT_FAILED" },
+  { no: 7, name: "BILATERAL_EVENT_ANCHOR_PINNED" },
+  { no: 8, name: "BILATERAL_EVENT_ANCHOR_CHANGED" },
 ]);
 
 /**
@@ -12323,12 +12339,15 @@ export class BilateralPrepareRequest extends Message<BilateralPrepareRequest> {
   transferAmountDisplay = "";
 
   /**
-   * Present iff the sender holds an offline-bearer anchor. The receiver pins it (admit) at
-   * relationship establishment, then verifies every offline-bearer receipt against it.
+   * Sender's CURRENT ML-KEM-768 encapsulation key (1184 bytes; empty = legacy peer).
+   * The device Kyber keypair is deliberately RANDOMIZED per wallet init (no persisted device
+   * secret), so the peer's copy must be refreshed on every prepare exchange — exactly like
+   * sender_signing_public_key above. The receiver persists it on the contact record; the
+   * §11.1 per-step EK receipt (kyber_ct encapsulation) fail-closes without it.
    *
-   * @generated from field: dsm.AnchorIdentityProto sender_anchor_identity = 15;
+   * @generated from field: bytes sender_kyber_public_key = 16;
    */
-  senderAnchorIdentity?: AnchorIdentityProto;
+  senderKyberPublicKey = new Uint8Array(0);
 
   constructor(data?: PartialMessage<BilateralPrepareRequest>) {
     super();
@@ -12352,7 +12371,7 @@ export class BilateralPrepareRequest extends Message<BilateralPrepareRequest> {
     { no: 12, name: "token_id_hint", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 13, name: "memo_hint", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 14, name: "transfer_amount_display", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 15, name: "sender_anchor_identity", kind: "message", T: AnchorIdentityProto },
+    { no: 16, name: "sender_kyber_public_key", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BilateralPrepareRequest {
@@ -12369,6 +12388,85 @@ export class BilateralPrepareRequest extends Message<BilateralPrepareRequest> {
 
   static equals(a: BilateralPrepareRequest | PlainMessage<BilateralPrepareRequest> | undefined, b: BilateralPrepareRequest | PlainMessage<BilateralPrepareRequest> | undefined): boolean {
     return proto3.util.equals(BilateralPrepareRequest, a, b);
+  }
+}
+
+/**
+ * A -> B, rides BilateralConfirmRequest (Software-Authority / Hardware-Identity receiver-admit).
+ * A discloses its fused-anchor pin material so B can PIN it under the ALREADY-verified contact,
+ * bound to THIS transfer's state transition (never a standalone/implicit pin). pk_chip is the
+ * resident TROPIC01 ECC public key that verifies the release's σ^chip; a disclosure without it is
+ * rejected (no partial v2 pin).
+ *
+ * @generated from message dsm.AnchorDisclosure
+ */
+export class AnchorDisclosure extends Message<AnchorDisclosure> {
+  /**
+   * @generated from field: bytes bundle = 1;
+   */
+  bundle = new Uint8Array(0);
+
+  /**
+   * @generated from field: bytes anchor_id = 2;
+   */
+  anchorId = new Uint8Array(0);
+
+  /**
+   * H0
+   *
+   * @generated from field: uint64 enrolled_counter = 3;
+   */
+  enrolledCounter = protoInt64.zero;
+
+  /**
+   * @generated from field: bytes partition_pk = 4;
+   */
+  partitionPk = new Uint8Array(0);
+
+  /**
+   * policy the anchor is admitted under
+   *
+   * @generated from field: bytes policy_hash = 5;
+   */
+  policyHash = new Uint8Array(0);
+
+  /**
+   * resident chip Ed25519 key (σ^chip)
+   *
+   * @generated from field: bytes pk_chip = 9;
+   */
+  pkChip = new Uint8Array(0);
+
+  constructor(data?: PartialMessage<AnchorDisclosure>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "dsm.AnchorDisclosure";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "bundle", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 2, name: "anchor_id", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "enrolled_counter", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 4, name: "partition_pk", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 5, name: "policy_hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 9, name: "pk_chip", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AnchorDisclosure {
+    return new AnchorDisclosure().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AnchorDisclosure {
+    return new AnchorDisclosure().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AnchorDisclosure {
+    return new AnchorDisclosure().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AnchorDisclosure | PlainMessage<AnchorDisclosure> | undefined, b: AnchorDisclosure | PlainMessage<AnchorDisclosure> | undefined): boolean {
+    return proto3.util.equals(AnchorDisclosure, a, b);
   }
 }
 
@@ -12410,6 +12508,25 @@ export class BilateralPrepareResponse extends Message<BilateralPrepareResponse> 
    */
   responderSigningPublicKey = new Uint8Array(0);
 
+  /**
+   * Fresh receiver challenge r_R (fused-anchor release binding). The receiver
+   * generates this per offline-bearer transfer; it rides the prepare response
+   * (which precedes the sender's confirm) so the sender can bind it into the
+   * anchor appliance PREPARE. Empty for ordinary (non-bearer) transfers.
+   *
+   * @generated from field: bytes receiver_challenge = 7;
+   */
+  receiverChallenge = new Uint8Array(0);
+
+  /**
+   * Responder's CURRENT ML-KEM-768 encapsulation key (1184 bytes; empty = legacy peer).
+   * Mirrors responder_signing_public_key: the sender persists it on the contact record so the
+   * §11.1 per-step EK receipt built in the immediately following confirm can encapsulate to it.
+   *
+   * @generated from field: bytes responder_kyber_public_key = 9;
+   */
+  responderKyberPublicKey = new Uint8Array(0);
+
   constructor(data?: PartialMessage<BilateralPrepareResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -12424,6 +12541,8 @@ export class BilateralPrepareResponse extends Message<BilateralPrepareResponse> 
     { no: 4, name: "counterparty_state_hash", kind: "message", T: Hash32 },
     { no: 5, name: "local_state_hash", kind: "message", T: Hash32 },
     { no: 6, name: "responder_signing_public_key", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 7, name: "receiver_challenge", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 9, name: "responder_kyber_public_key", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BilateralPrepareResponse {
@@ -13119,33 +13238,25 @@ export class BilateralConfirmRequest extends Message<BilateralConfirmRequest> {
   senderSmtRootBefore = new Uint8Array(0);
 
   /**
-   * LEGACY Safe 7 offline-bearer shape (fields 10/11). The receiver NO LONGER accepts an
-   * offline-bearer transfer via IslandAttestation — these are quarantined and route to online
-   * recovery (superseded by field 12). Still emitted by the unmigrated sender; Phase 5 removes
-   * the producer.
-   *
-   * @generated from field: dsm.IslandAttestationProto island_attestation = 10;
-   */
-  islandAttestation?: IslandAttestationProto;
-
-  /**
-   * == the transition target state the gate signed as expiry_tick
-   *
-   * @generated from field: uint64 anchor_expiry_tick = 11;
-   */
-  anchorExpiryTick = protoInt64.zero;
-
-  /**
-   * Canonical offline-bearer release (Boot Fenced Fused Anchor): the prost-encoded
-   * dsm.anchor.OfflineRelease (Δ + boot chain + fused root-advance cert + counter evidence),
-   * carried as opaque bytes so the dsm.anchor namespace stays decoupled from dsm_app. The receiver
-   * decodes it and applies anchor_core::accept::accept_offline (the 22-check predicate). Until the
-   * producer side ships (Phase 5) this is empty and the transfer fails closed to online recovery;
-   * no value is released on an absent or invalid release.
+   * Canonical offline-bearer release (Software-Authority / Hardware-Identity v2): the prost-encoded
+   * dsm.anchor.OfflineRelease (Δ + Π_i/Π_{i+1} anchor-state inclusion proofs + the v2 certificate
+   * carrying σ^chip + σ^host), carried as opaque bytes so the dsm.anchor namespace stays decoupled
+   * from dsm_app. The receiver decodes it and applies anchor_core::accept::accept_offline. Empty
+   * for ordinary transfers; an absent or invalid release fails closed to online recovery — no value
+   * is released on it.
    *
    * @generated from field: bytes offline_release = 12;
    */
   offlineRelease = new Uint8Array(0);
+
+  /**
+   * Receiver-admit fold: A's fused-anchor pin disclosure, present iff this confirm carries a bearer
+   * release. B pins it TOFU on the first transfer (already-verified contact, bound to this
+   * transfer) and verifies same-anchor on every subsequent one. Absent for ordinary transfers.
+   *
+   * @generated from field: dsm.AnchorDisclosure anchor_disclosure = 15;
+   */
+  anchorDisclosure?: AnchorDisclosure;
 
   constructor(data?: PartialMessage<BilateralConfirmRequest>) {
     super();
@@ -13164,9 +13275,8 @@ export class BilateralConfirmRequest extends Message<BilateralConfirmRequest> {
     { no: 7, name: "shared_chain_tip_new", kind: "message", T: Hash32 },
     { no: 8, name: "pre_entropy", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
     { no: 9, name: "sender_smt_root_before", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 10, name: "island_attestation", kind: "message", T: IslandAttestationProto },
-    { no: 11, name: "anchor_expiry_tick", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
     { no: 12, name: "offline_release", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 15, name: "anchor_disclosure", kind: "message", T: AnchorDisclosure },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BilateralConfirmRequest {
@@ -19989,15 +20099,6 @@ export class RelationshipChainStateProto extends Message<RelationshipChainStateP
    */
   counterpartySig?: Uint8Array;
 
-  /**
-   * Offline-bearer secure-element island attestation (anti-clone). Feeds compute_chain_tip,
-   * so the faithful codec MUST carry it. Message field -> Option in prost (None vs Some
-   * preserved). Absent on non-offline-bearer states.
-   *
-   * @generated from field: dsm.IslandAttestationProto island_attestation = 11;
-   */
-  islandAttestation?: IslandAttestationProto;
-
   constructor(data?: PartialMessage<RelationshipChainStateProto>) {
     super();
     proto3.util.initPartial(data, this);
@@ -20015,7 +20116,6 @@ export class RelationshipChainStateProto extends Message<RelationshipChainStateP
     { no: 8, name: "balance_witness", kind: "message", T: BalanceWitnessEntryProto, repeated: true },
     { no: 9, name: "entity_sig", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
     { no: 10, name: "counterparty_sig", kind: "scalar", T: 12 /* ScalarType.BYTES */, opt: true },
-    { no: 11, name: "island_attestation", kind: "message", T: IslandAttestationProto },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RelationshipChainStateProto {
@@ -20032,225 +20132,6 @@ export class RelationshipChainStateProto extends Message<RelationshipChainStateP
 
   static equals(a: RelationshipChainStateProto | PlainMessage<RelationshipChainStateProto> | undefined, b: RelationshipChainStateProto | PlainMessage<RelationshipChainStateProto> | undefined): boolean {
     return proto3.util.equals(RelationshipChainStateProto, a, b);
-  }
-}
-
-/**
- * Offline-bearer secure-element island attestation folded into a relationship chain tip
- * (anti-clone, see dsm_anticlone.instructions.md). Carried in the faithful codec because it
- * feeds compute_chain_tip.
- *
- * @generated from message dsm.IslandAttestationProto
- */
-export class IslandAttestationProto extends Message<IslandAttestationProto> {
-  /**
-   * SHA-256(leaf SubjectPublicKeyInfo)
-   *
-   * @generated from field: bytes id_island = 1;
-   */
-  idIsland = new Uint8Array(0);
-
-  /**
-   * island signature over the framed intent challenge
-   *
-   * @generated from field: bytes signature = 2;
-   */
-  signature = new Uint8Array(0);
-
-  /**
-   * pinning policy id under which the island was admitted
-   *
-   * @generated from field: bytes policy_id = 3;
-   */
-  policyId = new Uint8Array(0);
-
-  /**
-   * canonical anchor-set id (compute_anchor_set_id)
-   *
-   * @generated from field: bytes id_anchor_set = 4;
-   */
-  idAnchorSet = new Uint8Array(0);
-
-  /**
-   * UI transcript hash the island signed over
-   *
-   * @generated from field: bytes ui_transcript_hash = 5;
-   */
-  uiTranscriptHash = new Uint8Array(0);
-
-  /**
-   * Stateful-receipt fields (anchor monotonic frontier + firmware/policy binding). Append-only;
-   * NOT folded into compute_chain_tip (only id_island/signature/policy_id are), so tip bytes are
-   * unchanged. genesis/device_id are already on StitchedReceiptV2 and not duplicated here.
-   *
-   * dsm_anchor_pubkey_hash(leaf_spki)
-   *
-   * @generated from field: bytes anchor_pubkey_hash = 6;
-   */
-  anchorPubkeyHash = new Uint8Array(0);
-
-  /**
-   * device-measured firmware hash (secmon-gate enforced)
-   *
-   * @generated from field: bytes firmware_hash = 7;
-   */
-  firmwareHash = new Uint8Array(0);
-
-  /**
-   * dsm_policy_hash(policy_id, id_anchor_set)
-   *
-   * @generated from field: bytes policy_hash = 8;
-   */
-  policyHash = new Uint8Array(0);
-
-  /**
-   * anchor frontier root this advance consumes
-   *
-   * @generated from field: bytes parent_root = 9;
-   */
-  parentRoot = new Uint8Array(0);
-
-  /**
-   * anchor frontier root this advance produces
-   *
-   * @generated from field: bytes successor_root = 10;
-   */
-  successorRoot = new Uint8Array(0);
-
-  /**
-   * == payload_hash of the transition
-   *
-   * @generated from field: bytes operation_hash = 11;
-   */
-  operationHash = new Uint8Array(0);
-
-  /**
-   * monotonic anchor frontier counter
-   *
-   * @generated from field: uint64 state_number = 12;
-   */
-  stateNumber = protoInt64.zero;
-
-  constructor(data?: PartialMessage<IslandAttestationProto>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "dsm.IslandAttestationProto";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "id_island", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 2, name: "signature", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 3, name: "policy_id", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 4, name: "id_anchor_set", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 5, name: "ui_transcript_hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 6, name: "anchor_pubkey_hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 7, name: "firmware_hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 8, name: "policy_hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 9, name: "parent_root", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 10, name: "successor_root", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 11, name: "operation_hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 12, name: "state_number", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): IslandAttestationProto {
-    return new IslandAttestationProto().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): IslandAttestationProto {
-    return new IslandAttestationProto().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): IslandAttestationProto {
-    return new IslandAttestationProto().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: IslandAttestationProto | PlainMessage<IslandAttestationProto> | undefined, b: IslandAttestationProto | PlainMessage<IslandAttestationProto> | undefined): boolean {
-    return proto3.util.equals(IslandAttestationProto, a, b);
-  }
-}
-
-/**
- * The sender's published offline-bearer anchor identity, exchanged so the receiver can PIN it
- * (admit it through the relationship-establishment authority path) and thereafter verify every
- * offline-bearer receipt against this exact identity + enrolled firmware hash. Comes from the
- * element (real Safe 7 transport) or the in-process mock; the exchange + pinning are identical.
- *
- * @generated from message dsm.AnchorIdentityProto
- */
-export class AnchorIdentityProto extends Message<AnchorIdentityProto> {
-  /**
-   * anchor id (from birth commitment + key)
-   *
-   * @generated from field: bytes id_anchor = 1;
-   */
-  idAnchor = new Uint8Array(0);
-
-  /**
-   * birth commitment C
-   *
-   * @generated from field: bytes commitment_c = 2;
-   */
-  commitmentC = new Uint8Array(0);
-
-  /**
-   * SubjectPublicKeyInfo DER of the signing key
-   *
-   * @generated from field: bytes leaf_spki = 3;
-   */
-  leafSpki = new Uint8Array(0);
-
-  /**
-   * display-bound firmware id
-   *
-   * @generated from field: bytes firmware_id = 4;
-   */
-  firmwareId = new Uint8Array(0);
-
-  /**
-   * consent screen layout version
-   *
-   * @generated from field: uint32 screen_template_id = 5;
-   */
-  screenTemplateId = 0;
-
-  /**
-   * measured firmware hash enrolled at provisioning
-   *
-   * @generated from field: bytes firmware_hash = 6;
-   */
-  firmwareHash = new Uint8Array(0);
-
-  constructor(data?: PartialMessage<AnchorIdentityProto>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "dsm.AnchorIdentityProto";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "id_anchor", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 2, name: "commitment_c", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 3, name: "leaf_spki", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 4, name: "firmware_id", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 5, name: "screen_template_id", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
-    { no: 6, name: "firmware_hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AnchorIdentityProto {
-    return new AnchorIdentityProto().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AnchorIdentityProto {
-    return new AnchorIdentityProto().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AnchorIdentityProto {
-    return new AnchorIdentityProto().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: AnchorIdentityProto | PlainMessage<AnchorIdentityProto> | undefined, b: AnchorIdentityProto | PlainMessage<AnchorIdentityProto> | undefined): boolean {
-    return proto3.util.equals(AnchorIdentityProto, a, b);
   }
 }
 

--- a/dsm_client/frontend/src/services/bilateral/bilateralEventService.ts
+++ b/dsm_client/frontend/src/services/bilateral/bilateralEventService.ts
@@ -14,6 +14,9 @@ export const BilateralEventType = {
   TRANSFER_COMPLETE: pb.BilateralEventType.BILATERAL_EVENT_TRANSFER_COMPLETE,
   REJECTED: pb.BilateralEventType.BILATERAL_EVENT_REJECTED,
   FAILED: pb.BilateralEventType.BILATERAL_EVENT_FAILED,
+  // Stage 4 Slice 3: receiver-side anchor trust signals.
+  ANCHOR_PINNED: pb.BilateralEventType.BILATERAL_EVENT_ANCHOR_PINNED,
+  ANCHOR_CHANGED: pb.BilateralEventType.BILATERAL_EVENT_ANCHOR_CHANGED,
 } as const;
 
 export type BilateralEventTypeValue = typeof BilateralEventType[keyof typeof BilateralEventType];

--- a/proto/dsm_app.proto
+++ b/proto/dsm_app.proto
@@ -2020,6 +2020,8 @@ enum BilateralEventType {
   BILATERAL_EVENT_TRANSFER_COMPLETE= 4; // Both: transaction finalized
   BILATERAL_EVENT_REJECTED         = 5; // Receiver: rejected transfer
   BILATERAL_EVENT_FAILED           = 6; // Either: transaction failed
+  BILATERAL_EVENT_ANCHOR_PINNED    = 7; // Receiver: first-transfer TOFU anchor pin admitted (trust established)
+  BILATERAL_EVENT_ANCHOR_CHANGED   = 8; // Receiver: a pinned anchor's identity changed on a later transfer (SECURITY warning; transfer refused, pinned anchor kept)
 }
 
 enum BilateralFailureReason {


### PR DESCRIPTION
## Summary

Stage 4 Slice 3 (signals **a + b**): the offline-bearer flow previously only *logged* the three moments a user cares about. This makes the app speak at two of them, keeping all logic in Rust and the frontend as pure rendering. No activation gate is flipped; offline-bearer stays *implemented-but-activation-gated*.

**(a) Sender — "connect your anchor device"**
- The "no anchor appliance" send error dropped the deleted v1 "Path-B" wording; it now names the device to connect (`core_sdk.rs` const `OFFLINE_BEARER_NO_APPLIANCE_MSG` + unit test). It already rides the `BilateralEventFailed` message; the dialog substring-maps it to a persistent "connect your anchor device" toast.

**(b) Receiver — TOFU trust + anchor-changed security warning**
- Two additive `BilateralEventType` values: `ANCHOR_PINNED = 7`, `ANCHOR_CHANGED = 8`.
- `admit_anchor_disclosure` emits `ANCHOR_PINNED` on first-transfer TOFU trust and `ANCHOR_CHANGED` when a pinned anchor's identity changes on a later transfer. Per owner directive the change is treated as a **security event**: the transfer is already refused fail-closed by the acceptance predicate (it verifies against the *pinned* anchor) and the pinned anchor is never overwritten — we only surface it (prominent persistent warning) and keep the `log::warn` as the audit record. `commitment_hash` is threaded through so both events tie to the transfer.
- Frontend (rendering only): decode both events, toast via the existing `BilateralTransferDialog` subscriber, resolving the contact alias from the contacts store.

**Also:** `proto:gen` resynced the **stale** generated `dsm_app_pb.ts` — it still carried the removed v1 `AnchorIdentityProto`/`IslandAttestationProto` and was missing the v2 `AnchorDisclosure`. Nothing referenced the removed types (tsc error count unchanged at 103 pre-existing, none in the touched files).

## Verification

- `dsm_sdk` tests: `offline_bearer_no_appliance_message_is_v2_worded` + `admit_anchor_disclosure_emits_pin_and_change_events` (first disclosure → ANCHOR_PINNED + pin stored; identical repeat → silent NoChange; differing anchor → ANCHOR_CHANGED + **original pin retained**) — green.
- `cargo check --workspace --tests` green; `ci/production_safety_checks.sh` (restriction clippy + TLA+) + proto-guard + clockless/protobuf gate green.
- Frontend: touched files lint clean; `tsc` introduces **zero** new errors (103 pre-existing, unrelated); existing jest bilateral-event tests green.

**Scope note:** the read-only chip/anchor status panel (signal c) is deferred to a separate slice. The live 2-device visual confirmation is Stage 4 Slice 5 (owner-run hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)