### PR TITLE
feat(offline-bearer): anchor.status read-only diagnostics route + panel (signal c)

### DIFF
--- a/dsm_client/deterministic_state_machine/dsm/src/core/bridge.rs
+++ b/dsm_client/deterministic_state_machine/dsm/src/core/bridge.rs
@@ -1311,6 +1311,8 @@ pub fn handle_envelope_universal(env_bytes: &[u8]) -> Vec<u8> {
         Some(gp::envelope::Payload::StorageNodeStatsResponse(_))
         | Some(gp::envelope::Payload::StorageNodeManageResponse(_))
         | Some(gp::envelope::Payload::SessionStateResponse(_))
+        // Offline-bearer anchor status (signal (c)) — SDK-owned `anchor.status` query response.
+        | Some(gp::envelope::Payload::AnchorStatusResponse(_))
         | Some(gp::envelope::Payload::TokenPolicyListResponse(_))
         // Outbound-only push envelopes — never arrive as inbound requests
         | Some(gp::envelope::Payload::NfcRecoveryCapsule(_))

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/anchor_routes.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/anchor_routes.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Anchor route handlers for the app router (offline-bearer signal (c)).
+//!
+//! Query routes:
+//! - `anchor.status` → read-only [`AnchorStatusResponse`] diagnostics snapshot of the sender's
+//!   anchor appliance (RP2350/TROPIC01). Purely observational: no staging, no counter move, no
+//!   device-state mutation. When no appliance can attach it reports `anchor_connected=false`
+//!   rather than failing the route.
+
+use dsm::types::proto as generated;
+
+use crate::bridge::{AppQuery, AppResult};
+
+use super::app_router_impl::AppRouterImpl;
+use super::response_helpers::pack_envelope_ok;
+
+impl AppRouterImpl {
+    /// Dispatch handler for `anchor.*` query routes.
+    pub(crate) async fn handle_anchor_query(&self, q: AppQuery) -> AppResult {
+        match q.path.as_str() {
+            "anchor.status" => {
+                let snap = self.core_sdk.anchor_appliance_status();
+                let resp = generated::AnchorStatusResponse {
+                    anchor_connected: snap.connected,
+                    anchor_id: snap.anchor_id.to_vec(),
+                    pk_chip: snap.pk_chip,
+                    partition_pk: snap.partition_pk,
+                    anchor_counter: snap.anchor_counter,
+                    frontier_root: snap.frontier_root.to_vec(),
+                    enrolled_counter: snap.enrolled_counter,
+                    bundle: snap.bundle.to_vec(),
+                    status: snap.status,
+                };
+                pack_envelope_ok(generated::envelope::Payload::AnchorStatusResponse(resp))
+            }
+            _ => super::response_helpers::err(format!("unknown anchor query: {}", q.path)),
+        }
+    }
+}

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/app_router_impl.rs
@@ -2721,6 +2721,8 @@ impl AppRouter for AppRouterImpl {
             "debug.dump_state" | "debug.trigger_genesis" => self.handle_debug_query(q).await,
             // Session routes
             "session.status" => self.handle_session_query(q).await,
+            // Offline-bearer anchor status (signal (c)) — read-only diagnostics
+            "anchor.status" => self.handle_anchor_query(q).await,
             // Recovery routes
             p if p.starts_with("recovery.") => self.handle_recovery_query(q).await,
             // Bitcoin query routes

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/mod.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/handlers/mod.rs
@@ -18,6 +18,7 @@ pub mod unilateral_impl;
 pub use app_router_impl::AppRouterImpl;
 pub use bilateral_impl::BiImpl;
 pub use core_bridge_adapters::{install_app_router_adapter, is_app_router_installed};
+pub mod anchor_routes;
 pub mod bilateral_routes;
 pub mod bitcoin_helpers;
 pub mod bitcoin_invoke_routes;

--- a/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
+++ b/dsm_client/deterministic_state_machine/dsm_sdk/src/sdk/core_sdk.rs
@@ -1601,7 +1601,93 @@ pub struct StagedBearerTransition {
     pub pin: crate::anchor::AnchorPin,
 }
 
+/// Read-only snapshot of the sender's anchor appliance for the `anchor.status` diagnostics route
+/// (signal (c)). Purely observational: NO staging, NO counter move, NO device-state mutation.
+/// A disconnected snapshot (no appliance attachable) reports `connected = false` with zeroed
+/// identity — a diagnostics read must never fail the route.
+#[derive(Clone, Debug, Default)]
+pub struct AnchorStatusSnapshot {
+    pub connected: bool,
+    pub anchor_id: [u8; 32],
+    pub pk_chip: Vec<u8>,
+    pub partition_pk: Vec<u8>,
+    pub anchor_counter: u64,
+    pub frontier_root: [u8; 32],
+    pub enrolled_counter: u64,
+    pub bundle: [u8; 32],
+    pub status: String,
+}
+
 impl CoreSDK {
+    /// Read-only anchor appliance snapshot for the `anchor.status` diagnostics route (signal (c)).
+    /// Attaches (and caches) the appliance via the installed factory if not already attached, then
+    /// reads `pin()`/`status()`. Unlike [`stage_offline_bearer_transition`](Self::stage_offline_bearer_transition)
+    /// this performs NO anchor-state leaf reconciliation and NO mutation. When no appliance can
+    /// attach (no device / fail-closed) it returns a disconnected snapshot rather than an error, so
+    /// the diagnostics panel can render "no anchor connected" instead of failing.
+    #[must_use]
+    pub fn anchor_appliance_status(&self) -> AnchorStatusSnapshot {
+        let dev = self.device_info.device_id;
+        let seed = |tag: &str| blake3_cat(&[tag.as_bytes(), &dev]);
+
+        let mut guard = self.anchor_appliance.lock();
+        if guard.is_none() {
+            let attached: Result<Box<dyn crate::anchor::AnchorAppliance + Send>, DsmError> =
+                match crate::bridge::anchor_appliance_factory() {
+                    Some(factory) => factory(),
+                    None => hardware_appliance_or_fail(&seed, dev),
+                };
+            match attached {
+                Ok(a) => *guard = Some(a),
+                Err(e) => {
+                    log::info!("[anchor.status] no anchor appliance attached: {e}");
+                    return AnchorStatusSnapshot {
+                        status: "no anchor appliance connected".into(),
+                        ..Default::default()
+                    };
+                }
+            }
+        }
+
+        let app = match guard.as_mut() {
+            Some(a) => a,
+            None => {
+                return AnchorStatusSnapshot {
+                    status: "no anchor appliance connected".into(),
+                    ..Default::default()
+                }
+            }
+        };
+
+        let pin = app.pin();
+        match app.status() {
+            Ok(s) => AnchorStatusSnapshot {
+                connected: true,
+                anchor_id: pin.anchor_id,
+                pk_chip: pin.pk_chip,
+                partition_pk: pin.partition_pk,
+                anchor_counter: s.anchor_counter,
+                frontier_root: s.root,
+                enrolled_counter: pin.enrolled_counter,
+                bundle: pin.bundle,
+                status: format!("anchor connected (counter u={})", s.anchor_counter),
+            },
+            Err(e) => {
+                log::warn!("[anchor.status] appliance attached but OP_STATUS failed: {e}");
+                AnchorStatusSnapshot {
+                    connected: false,
+                    anchor_id: pin.anchor_id,
+                    pk_chip: pin.pk_chip,
+                    partition_pk: pin.partition_pk,
+                    enrolled_counter: pin.enrolled_counter,
+                    bundle: pin.bundle,
+                    status: "anchor present but status read failed".into(),
+                    ..Default::default()
+                }
+            }
+        }
+    }
+
     /// v2 producer phase 1 (Software-Authority / Hardware-Identity): lazily attach the appliance
     /// (reconciling the DeviceState anchor-state leaf to the chip's CURRENT active state), then
     /// deterministically stage the next transition — compute `D`, the successor frontier
@@ -2866,6 +2952,45 @@ mod tests {
         assert!(
             !OFFLINE_BEARER_NO_APPLIANCE_MSG.contains("Path-B"),
             "the message must not reference the deleted v1 Path-B concept"
+        );
+    }
+
+    /// Stage 4 Slice 3 (signal c): the read-only `anchor.status` accessor attaches the appliance
+    /// and reports a connected snapshot (identity + counters) WITHOUT mutating the device head —
+    /// the data source behind the diagnostics panel. Contrast `stage_offline_bearer_transition`,
+    /// which reconciles the anchor-state leaf.
+    #[test]
+    #[serial]
+    fn anchor_status_reports_connected_snapshot_without_mutation() {
+        let sdk = test_sdk();
+        let had_head_before = sdk.state_machine.lock().device_head().is_some();
+
+        let snap = sdk.anchor_appliance_status();
+        assert!(
+            snap.connected,
+            "the in-process mock appliance must report connected"
+        );
+        assert_eq!(
+            snap.enrolled_counter, 1_000_000,
+            "enrolled counter comes from the appliance pin"
+        );
+        assert_ne!(
+            snap.anchor_id, [0u8; 32],
+            "a connected anchor exposes a non-zero identity"
+        );
+        assert!(
+            !snap.pk_chip.is_empty(),
+            "a connected anchor exposes the resident chip pubkey"
+        );
+        assert!(
+            snap.status.contains("connected"),
+            "the human-readable status names the connected state"
+        );
+
+        let had_head_after = sdk.state_machine.lock().device_head().is_some();
+        assert_eq!(
+            had_head_before, had_head_after,
+            "anchor.status is read-only and must not create or mutate the device head"
         );
     }
 

--- a/dsm_client/frontend/src/components/AnchorStatusPanel.tsx
+++ b/dsm_client/frontend/src/components/AnchorStatusPanel.tsx
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { getAnchorStatus, AnchorStatus } from '../dsm/anchor';
+import logger from '../utils/logger';
+
+const cardStyle: React.CSSProperties = {
+  background: 'rgba(var(--bg-rgb),0.55)',
+  border: '1px solid var(--border)',
+  borderRadius: 8,
+  padding: 10,
+  marginBottom: 10,
+  color: 'var(--text-dark)',
+  fontSize: '10px',
+  lineHeight: 1.4,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 8,
+  wordBreak: 'break-all',
+  marginTop: 2,
+};
+
+/**
+ * Read-only offline-bearer anchor status (Stage 4 Slice 3, signal c). Pure rendering: reads the
+ * `anchor.status` route and displays the sender's appliance snapshot (connected state, live counter
+ * floor u, enrolled counter, anchor identity/chip-key/frontier prefixes). No protocol logic here —
+ * all state comes from the Rust handler.
+ */
+export default function AnchorStatusPanel() {
+  const [status, setStatus] = useState<AnchorStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setStatus(await getAnchorStatus());
+    } catch (e) {
+      logger.warn('[AnchorStatusPanel] getAnchorStatus failed', e);
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const dot = (ok: boolean) => (
+    <span
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 8,
+        borderRadius: 4,
+        marginRight: 6,
+        background: ok ? 'var(--good, #3fb950)' : 'var(--muted, #8b949e)',
+      }}
+    />
+  );
+
+  const label = (text: string) => <span style={{ opacity: 0.7 }}>{text}</span>;
+
+  return (
+    <div style={cardStyle} data-testid="anchor-status-panel">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <strong style={{ fontSize: '11px' }}>Offline anchor</strong>
+        <button
+          onClick={() => void refresh()}
+          disabled={loading}
+          data-testid="anchor-status-refresh"
+          style={{
+            fontSize: '9px',
+            padding: '3px 8px',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            background: 'transparent',
+            color: 'var(--text-dark)',
+            cursor: loading ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {loading ? '…' : 'Refresh'}
+        </button>
+      </div>
+
+      {error ? (
+        <div data-testid="anchor-status-error" style={{ opacity: 0.8 }}>
+          Status unavailable: {error}
+        </div>
+      ) : !status ? (
+        <div style={{ opacity: 0.7 }}>Reading anchor…</div>
+      ) : !status.connected ? (
+        <div data-testid="anchor-status-disconnected">
+          {dot(false)} No anchor device connected — {status.statusText}
+        </div>
+      ) : (
+        <div data-testid="anchor-status-connected">
+          <div style={{ marginBottom: 6 }}>
+            {dot(true)} {status.statusText}
+          </div>
+          <div style={rowStyle}>
+            {label('Counter (u)')}
+            <span>{String(status.anchorCounter)}</span>
+          </div>
+          <div style={rowStyle}>
+            {label('Enrolled at')}
+            <span>{String(status.enrolledCounter)}</span>
+          </div>
+          {status.anchorIdB32 && (
+            <div style={rowStyle}>
+              {label('Anchor ID')}
+              <span>{status.anchorIdB32}…</span>
+            </div>
+          )}
+          {status.pkChipB32 && (
+            <div style={rowStyle}>
+              {label('Chip key')}
+              <span>{status.pkChipB32}…</span>
+            </div>
+          )}
+          {status.frontierRootB32 && (
+            <div style={rowStyle}>
+              {label('Frontier')}
+              <span>{status.frontierRootB32}…</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dsm_client/frontend/src/components/DiagnosticsOverlay.tsx
+++ b/dsm_client/frontend/src/components/DiagnosticsOverlay.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { useDiagnostics } from '../hooks/useDiagnostics';
 import { useUX } from '../contexts/UXContext';
 import { decodeBase32Crockford } from '../utils/textId';
+import AnchorStatusPanel from './AnchorStatusPanel';
 
 const overlayBackdropStyle: React.CSSProperties = {
   position: 'absolute',
@@ -188,6 +189,9 @@ export default function DiagnosticsOverlay() {
                 <button data-testid="open-feedback" onClick={() => openGitHubFeedback()} style={actionButtonStyle}>Send feedback</button>
               </div>
             </div>
+
+            {/* Offline-bearer anchor status (Stage 4 Slice 3, signal c) — read-only diagnostics */}
+            <AnchorStatusPanel />
 
             <pre style={{ fontSize: '10px', lineHeight: 1.4, whiteSpace: 'pre-wrap', wordBreak: 'break-all', background: 'rgba(var(--bg-rgb),0.78)', padding: '10px', borderRadius: 8, border: '1px solid var(--border)', color: 'var(--text-dark)', margin: 0 }}>{diagnostics ?? 'No diagnostics collected yet.'}</pre>
 

--- a/dsm_client/frontend/src/dsm/anchor.ts
+++ b/dsm_client/frontend/src/dsm/anchor.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import * as pb from '../proto/dsm_app_pb';
+import { routerQueryBin } from './WebViewBridge';
+import { decodeFramedEnvelopeV3 } from './decoding';
+import { bytesToBase32CrockfordPrefix } from '../utils/textId';
+import logger from '../utils/logger';
+
+/**
+ * Read-only offline-bearer anchor status for the diagnostics panel (Stage 4 Slice 3, signal c).
+ * Pure render data derived from the `anchor.status` route — no protocol logic lives here.
+ */
+export interface AnchorStatus {
+  /** Appliance attached and OP_STATUS read OK. */
+  connected: boolean;
+  /** Enrolled anchor identity (Crockford base32 prefix); '' when disconnected. */
+  anchorIdB32: string;
+  /** Resident Ed25519 chip pubkey (σ^chip) prefix; '' when disconnected. */
+  pkChipB32: string;
+  /** Live counter floor u_i. */
+  anchorCounter: bigint;
+  /** Current offline frontier h_i (base32 prefix). */
+  frontierRootB32: string;
+  /** Counter floor at enrollment. */
+  enrolledCounter: bigint;
+  /** Human-readable status line supplied by Rust. */
+  statusText: string;
+}
+
+/** Base32-encode a 32-byte field for display, treating an all-zero/empty field as "not present". */
+function b32OrEmpty(bytes: Uint8Array | undefined, prefixLen: number): string {
+  if (!bytes || bytes.length === 0 || bytes.every((x) => x === 0)) return '';
+  return bytesToBase32CrockfordPrefix(bytes, prefixLen);
+}
+
+/**
+ * Query the sender's anchor appliance status (`anchor.status` route). Read-only diagnostics: the
+ * Rust handler never mutates device or appliance state. A disconnected appliance returns a
+ * `connected=false` snapshot rather than throwing — that is an expected, renderable state.
+ */
+export async function getAnchorStatus(): Promise<AnchorStatus> {
+  const arg = new pb.ArgPack({ codec: pb.Codec.PROTO, body: new Uint8Array(0) });
+  const resBytes = await routerQueryBin('anchor.status', new Uint8Array(arg.toBinary()));
+  if (!resBytes || resBytes.length === 0) {
+    throw new Error('getAnchorStatus: empty response from bridge');
+  }
+
+  const env = decodeFramedEnvelopeV3(resBytes);
+  if (env.payload.case === 'error') {
+    throw new Error(`getAnchorStatus: ${env.payload.value.message || 'unknown error'}`);
+  }
+  if (env.payload.case !== 'anchorStatusResponse') {
+    throw new Error(`getAnchorStatus: unexpected payload ${env.payload.case}`);
+  }
+
+  const resp = env.payload.value;
+  if (!resp) {
+    throw new Error('getAnchorStatus: anchorStatusResponse payload is null');
+  }
+
+  logger.debug('[DSM:getAnchorStatus] snapshot', {
+    connected: resp.anchorConnected,
+    counter: String(resp.anchorCounter),
+  });
+
+  return {
+    connected: resp.anchorConnected,
+    anchorIdB32: b32OrEmpty(resp.anchorId, 12),
+    pkChipB32: b32OrEmpty(resp.pkChip, 12),
+    anchorCounter: resp.anchorCounter,
+    frontierRootB32: b32OrEmpty(resp.frontierRoot, 12),
+    enrolledCounter: resp.enrolledCounter,
+    statusText: resp.status,
+  };
+}

--- a/dsm_client/frontend/src/proto/dsm_app_pb.ts
+++ b/dsm_client/frontend/src/proto/dsm_app_pb.ts
@@ -13766,6 +13766,114 @@ export class BilateralEventNotification extends Message<BilateralEventNotificati
 }
 
 /**
+ * Read-only offline-bearer anchor status (signal (c)): the `anchor.status` query response.
+ * A pure diagnostics snapshot of the sender's anchor appliance (RP2350/TROPIC01) — never
+ * mutates the appliance or the device state. `anchor_connected=false` means no appliance could
+ * attach (no device / fail-closed); the identity/counter fields are then zero.
+ *
+ * @generated from message dsm.AnchorStatusResponse
+ */
+export class AnchorStatusResponse extends Message<AnchorStatusResponse> {
+  /**
+   * appliance attached and OP_STATUS read OK
+   *
+   * @generated from field: bool anchor_connected = 1;
+   */
+  anchorConnected = false;
+
+  /**
+   * enrolled anchor identity (AnchorPin.anchor_id)
+   *
+   * @generated from field: bytes anchor_id = 2;
+   */
+  anchorId = new Uint8Array(0);
+
+  /**
+   * resident Ed25519 pubkey (σ^chip)
+   *
+   * @generated from field: bytes pk_chip = 3;
+   */
+  pkChip = new Uint8Array(0);
+
+  /**
+   * RP2350 partition pubkey pk_host (σ^host)
+   *
+   * @generated from field: bytes partition_pk = 4;
+   */
+  partitionPk = new Uint8Array(0);
+
+  /**
+   * live counter floor u_i (OP_STATUS)
+   *
+   * @generated from field: uint64 anchor_counter = 5;
+   */
+  anchorCounter = protoInt64.zero;
+
+  /**
+   * current offline frontier h_i (OP_STATUS)
+   *
+   * @generated from field: bytes frontier_root = 6;
+   */
+  frontierRoot = new Uint8Array(0);
+
+  /**
+   * counter floor at enrollment (AnchorPin)
+   *
+   * @generated from field: uint64 enrolled_counter = 7;
+   */
+  enrolledCounter = protoInt64.zero;
+
+  /**
+   * anchor bundle B (AnchorPin.bundle)
+   *
+   * @generated from field: bytes bundle = 8;
+   */
+  bundle = new Uint8Array(0);
+
+  /**
+   * human-readable status line
+   *
+   * @generated from field: string status = 9;
+   */
+  status = "";
+
+  constructor(data?: PartialMessage<AnchorStatusResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "dsm.AnchorStatusResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "anchor_connected", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 2, name: "anchor_id", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "pk_chip", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 4, name: "partition_pk", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 5, name: "anchor_counter", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 6, name: "frontier_root", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 7, name: "enrolled_counter", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 8, name: "bundle", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 9, name: "status", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AnchorStatusResponse {
+    return new AnchorStatusResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AnchorStatusResponse {
+    return new AnchorStatusResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AnchorStatusResponse {
+    return new AnchorStatusResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AnchorStatusResponse | PlainMessage<AnchorStatusResponse> | undefined, b: AnchorStatusResponse | PlainMessage<AnchorStatusResponse> | undefined): boolean {
+    return proto3.util.equals(AnchorStatusResponse, a, b);
+  }
+}
+
+/**
  * @generated from message dsm.DsmBtMessage
  */
 export class DsmBtMessage extends Message<DsmBtMessage> {
@@ -18371,6 +18479,14 @@ export class Envelope extends Message<Envelope> {
      */
     value: AddDeviceAdmissionV1;
     case: "deviceAdmission";
+  } | {
+    /**
+     * Offline-bearer anchor status (signal (c)) — read-only `anchor.status` diagnostics.
+     *
+     * @generated from field: dsm.AnchorStatusResponse anchor_status_response = 112;
+     */
+    value: AnchorStatusResponse;
+    case: "anchorStatusResponse";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<Envelope>) {
@@ -18474,6 +18590,7 @@ export class Envelope extends Message<Envelope> {
     { no: 107, name: "device_tree_snapshot_response", kind: "message", T: DeviceTreeSnapshotResponse, oneof: "payload" },
     { no: 108, name: "device_admission_request", kind: "message", T: AddDeviceAdmissionRequestV1, oneof: "payload" },
     { no: 109, name: "device_admission", kind: "message", T: AddDeviceAdmissionV1, oneof: "payload" },
+    { no: 112, name: "anchor_status_response", kind: "message", T: AnchorStatusResponse, oneof: "payload" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Envelope {

--- a/proto/dsm_app.proto
+++ b/proto/dsm_app.proto
@@ -2047,6 +2047,22 @@ message BilateralEventNotification {
   optional BilateralFailureReason failure_reason = 10;
 }
 
+// Read-only offline-bearer anchor status (signal (c)): the `anchor.status` query response.
+// A pure diagnostics snapshot of the sender's anchor appliance (RP2350/TROPIC01) — never
+// mutates the appliance or the device state. `anchor_connected=false` means no appliance could
+// attach (no device / fail-closed); the identity/counter fields are then zero.
+message AnchorStatusResponse {
+  bool   anchor_connected = 1;                      // appliance attached and OP_STATUS read OK
+  bytes  anchor_id        = 2 [(dsm_fixed_len)=32]; // enrolled anchor identity (AnchorPin.anchor_id)
+  bytes  pk_chip          = 3 [(dsm_max_len)=64];   // resident Ed25519 pubkey (σ^chip)
+  bytes  partition_pk     = 4 [(dsm_max_len)=128];  // RP2350 partition pubkey pk_host (σ^host)
+  uint64 anchor_counter   = 5;                      // live counter floor u_i (OP_STATUS)
+  bytes  frontier_root    = 6 [(dsm_fixed_len)=32]; // current offline frontier h_i (OP_STATUS)
+  uint64 enrolled_counter = 7;                      // counter floor at enrollment (AnchorPin)
+  bytes  bundle           = 8 [(dsm_fixed_len)=32]; // anchor bundle B (AnchorPin.bundle)
+  string status           = 9;                      // human-readable status line
+}
+
 // =========================== Bluetooth Transport ====================
 enum BtMessageType {
   BTMSG_TYPE_UNSPECIFIED = 0;
@@ -2654,6 +2670,9 @@ message Envelope {
     // admission). New device → existing device, then existing → new device.
     AddDeviceAdmissionRequestV1       device_admission_request         = 108;
     AddDeviceAdmissionV1              device_admission                 = 109;
+
+    // Offline-bearer anchor status (signal (c)) — read-only `anchor.status` diagnostics.
+    AnchorStatusResponse              anchor_status_response           = 112;
 
   }
   reserved 110, 111; // removed v1 counter-era bearer round-trip (BilateralBearerPrepared/Proceed)


### PR DESCRIPTION
## What

Stage 4 Slice 3 **signal (c)** — the piece deferred out of PR #581. Surfaces the sender's offline-bearer anchor appliance (RP2350/TROPIC01) through a **read-only** `anchor.status` query route and a diagnostics panel. No transfer-path change, no activation-gate flip: pure observation over the existing (gated) machinery. Honest status is unchanged — offline-bearer stays *implemented-but-activation-gated*; the live 2-device run is Slice 5 (owner hardware).

### Protocol
- `proto/dsm_app.proto`: new `AnchorStatusResponse` message + `Envelope.payload` oneof variant **field 112** (110/111 stay reserved). Fields: `anchor_connected`, `anchor_id`, `pk_chip` (σ^chip), `partition_pk` (σ^host), `anchor_counter` (live floor u), `frontier_root` (h_i), `enrolled_counter`, `bundle`, `status`.

### Rust
- `CoreSDK::anchor_appliance_status()` — attaches (and caches) the appliance via the installed factory and reads `pin()`/`status()` **only**. Unlike `stage_offline_bearer_transition` it performs **no** anchor-state leaf reconciliation and **no** mutation. A non-attachable appliance (no device / fail-closed) returns a `connected=false` snapshot rather than erroring — a diagnostics read must not fail the route.
- `handlers/anchor_routes.rs::handle_anchor_query` maps the snapshot to the proto; registered as the exact `"anchor.status"` query arm. `core/bridge.rs` marks the new payload SDK-owned (same arm as `session_state_response`).

### Frontend (rendering only, per no-business-logic-in-frontend)
- `src/dsm/anchor.ts::getAnchorStatus()` mirrors the `storage.status` query shape.
- `AnchorStatusPanel` renders the snapshot (connected dot, counter u, enrolled counter, base32 identity/chip-key/frontier prefixes, refresh) inside the existing `DiagnosticsOverlay`.
- Regenerated `dsm_app_pb.ts` via `proto:gen`.

## Verification
- `cargo test -p dsm_sdk anchor_status` → **PASS** (asserts connected snapshot + fields, and that the device head is **not** mutated).
- Production clippy (`-W unwrap/expect/panic -D warnings`) on `dsm`/`dsm_sdk` → **exit 0**.
- `scripts/guard_protos.sh` → **OK**; `dsm_sdk` compiles.
- Frontend `tsc --noEmit` → **clean on the new files** (pre-existing unrelated `JSX.Element`/test-fixture errors on `main` are untouched).

## Scope
Signal (c) only. Not included: Slice 5 live 2-device hardware run (owner-run). No activation-gate flip.
